### PR TITLE
FCN-86: Implement day time selector for individual updates

### DIFF
--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
@@ -1,9 +1,83 @@
+import React, { useState } from 'react';
 import { Section, WizRadioGroup, Radio } from '@patternfly-labs/react-form-wizard';
-import { Content, ContentVariants } from '@patternfly/react-core';
+import { useInput } from '@patternfly-labs/react-form-wizard/inputs/Input';
+import { useData } from '@patternfly-labs/react-form-wizard';
+import {
+  Content,
+  ContentVariants,
+  FormGroup,
+  Grid,
+  GridItem,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
 import { useTranslation } from '../../../../../../context/TranslationContext';
+import parseUpdateSchedule from './parseUpdateSchedule';
 
-export const ClusterUpdatesSubstep = () => {
+const daysOptions = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const hoursOptions = Array.from(Array(24).keys());
+
+export const ClusterUpdatesSubstep = (props: any) => {
   const { t } = useTranslation();
+  const { value } = useInput(props);
+  const { update } = useData();
+  const { cluster } = value;
+
+  const [daySelectOpen, setDaySelectOpen] = useState(false);
+  const [timeSelectOpen, setTimeSelectOpen] = useState(false);
+
+  const upgradeSchedule = cluster?.upgrade_schedule || '';
+
+  const parseCurrentValue = (): [string, string] => {
+    if (!upgradeSchedule) {
+      return ['', ''];
+    }
+    return parseUpdateSchedule(upgradeSchedule);
+  };
+
+  const onDaySelect = (selection: string | number | undefined) => {
+    const selectedHour = parseCurrentValue()[0] || '0';
+    const cronValue = `00 ${selectedHour} * * ${selection}`;
+    update({ cluster: { ...cluster, upgrade_schedule: cronValue } });
+    setDaySelectOpen(false);
+  };
+
+  const onHourSelect = (selection: string | number | undefined) => {
+    const selectedDay = parseCurrentValue()[1] || '0';
+    const cronValue = `00 ${selection} * * ${selectedDay}`;
+    update({ cluster: { ...cluster, upgrade_schedule: cronValue } });
+    setTimeSelectOpen(false);
+  };
+
+  const formatHourLabel = (hour: number) => `${hour.toString().padStart(2, '0')}:00 UTC`;
+
+  const [selectedHour, selectedDay] = parseCurrentValue();
+
+  const dayToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setDaySelectOpen(!daySelectOpen)}
+      isExpanded={daySelectOpen}
+      isFullWidth
+    >
+      {daysOptions[Number(selectedDay)] ?? t('Select day')}
+    </MenuToggle>
+  );
+
+  const hourToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={() => setTimeSelectOpen(!timeSelectOpen)}
+      isExpanded={timeSelectOpen}
+      isFullWidth
+    >
+      {formatHourLabel(Number(selectedHour) || 0)}
+    </MenuToggle>
+  );
+
   return (
     <Section
       id="cluster-updates-substep-section"
@@ -11,14 +85,14 @@ export const ClusterUpdatesSubstep = () => {
       label={t('Cluster update strategy')}
     >
       <Content component={ContentVariants.p}>
-        {t(`The OpenShift version [4.14.6] that you selected in the &quot;HERE GOES LINK: Details
-        step&quot; will apply to the managed control plane and the machine pools configured in the
-        &quot;HERE GOES LINK: Networking and subnets step&quot;. After cluster creation, you can
+        {t(`The OpenShift version [4.14.6] that you selected in the "HERE GOES LINK: Details
+        step" will apply to the managed control plane and the machine pools configured in the
+        "HERE GOES LINK: Networking and subnets step". After cluster creation, you can
         update the managed control plane and machine pools independently.`)}
       </Content>
 
       <Content component={ContentVariants.p}>
-        {t(`In the event of &quot;HERE GOES LINK WITH EXTERNAL ICON: Critical security concerns&quot;
+        {t(`In the event of "HERE GOES LINK WITH EXTERNAL ICON: Critical security concerns"
         (CVEs) that significantly impact the security or stability of the cluster, updates may be
         automatically scheduled by Red Hat SRE to the latest z-stream version not impacted by the
         CVE within 2 business days after customer notifications.`)}
@@ -28,20 +102,65 @@ export const ClusterUpdatesSubstep = () => {
         <Radio
           id="cluster-upgrade-strategy-individual-radio-btn"
           label={t('Individual updates')}
-          value="automatic"
+          value="manual"
           description={t(
-            'Schedule each update individually. When planning updates, make sure to consider the end of life dates from the {HERE GOES LINK WITH EXTERNAL ICON: lifecycle policy'
+            'Schedule each update individually. When planning updates, make sure to consider the end of life dates from the {HERE GOES LINK WITH EXTERNAL ICON: lifecycle policy}'
           )}
         />
         <Radio
           id="cluster-upgrade-strategy-recurring-radio-btn"
           label={t('Recurring updates')}
-          value="manual"
+          value="automatic"
           description={t(
             "The cluster control plan will be automatically updated based on your preferred day and start time when new patch updates ({HERE GOES LINK WITH EXTERNAL ICON: z-stream}) are available. When a new minor version is available, you'll be notified and must manually allow the cluster to update the next minor version. The compute nodes will need to be manually updated."
           )}
         />
       </WizRadioGroup>
+
+      {cluster?.upgrade_policy === 'automatic' && (
+        <FormGroup label={t('Select a day and start time')} style={{ marginLeft: '1.5rem' }}>
+          <Grid hasGutter>
+            <GridItem sm={6} md={6}>
+              <Select
+                isOpen={daySelectOpen}
+                selected={selectedDay}
+                onOpenChange={(isOpen) => setDaySelectOpen(isOpen)}
+                onSelect={(_, value) => onDaySelect(value)}
+                shouldFocusToggleOnSelect
+                toggle={dayToggle}
+              >
+                <SelectList>
+                  {daysOptions.map((day, idx) => (
+                    <SelectOption key={day} value={idx.toString()}>
+                      {day}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </GridItem>
+            <GridItem sm={6} md={6}>
+              <Select
+                isOpen={timeSelectOpen}
+                selected={selectedHour}
+                onOpenChange={(isOpen) => setTimeSelectOpen(isOpen)}
+                onSelect={(_, value) => onHourSelect(value)}
+                shouldFocusToggleOnSelect
+                toggle={hourToggle}
+                maxMenuHeight="20em"
+                isScrollable
+              >
+                <SelectList>
+                  {hoursOptions.map((hour) => (
+                    <SelectOption key={hour} value={hour.toString()}>
+                      {formatHourLabel(hour)}
+                    </SelectOption>
+                  ))}
+                </SelectList>
+              </Select>
+            </GridItem>
+          </Grid>
+        </FormGroup>
+      )}
     </Section>
   );
 };

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/parseUpdateSchedule.ts
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/parseUpdateSchedule.ts
@@ -1,0 +1,17 @@
+const parseUpdateSchedule = (cronString: string): [string, string] => {
+  if (!cronString) {
+    return ['', ''];
+  }
+
+  const parts = cronString.split(' ');
+  if (parts.length < 5) {
+    return ['', ''];
+  }
+
+  const hour = parts[1];
+  const day = parts[4];
+
+  return [hour, day];
+};
+
+export default parseUpdateSchedule;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
Implementing day time selector for individual updates.


**Jira issue #** 
https://issues.redhat.com/browse/FCN-86

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. 
2. 
3. 

**Test Environment:**
- [ ] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->

### After
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

## Summary by Sourcery

Add configurable day and time selection for cluster recurring updates in the ROSA wizard.

New Features:
- Allow users to configure a specific day of week and start time for automatic cluster updates via dropdown selectors in the Additional setup step.

Enhancements:
- Wire the cluster updates substep to the wizard data model and parse existing cron-like upgrade schedules to prepopulate the UI.
- Improve cluster updates copy by fixing HTML-escaped quotes in informational text.