### PR TITLE
ActionDropdown component and support files

### DIFF
--- a/src/components/ActionsDropdown/ActionDropdown.stories.tsx
+++ b/src/components/ActionsDropdown/ActionDropdown.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ActionsDropdown, DropdownItem } from './ActionsDropdown'; // Adjust import path
+
+const mockItems: DropdownItem<string>[] = [
+  { id: 'item1', text: 'Item One' },
+  { id: 'item2', text: 'Item Two' },
+  { id: 'item3', text: 'Item Three', separator: true },
+  { id: 'disabled_item', text: 'Disabled Item', isDisabled: true },
+];
+
+const meta: Meta<typeof ActionsDropdown> = {
+  title: 'Components/ActionsDropdown',
+  component: ActionsDropdown,
+  tags: ['autodocs'],
+  argTypes: {
+    onSelect: { action: 'selected' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    id: 'primary-dropdown',
+    text: 'My Actions',
+    dropdownItems: mockItems,
+  },
+};
+
+export const Kebab: Story = {
+  args: {
+    id: 'kebab-dropdown',
+    isKebab: true,
+    dropdownItems: mockItems,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    id: 'disabled-dropdown',
+    text: 'Cannot Click',
+    isDisabled: true,
+    dropdownItems: mockItems,
+  },
+};
+
+export const WithTooltip: Story = {
+  args: {
+    id: 'tooltip-dropdown',
+    text: 'Hover Me',
+    tooltip: 'This is a helpful tooltip!',
+    dropdownItems: mockItems,
+  },
+};

--- a/src/components/ActionsDropdown/ActionsDropdown.test.tsx
+++ b/src/components/ActionsDropdown/ActionsDropdown.test.tsx
@@ -1,0 +1,200 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ActionsDropdown, DropdownItem } from './ActionsDropdown';
+
+const mockItems: DropdownItem<string>[] = [
+  { id: 'item1', text: 'Item One' },
+  { id: 'item2', text: 'Item Two', isDisabled: true },
+  { id: 'item3', text: 'Item Three', separator: true },
+  {
+    id: 'flyout',
+    text: 'Flyout Menu',
+    flyoutMenu: [
+      { id: 'flyout1', text: 'Flyout Item One' },
+      { id: 'flyout2', text: 'Flyout Item Two' },
+    ],
+  },
+  { id: 'item4', text: 'Item with onSelect', onSelect: jest.fn() },
+];
+
+describe('ActionsDropdown', () => {
+  const user = userEvent.setup();
+
+  it('should render the toggle button with the provided text', () => {
+    render(
+      <ActionsDropdown id="test-dropdown" dropdownItems={mockItems} text="My Actions" />,
+    );
+    expect(screen.getByRole('button', { name: /My Actions/i })).toBeInTheDocument();
+  });
+
+  it('should render as a kebab toggle when isKebab is true', () => {
+    render(
+      <ActionsDropdown id="test-kebab" dropdownItems={mockItems} isKebab />,
+    );
+    expect(screen.getByRole('button', { name: /Actions/i })).toBeInTheDocument();
+  });
+
+  it('should allow overriding the kebab aria-label', () => {
+    render(
+      <ActionsDropdown
+        id="test-kebab"
+        dropdownItems={mockItems}
+        isKebab
+        kebabAriaLabel="More Options"
+      />,
+    );
+    expect(screen.getByRole('button', { name: /More Options/i })).toBeInTheDocument();
+  });
+
+
+  it('should render a disabled toggle when isDisabled is true', () => {
+    render(
+      <ActionsDropdown
+        id="test-disabled"
+        dropdownItems={mockItems}
+        text="Disabled"
+        isDisabled
+      />,
+    );
+    expect(screen.getByRole('button', { name: /Disabled/i })).toBeDisabled();
+  });
+
+  it('should open and close the menu on toggle click', async () => {
+    render(
+      <ActionsDropdown id="test-toggle" dropdownItems={mockItems} text="Toggle Me" />,
+    );
+
+    expect(screen.queryByText('Item One')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /Toggle Me/i }));
+    expect(screen.getByText('Item One')).toBeVisible();
+    expect(screen.getByText('Item Two')).toBeVisible();
+
+    await user.click(screen.getByRole('button', { name: /Toggle Me/i }));
+    await waitFor(() => {
+        expect(screen.queryByText('Item One')).not.toBeInTheDocument();
+    });
+  });
+
+  it('should call onSelect with the correct item id and close the menu', async () => {
+    const onSelectMock = jest.fn();
+    render(
+      <ActionsDropdown
+        id="test-select"
+        dropdownItems={mockItems}
+        text="Select Item"
+        onSelect={onSelectMock}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Select Item/i }));
+    const menuItem = screen.getByText('Item One');
+    await user.click(menuItem);
+
+    expect(onSelectMock).toHaveBeenCalledWith('item1');
+    expect(onSelectMock).toHaveBeenCalledTimes(1);
+
+    await waitFor(() => {
+        expect(screen.queryByText('Item One')).not.toBeInTheDocument();
+    });
+  });
+  
+  it("should call the item's specific onSelect handler", async () => {
+    render(<ActionsDropdown id="test-item-select" dropdownItems={mockItems} text="Item Select Test" />);
+
+    await user.click(screen.getByRole('button', { name: /Item Select Test/i }));
+    await user.click(screen.getByText('Item with onSelect'));
+
+    expect(mockItems.find(item => item.id === 'item4')?.onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  // Test 7: Closing on Escape
+  it('should close the menu when Escape key is pressed and focus the toggle', async () => {
+    render(<ActionsDropdown id="test-escape" dropdownItems={mockItems} text="Escape Test" />);
+    const toggleButton = screen.getByRole('button', { name: /Escape Test/i });
+
+    await user.click(toggleButton);
+    expect(screen.getByText('Item One')).toBeVisible();
+
+    await user.keyboard('{escape}');
+    await waitFor(() => {
+        expect(screen.queryByText('Item One')).not.toBeInTheDocument();
+    });
+    expect(toggleButton).toHaveFocus();
+  });
+
+  it('should close the menu on an outside click', async () => {
+    render(
+      <div>
+        <ActionsDropdown id="test-outside" dropdownItems={mockItems} text="Outside Click" />
+        <button>Outside Button</button>
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Outside Click/i }));
+    expect(screen.getByText('Item One')).toBeVisible();
+    
+    await user.click(screen.getByRole('button', { name: /Outside Button/i }));
+    await waitFor(() => {
+        expect(screen.queryByText('Item One')).not.toBeInTheDocument();
+    });
+  });
+  
+  it('should not be clickable for a disabled item', async () => {
+    const onSelectMock = jest.fn();
+    render(
+        <ActionsDropdown
+            id="test-disabled-item"
+            dropdownItems={mockItems}
+            text="Disabled Item Test"
+            onSelect={onSelectMock}
+        />
+    );
+    
+    await user.click(screen.getByRole('button', { name: /Disabled Item Test/i }));
+    const disabledItem = screen.getByText('Item Two');
+    
+    expect(disabledItem.closest('button')).toHaveAttribute('aria-disabled', 'true');
+    
+    await user.click(disabledItem);
+    
+    expect(onSelectMock).not.toHaveBeenCalled();
+    expect(screen.getByText('Item Two')).toBeVisible();
+  });
+  
+  describe('when dealing with flyout menus', () => {
+    it('should show the flyout menu on hover/click and handle selection', async () => {
+      const onSelectMock = jest.fn();
+      render(<ActionsDropdown id="test-flyout" dropdownItems={mockItems} text="Flyout Test" onSelect={onSelectMock} />);
+
+      await user.click(screen.getByRole('button', { name: /Flyout Test/i }));
+      const flyoutParent = screen.getByText('Flyout Menu');
+      
+      fireEvent.mouseEnter(flyoutParent);
+
+      const flyoutItem = await screen.findByText('Flyout Item One');
+      expect(flyoutItem).toBeVisible();
+
+      await user.click(flyoutItem);
+
+      expect(onSelectMock).toHaveBeenCalledWith('flyout1');
+
+      await waitFor(() => {
+          expect(screen.queryByText('Flyout Menu')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not call onSelect when a flyout parent is clicked', async () => {
+        const onSelectMock = jest.fn();
+        render(<ActionsDropdown id="test-flyout-parent" dropdownItems={mockItems} text="Flyout Parent Test" onSelect={onSelectMock} />);
+  
+        await user.click(screen.getByRole('button', { name: /Flyout Parent Test/i }));
+        
+        const flyoutParent = screen.getByText('Flyout Menu');
+        await user.click(flyoutParent);
+
+        expect(onSelectMock).not.toHaveBeenCalled();
+        expect(screen.getByText('Flyout Menu')).toBeVisible();
+    });
+  });
+});

--- a/src/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/src/components/ActionsDropdown/ActionsDropdown.tsx
@@ -1,0 +1,253 @@
+import {
+  Divider,
+  Label,
+  LabelProps,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuList,
+  MenuProps,
+  MenuToggle,
+  Popper,
+  PopperProps,
+  Tooltip,
+  TooltipPosition,
+} from "@patternfly/react-core";
+import EllipsisVIcon from "@patternfly/react-icons/dist/esm/icons/ellipsis-v-icon";
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type DropdownItem<T extends string | number> = {
+  id: T;
+  text: React.ReactNode;
+  isDisabled?: boolean;
+  separator?: boolean;
+  tooltip?: React.ReactNode;
+  flyoutMenu?: DropdownItem<T>[];
+  onSelect?: () => void;
+  description?: string;
+  isAriaDisabled?: boolean;
+  isSelected?: boolean;
+  icon?: React.ReactNode;
+  label?: string;
+  labelColor?: LabelProps["color"];
+  tooltipPosition?: TooltipPosition;
+};
+
+export type DropdownProps<T extends string | number> = Omit<
+  MenuProps,
+  "children" | "onSelect"
+> & {
+  id: string;
+  dropdownItems: DropdownItem<T>[];
+  text?: React.ReactNode;
+  isDisabled?: boolean;
+  isKebab?: boolean;
+  onSelect?: (id: T) => void;
+  isPlain?: boolean;
+  isPrimary?: boolean;
+  tooltip?: React.ReactNode;
+  tooltipPosition?: TooltipPosition;
+  dropdownPosition?: PopperProps["placement"];
+  onToggle?: (isOpen?: boolean) => void;
+  onHover?: () => void;
+  kebabAriaLabel?: string;
+};
+
+const MenuItems = forwardRef<HTMLDivElement, any>(
+  ({ menuItems, onSelect, ...menuProps }, ref) => (
+    <Menu
+      ref={ref}
+      onSelect={onSelect}
+      containsFlyout={menuItems.some((mi: any) => mi.flyoutMenu)}
+      {...menuProps}
+    >
+      <MenuContent>
+        <MenuList>
+          {menuItems.map((item: any) => {
+            const menuItem = (
+              <MenuItem
+                key={item.id}
+                itemId={item.id}
+                isAriaDisabled={item.isDisabled || item.isAriaDisabled}
+                isSelected={item.isSelected}
+                description={item.description}
+                flyoutMenu={
+                  item.flyoutMenu?.length ? (
+                    <MenuItems
+                      id={`${item.id}-submenu`}
+                      menuItems={item.flyoutMenu}
+                      onSelect={onSelect}
+                    />
+                  ) : undefined
+                }
+              >
+                {item.text}
+                {item.label && item.labelColor && (
+                  <Label color={item.labelColor}>{item.label}</Label>
+                )}
+              </MenuItem>
+            );
+            const wrapped = item.tooltip ? (
+              <Tooltip
+                key={item.id}
+                position={item.tooltipPosition}
+                content={item.tooltip}
+              >
+                <div>{menuItem}</div>
+              </Tooltip>
+            ) : (
+              menuItem
+            );
+            return (
+              <React.Fragment key={item.id}>
+                {item.separator && <Divider />}
+                {wrapped}
+              </React.Fragment>
+            );
+          })}
+        </MenuList>
+      </MenuContent>
+    </Menu>
+  ),
+);
+
+export function ActionsDropdown<T extends string | number>(
+  props: DropdownProps<T>,
+) {
+  const {
+    dropdownItems,
+    id,
+    onSelect,
+    text,
+    isDisabled,
+    isKebab,
+    isPlain,
+    isPrimary,
+    tooltip,
+    tooltipPosition,
+    onToggle,
+    onHover,
+    kebabAriaLabel = "Actions",
+    ...rest
+  } = props;
+  const [isOpen, setOpen] = useState<boolean>(false);
+  const popperContainer = useRef<HTMLDivElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const toggleMenu = useCallback(() => {
+    onToggle?.(!isOpen);
+    setOpen(!isOpen);
+  }, [isOpen, onToggle]);
+
+  const findItemById = useCallback(
+    (items: DropdownItem<T>[], targetId: T): DropdownItem<T> | undefined => {
+      for (const item of items) {
+        if (item.id === targetId) return item;
+        if (item.flyoutMenu) {
+          const found = findItemById(item.flyoutMenu, targetId);
+          if (found) return found;
+        }
+      }
+      return undefined;
+    },
+    [],
+  );
+  const handleSelect = useCallback(
+    (_event?: React.MouseEvent, itemId?: string | number) => {
+      if (itemId === undefined) return;
+      const selectedItem = findItemById(dropdownItems, itemId as T);
+      if (!selectedItem || selectedItem.flyoutMenu?.length) return; // Ignore flyout parents
+
+      // For OCM
+      if (selectedItem.onSelect) {
+        selectedItem.onSelect();
+      }
+
+      // For ACM
+      if (onSelect) {
+        onSelect(itemId as T);
+      }
+
+      setOpen(false);
+    },
+    [dropdownItems, findItemById, onSelect],
+  );
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (isOpen && !popperContainer.current?.contains(event.target as Node)) {
+        toggleMenu();
+      }
+    };
+    const handleMenuKeys = (event: KeyboardEvent) => {
+      if (isOpen && event.key === "Escape") {
+        toggleMenu();
+        toggleRef.current?.focus();
+      }
+    };
+    window.addEventListener("click", handleClickOutside);
+    window.addEventListener("keydown", handleMenuKeys);
+    return () => {
+      window.removeEventListener("click", handleClickOutside);
+      window.removeEventListener("keydown", handleMenuKeys);
+    };
+  }, [isOpen, toggleMenu]);
+
+  const toggleVariant = useMemo(() => {
+    if (isKebab) return "plain";
+    if (isPlain) return "plainText";
+    if (isPrimary) return "primary";
+    return "default";
+  }, [isKebab, isPlain, isPrimary]);
+
+  const popper = (
+    <Popper
+      trigger={
+        <MenuToggle
+          ref={toggleRef}
+          variant={toggleVariant}
+          id={id}
+          isDisabled={isDisabled}
+          onClick={toggleMenu}
+          onMouseOver={onHover}
+          isExpanded={isOpen}
+          aria-label={isKebab ? kebabAriaLabel : String(text)}
+        >
+          {isKebab ? <EllipsisVIcon /> : text}
+        </MenuToggle>
+      }
+      isVisible={isOpen}
+      appendTo={popperContainer.current || "inline"}
+      placement={
+        props.dropdownPosition ?? (isKebab ? "bottom-end" : "bottom-start")
+      }
+      popper={
+        <MenuItems
+          ref={menuRef}
+          menuItems={dropdownItems}
+          onSelect={handleSelect}
+        />
+      }
+    />
+  );
+
+  return (
+    <div ref={popperContainer}>
+      {tooltip ? (
+        <Tooltip content={tooltip} position={tooltipPosition}>
+          {popper}
+        </Tooltip>
+      ) : (
+        popper
+      )}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,1 @@
-export { MyButton } from "./components/MyButton";
-export { ClusterListActions } from "./components/ClusterListActions/ClusterListActions";
+export * from "./components/ActionsDropdown/ActionsDropdown";


### PR DESCRIPTION
This PR introduces ActionDropdown component for ACM and OCM.

1. ACM and OCM use different Patternfly items for ActionsDropdowns. OCM uses basic dropdown component while ACM uses more robust Popper (more customizable). In this PR we go with Popper, since ACM has more requirements for actions than OCM.
2. To test checkout this PR, run npm install and then npm run storybook. It should open component in isolation so it can be tested.
3. To test it in ACM and OCM it requires a lot of setup, until npm package gets published.
4. The component is generic enough to accommodate both ACM and OCM needs while being not generic enough to be used by anyone(that way it is enough to just use PF component)

Storybook:
<img width="2090" height="1064" alt="image" src="https://github.com/user-attachments/assets/2b2d535a-4042-4124-9624-bf42b7bcbed5" />
