### PR TITLE
FCN-61: collapse expand optional sections in review step

### DIFF
--- a/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
@@ -22,11 +22,35 @@ export const ReviewStepData = (props: any) => {
   const [isRolesAndPoliciesExpanded, setIsRolesAndPoliciesExpanded] = React.useState<boolean>(true);
   const [isNetworkingAndSubnetsExpanded, setIsNetworkingAndSubnetsExpanded] =
     React.useState<boolean>(true);
-  const [isEncryptionExpanded, setIsEncryptionExpanded] = React.useState<boolean>(true);
+  const [isEncryptionExpanded, setIsEncryptionExpanded] = React.useState<boolean>(false);
   const [isOptionalNetworkingExpanded, setIsOptionalNetworkingExpanded] =
-    React.useState<boolean>(true);
+    React.useState<boolean>(false);
   const [isOptionalClusterUpgradesExpanded, setIsOptionalClusterUpgradesExpanded] =
-    React.useState<boolean>(true);
+    React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    if (
+      (cluster?.encryption_keys && cluster?.encryption_keys !== 'default') ||
+      cluster?.etcd_encryption ||
+      cluster?.etcd_key_arn ||
+      cluster?.kms_key_arn
+    ) {
+      setIsEncryptionExpanded(true);
+    }
+    if (cluster?.cidr_default && cluster?.cidr_default === false) {
+      setIsOptionalNetworkingExpanded(true);
+    }
+    if (cluster?.upgrade_policy === 'manual') {
+      setIsOptionalClusterUpgradesExpanded(true);
+    }
+  }, [
+    cluster?.cidr_default,
+    cluster?.encryption_keys,
+    cluster?.etcd_encryption,
+    cluster?.etcd_key_arn,
+    cluster?.kms_key_arn,
+    cluster?.upgrade_policy,
+  ]);
 
   return (
     <Section label="Review your ROSA cluster">


### PR DESCRIPTION
## Description
If the user did not touch any optional fields in optional steps the expandable sections for those fields in the review step should remain collapsed to minimize context that is presented to the user.


**Jira issue #** [FCN-61](https://issues.redhat.com/browse/FCN-61)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1.  Launch storybook and navigate straight to the Review step in the wizard, no need to fill any fields
2. Confirm that optional steps are collapsed. Edit some fields in those steps and confirm that sections are expanded.

**Test Environment:**
- [ ] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<img width="1440" height="842" alt="image" src="https://github.com/user-attachments/assets/9f0cf1af-5d0c-45c2-848f-c2ad24026877" />

### After
<img width="1652" height="562" alt="image" src="https://github.com/user-attachments/assets/5789bb9c-27d6-4c24-af19-5c09186501ab" />


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

