### PR TITLE
FCN-26 Create starter analytics event schema

### DIFF
--- a/src/utilities/analytics.ts
+++ b/src/utilities/analytics.ts
@@ -1,0 +1,355 @@
+/* eslint-disable camelcase */
+
+/**
+ * Analytics Event Builder Utility
+ *
+ * This module provides helper functions to create standardized analytics events for Segment tracking.
+ * Each function returns an object with an `event` name and `properties` object that can be passed
+ * directly to the analytics tracking service.
+ *
+ * @example
+ * // Using with the useChrome hook
+ * const { analytics } = useChrome();
+ *
+ * const { event, properties } = fileDownload({ link_name: 'ocp-cli' });
+ * analytics.track(event, properties);
+ *
+ * @example
+ * // Tracking a button click with optional value
+ * const { event, properties } = buttonClicked({
+ *   link_name: 'submit-form',
+ *   resourceType: 'cluster',
+ *   value: true
+ * });
+ * analytics.track(event, properties);
+ */
+
+const eventNames = {
+  FILE_DOWNLOADED: 'File Downloaded',
+  BUTTON_CLICKED: 'Button Clicked',
+  LINK_CLICKED: 'Link Clicked',
+  CHECKBOX_CLICKED: 'Checkbox Clicked',
+  RADIOBUTTON_CLICKED: 'Radiobutton Clicked',
+  SECTION_EXPANDED: 'Section Expanded',
+  ALERT_INTERACTION: 'Alert Interaction',
+  TAB_VIEWED: 'Tab Viewed',
+};
+
+const dataKeys = {
+  // Used to help key events
+  LINK_NAME: 'link_name',
+  CURRENT_PATH: 'current_path',
+  RESOURCE_TYPE: 'resourceType',
+  LINK_URL: 'link_url',
+  FROM_FCN: 'from-fcn',
+
+  // Custom properties that can be added to the event
+
+  VALUE: 'value',
+  CHECKED: 'checked',
+  ACTION: 'action',
+  SEVERITY: 'severity',
+  TYPE: 'type',
+  TAB_NAME: 'tab_name',
+  INITIAL_LOAD: 'initial_load',
+  REDIRECTED_TO_DEFAULT_TAB: 'redirected_to_default_tab',
+};
+
+export const actionTypes = {
+  DISMISS: 'dismiss',
+};
+
+export const severityTypes = {
+  INFO: 'info',
+  WARNING: 'warning',
+  ERROR: 'error',
+};
+
+const defaultCurrentPath = window.location.pathname;
+const defaultResourceType = 'all';
+
+/**
+ * Creates a tracking event for file downloads
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the downloaded file (e.g., 'ocp-cli', 'pull-secret')
+ * @param {string} [params.current_path] - The current URL path where the download occurred. Defaults to window.location.pathname
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const fileDownload = ({
+  link_name,
+  current_path,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.FILE_DOWNLOADED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+
+    [dataKeys.FROM_FCN]: from_fcn,
+  },
+});
+
+/**
+ * Creates a tracking event for button clicks
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the button that was clicked
+ * @param {string} [params.current_path] - The current URL path where the click occurred. Defaults to window.location.pathname
+ * @param {string} [params.resourceType] - The type of resource associated with the button (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+ * @param {string|number|boolean} [params.value] - Optional value associated with the button click (e.g., toggle state, selection value)
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const buttonClicked = ({
+  link_name,
+  current_path,
+  resourceType,
+  value,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  value?: string | number | boolean;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.BUTTON_CLICKED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+
+    [dataKeys.FROM_FCN]: from_fcn,
+    ...(value !== undefined && {
+      [dataKeys.VALUE]: value,
+    }),
+  },
+});
+
+/**
+   use* Creates a tracking event for link clicks
+   *
+   * @param {Object} params - The event parameters
+   * @param {string} params.link_name - The name/identifier of the link that was clicked
+   * @param {string} [params.current_path] - The current URL path where the click occurred. Defaults to window.location.pathname
+   * @param {string} [params.resourceType] - The type of resource associated with the button (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+   * @param {string} params.link_url - The destination URL of the link
+   * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+   * @returns {Object} An object containing the event name and properties for analytics tracking
+   */
+export const linkClicked = ({
+  link_name,
+  current_path,
+  resourceType,
+  link_url,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  link_url: string;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.BUTTON_CLICKED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath, // aka path
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+    [dataKeys.LINK_URL]: link_url,
+
+    [dataKeys.FROM_FCN]: from_fcn,
+  },
+});
+
+/**
+ * Creates a tracking event for checkbox interactions
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the checkbox that was clicked
+ * @param {string} [params.current_path] - The current URL path where the interaction occurred. Defaults to window.location.pathname
+ * @param {string} [params.resourceType] - The type of resource associated with the button (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+ * @param {boolean} params.checked - The new checked state of the checkbox (true for checked, false for unchecked)
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const checkboxClicked = ({
+  link_name,
+  current_path,
+  resourceType,
+  checked,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  checked: boolean;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.CHECKBOX_CLICKED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+
+    [dataKeys.CHECKED]: checked,
+    [dataKeys.FROM_FCN]: from_fcn,
+  },
+});
+
+/**
+ * Creates a tracking event for radio button selections
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the radio button group
+ * @param {string} [params.current_path] - The current URL path where the selection occurred. Defaults to window.location.pathname
+ * @param {string} [params.resourceType] - The type of resource associated with the button (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+ * @param {string|number|boolean} params.value - The value of the selected radio button option
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const radioButtonClicked = ({
+  link_name,
+  current_path,
+  resourceType,
+  value,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  value: string | number | boolean;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.RADIOBUTTON_CLICKED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+
+    [dataKeys.VALUE]: value,
+    [dataKeys.FROM_FCN]: from_fcn,
+  },
+});
+
+/**
+ * Creates a tracking event for expandable section interactions
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the section that was expanded
+ * @param {string} [params.current_path] - The current URL path where the expansion occurred. Defaults to window.location.pathname
+ * @param {string} [params.resourceType] - The type of resource associated with the button (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const sectionExpanded = ({
+  link_name,
+  current_path,
+  resourceType,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.SECTION_EXPANDED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+
+    [dataKeys.FROM_FCN]: from_fcn,
+  },
+});
+
+/**
+ * Creates a tracking event for alert interactions (e.g., dismissing alerts)
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the alert or alert group
+ * @param {string} [params.current_path] - The current URL path where the interaction occurred. Defaults to window.location.pathname
+ * @param {string} [params.resourceType] - The type of resource associated with the button (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+ * @param {string} params.action - The action performed on the alert. Use values from actionTypes (e.g., 'dismiss')
+ * @param {string} params.severity - The severity level of the alert. Use values from severityTypes ('info', 'warning', 'error')
+ * @param {string} [params.type] - Optional additional type information about the alert (e.g. alert identifier if part of a group)
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const alertInteraction = ({
+  link_name,
+  current_path,
+  resourceType,
+  action,
+  severity,
+  type,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  action: (typeof actionTypes)[keyof typeof actionTypes];
+  severity: (typeof severityTypes)[keyof typeof severityTypes];
+  type?: string;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.ALERT_INTERACTION,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+
+    [dataKeys.ACTION]: action,
+    [dataKeys.SEVERITY]: severity,
+    [dataKeys.FROM_FCN]: from_fcn,
+    ...(type && { [dataKeys.TYPE]: type }),
+  },
+});
+
+/**
+ * Creates a tracking event for tab view interactions
+ *
+ * @param {Object} params - The event parameters
+ * @param {string} params.link_name - The name/identifier of the tab container or navigation component
+ * @param {string} [params.current_path] - The current URL path where the tab view occurred. Defaults to window.location.pathname
+ * @param {string} [params.resourceType] - The type of resource associated with the tab (e.g., 'osd', 'ocp', 'moa' ). Defaults to 'all'
+ * @param {string} params.tab_name - The name/identifier of the specific tab that was viewed
+ * @param {boolean} params.initial_load - Whether this tab view occurred on the initial page load (true) or from user interaction (false)
+ * @param {boolean} params.redirected_to_default_tab - Whether the user was redirected to this tab because it's the default (true) or navigated directly (false)
+ * @param {boolean} [params.from_fcn] - Whether the event originated from within a FCN shared component. Defaults to true
+ * @returns {Object} An object containing the event name and properties for analytics tracking
+ */
+export const tabViewed = ({
+  link_name,
+  current_path,
+  resourceType,
+  tab_name,
+  initial_load,
+  redirected_to_default_tab,
+  from_fcn = true,
+}: {
+  link_name: string;
+  current_path?: string;
+  resourceType?: string;
+  tab_name: string;
+  initial_load: boolean;
+  redirected_to_default_tab: boolean;
+  from_fcn?: boolean;
+}) => ({
+  event: eventNames.TAB_VIEWED,
+  properties: {
+    [dataKeys.LINK_NAME]: link_name,
+    [dataKeys.CURRENT_PATH]: current_path || defaultCurrentPath,
+    [dataKeys.RESOURCE_TYPE]: resourceType || defaultResourceType,
+
+    [dataKeys.TAB_NAME]: tab_name,
+    [dataKeys.INITIAL_LOAD]: initial_load,
+    [dataKeys.REDIRECTED_TO_DEFAULT_TAB]: redirected_to_default_tab,
+    [dataKeys.FROM_FCN]: from_fcn,
+  },
+});


### PR DESCRIPTION
## Description

As newly created shared components add event tracking, there is a need to ensure that the same events are used.  This ensures that data in Segment/Amplitude can be aggregated correctly to make future data-driven-decisions.

This PR adds a schema that defines a set of events and required/optional flags for that event.  

Right now this file doesn't do anything by itself - just definitions, so no new tests were added.

**Jira issue [FCN-26](https://issues.redhat.com/browse/FCN-26)** 



## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [x] Other (please specify): Helper / definitions

## Testing

This is set of global variables with helper functions.  No logic to be tested.   The testing of this file will be done once it is implemented (see [FCN-30](https://issues.redhat.com/browse/FCN-30))

<!-- 
### Manual Testing


**Test Steps:**
1. 
2. 
3. 

**Test Environment:**
- [ ] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)


- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
  

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass

-->

## Screenshots/Recordings
N/A
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
N/A
<!-- Screenshot or description of the previous behavior -->

### After
N/A
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
N/A
<!--
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces
-->

### Accessibility
N/A
<!--
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards
-->

### Dependencies
N/A
<!--
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed
-->

## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

