### PR TITLE
Add type safety across ROSA wizard props, callbacks, and form data

### DIFF
--- a/docs/ROSA_WIZARD_INTEGRATION.md
+++ b/docs/ROSA_WIZARD_INTEGRATION.md
@@ -1,0 +1,295 @@
+# ROSA HCP Wizard — Integration Guide for ACM/OCM Consumers
+
+This guide covers the typed interfaces that ACM and OCM applications use when integrating the ROSA HCP cluster creation wizard from `nxtcm-components`.
+
+## Overview
+
+The wizard accepts structured data describing AWS accounts, OpenShift versions, VPCs, roles, and other configuration options. On submit, it returns the full cluster configuration the user built. Both the input and output shapes are fully typed so consumers get compile-time validation and autocomplete.
+
+All types referenced below are exported from the library:
+
+```ts
+import type {
+  WizardStepsData,
+  BasicSetupStepProps,
+  ClusterFormData,
+  RosaWizardFormData,
+  WizardCallbackFunctions,
+  WizardType,
+  SelectDropdownType,
+  MachineTypesDropdownType,
+  VPC,
+  Subnet,
+  Roles,
+  OIDCConfig,
+} from 'nxtcm-components';
+```
+
+## Rendering the Wizard
+
+```tsx
+import { WizardWrapper } from 'nxtcm-components';
+
+<WizardWrapper
+  type="rosa-hcp"
+  title="Create ROSA HCP cluster"
+  wizardsStepsData={stepsData}
+  onSubmit={handleSubmit}
+  onCancel={handleCancel}
+/>
+```
+
+`type` is a union of `'rosa-hcp' | 'rosa-yaml-editor'`. The first renders the standard step-by-step wizard, the second adds a YAML editor step before review.
+
+## Input: `WizardStepsData`
+
+This is the top-level shape passed via the `wizardsStepsData` prop.
+
+```ts
+type WizardStepsData = {
+  basicSetupStep: BasicSetupStepProps;
+  callbackFunctions?: WizardCallbackFunctions;
+};
+```
+
+### `BasicSetupStepProps`
+
+All the dropdown and selection data the wizard needs to render its steps.
+
+```ts
+type BasicSetupStepProps = {
+  openShiftVersions: SelectDropdownType[];
+  awsInfrastructureAccounts: SelectDropdownType[];
+  awsBillingAccounts: SelectDropdownType[];
+  regions: SelectDropdownType[];
+  vpcList: VPC[];
+  roles: Roles;
+  oicdConfig: OIDCConfig[];
+  machineTypes: MachineTypesDropdownType[];
+};
+```
+
+### Option types
+
+Most dropdowns use `SelectDropdownType`:
+
+```ts
+type SelectDropdownType = {
+  label: string;       // display text
+  value: string;       // stored value
+  description?: string; // optional secondary text
+};
+```
+
+Machine types have an extra `id` field:
+
+```ts
+type MachineTypesDropdownType = {
+  id: string;
+  label: string;
+  description: string;
+  value: string;
+};
+```
+
+### VPC and Subnet data
+
+```ts
+type VPC = {
+  id: string;
+  name: string;
+  aws_subnets: Subnet[];
+};
+
+type Subnet = {
+  subnet_id: string;
+  name: string;            // should contain 'private' or 'public' for filtering
+  availability_zone: string;
+};
+```
+
+The wizard filters subnets by name to separate private and public subnets. Subnet names containing `'private'` are used for machine pool selection, and those containing `'public'` are used for the public subnet dropdown when the cluster is set to external access.
+
+### Roles
+
+```ts
+type Roles = {
+  installerRoles: SelectDropdownType[];
+  supportRoles: SelectDropdownType[];
+  workerRoles: SelectDropdownType[];
+};
+```
+
+### OIDC Config
+
+```ts
+type OIDCConfig = {
+  label: string;
+  value: string;
+  issuer_url: string; // shown as description in the dropdown
+};
+```
+
+### Callback Functions (optional)
+
+```ts
+type WizardCallbackFunctions = {
+  onAWSAccountChange?: (value: unknown) => void;
+  refreshAwsAccountDataCallback?: () => void;
+  refreshAwsBillingAccountCallback?: () => void;
+};
+```
+
+- `onAWSAccountChange` fires when the user selects a different AWS infrastructure account. Use this to reload roles, VPCs, or other account-dependent data.
+- `refreshAwsAccountDataCallback` is wired to the refresh button on the AWS infrastructure account dropdown.
+- `refreshAwsBillingAccountCallback` is wired to the refresh button on the AWS billing account dropdown.
+
+## Output: `ClusterFormData`
+
+The `onSubmit` callback receives the full form state wrapped as `RosaWizardFormData`:
+
+```ts
+type RosaWizardFormData = {
+  cluster: ClusterFormData;
+};
+```
+
+`ClusterFormData` contains every field the wizard collects:
+
+```ts
+type ClusterFormData = {
+  // details
+  name?: string;
+  cluster_version?: string;
+  associated_aws_id?: string;
+  billing_account_id?: string;
+  region?: string;
+
+  // roles and policies
+  installer_role_arn?: string;
+  support_role_arn?: string;
+  worker_role_arn?: string;
+  byo_oidc_config_id?: string;
+  custom_operator_roles_prefix?: string;
+
+  // machine pools
+  selected_vpc?: string;
+  machine_pools_subnets?: MachinePoolSubnetEntry[];
+  machine_type?: string;
+  autoscaling?: boolean;
+  nodes_compute?: number;
+  min_replicas?: number;
+  max_replicas?: number;
+  compute_root_volume?: number;
+  imds?: string;
+
+  // networking
+  cluster_privacy?: 'external' | 'internal';
+  cluster_privacy_public_subnet_id?: string;
+  cidr_default?: boolean;
+  network_machine_cidr?: string;
+  network_service_cidr?: string;
+  network_pod_cidr?: string;
+  network_host_prefix?: string;
+  configure_proxy?: boolean;
+
+  // proxy (only present if configure_proxy is true)
+  http_proxy_url?: string;
+  https_proxy_url?: string;
+  no_proxy_domains?: string;
+  additional_trust_bundle?: string;
+
+  // encryption
+  encryption_keys?: 'default' | 'custom';
+  kms_key_arn?: string;
+  etcd_encryption?: boolean;
+  etcd_key_arn?: string;
+
+  // cluster updates
+  upgrade_policy?: 'automatic' | 'manual';
+  upgrade_schedule?: string; // cron format, e.g. "00 14 * * 3"
+};
+```
+
+All fields are optional because the user fills them in progressively. By the time `onSubmit` fires, required fields will have been validated by the wizard's built-in validation.
+
+## Full Example
+
+```tsx
+import { WizardWrapper } from 'nxtcm-components';
+import type {
+  WizardStepsData,
+  ClusterFormData,
+} from 'nxtcm-components';
+
+function CreateClusterPage() {
+  const stepsData: WizardStepsData = {
+    basicSetupStep: {
+      openShiftVersions: [
+        { label: '4.15.2', value: '4.15.2' },
+        { label: '4.14.8', value: '4.14.8' },
+      ],
+      awsInfrastructureAccounts: [
+        { label: 'prod-account (123456789)', value: '123456789' },
+      ],
+      awsBillingAccounts: [
+        { label: 'billing-main (987654321)', value: '987654321' },
+      ],
+      regions: [
+        { label: 'US East (N. Virginia)', value: 'us-east-1' },
+        { label: 'US West (Oregon)', value: 'us-west-2' },
+      ],
+      vpcList: [
+        {
+          id: 'vpc-abc123',
+          name: 'production-vpc',
+          aws_subnets: [
+            { subnet_id: 'subnet-priv1', name: 'private-us-east-1a', availability_zone: 'us-east-1a' },
+            { subnet_id: 'subnet-pub1', name: 'public-us-east-1a', availability_zone: 'us-east-1a' },
+          ],
+        },
+      ],
+      roles: {
+        installerRoles: [{ label: 'ManagedOpenShift-Installer-Role', value: 'arn:aws:iam::role/installer' }],
+        supportRoles: [{ label: 'ManagedOpenShift-Support-Role', value: 'arn:aws:iam::role/support' }],
+        workerRoles: [{ label: 'ManagedOpenShift-Worker-Role', value: 'arn:aws:iam::role/worker' }],
+      },
+      oicdConfig: [
+        { label: 'oidc-abc123', value: 'abc123', issuer_url: 'https://oidc.example.com' },
+      ],
+      machineTypes: [
+        { id: 'm5.xlarge', label: 'm5.xlarge', description: '4 vCPU, 16 GiB', value: 'm5.xlarge' },
+        { id: 'm5.2xlarge', label: 'm5.2xlarge', description: '8 vCPU, 32 GiB', value: 'm5.2xlarge' },
+      ],
+    },
+    callbackFunctions: {
+      onAWSAccountChange: (accountId) => {
+        // reload roles, VPCs, etc. for the selected account
+      },
+      refreshAwsAccountDataCallback: () => {
+        // re-fetch AWS infrastructure accounts
+      },
+      refreshAwsBillingAccountCallback: () => {
+        // re-fetch AWS billing accounts
+      },
+    },
+  };
+
+  const handleSubmit = async (data: unknown) => {
+    const { cluster } = data as { cluster: ClusterFormData };
+    // cluster.name, cluster.region, cluster.machine_type, etc.
+    // are all typed and available here
+    await createCluster(cluster);
+  };
+
+  return (
+    <WizardWrapper
+      type="rosa-hcp"
+      title="Create ROSA HCP cluster"
+      wizardsStepsData={stepsData}
+      onSubmit={handleSubmit}
+      onCancel={() => navigate('/clusters')}
+    />
+  );
+}
+```

--- a/packages/react-form-wizard/src/Step.tsx
+++ b/packages/react-form-wizard/src/Step.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import { Form } from '@patternfly/react-core';
-import { Fragment, ReactNode, useLayoutEffect } from 'react';
+import { Fragment, ReactElement, ReactNode, useLayoutEffect } from 'react';
 import { DisplayMode, useDisplayMode } from './contexts/DisplayModeContext';
 import { HasInputsProvider, useHasInputs } from './contexts/HasInputsProvider';
 import { ShowValidationProvider, useSetShowValidation } from './contexts/ShowValidationProvider';
@@ -16,7 +16,7 @@ export interface StepProps {
   id: string;
   hidden?: HiddenFn;
   autohide?: boolean;
-  steps?: React.ReactNode[];
+  steps?: ReactElement[];
 }
 
 export function Step(props: StepProps) {

--- a/packages/react-form-wizard/src/Step.tsx
+++ b/packages/react-form-wizard/src/Step.tsx
@@ -1,24 +1,14 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { Form } from "@patternfly/react-core";
-import {
-  Fragment,
-  ReactNode,
-  useLayoutEffect,
-} from "react";
-import { DisplayMode, useDisplayMode } from "./contexts/DisplayModeContext";
-import { HasInputsProvider, useHasInputs } from "./contexts/HasInputsProvider";
-import {
-  ShowValidationProvider,
-  useSetShowValidation,
-} from "./contexts/ShowValidationProvider";
-import { useSetStepHasInputs } from "./contexts/StepHasInputsProvider";
-import { useStepShowValidation } from "./contexts/StepShowValidationProvider";
-import { useSetStepHasValidationError } from "./contexts/StepValidationProvider";
-import {
-  useHasValidationError,
-  ValidationProvider,
-} from "./contexts/ValidationProvider";
-import { HiddenFn, useInputHidden } from "./inputs/Input";
+import { Form } from '@patternfly/react-core';
+import { Fragment, ReactNode, useLayoutEffect } from 'react';
+import { DisplayMode, useDisplayMode } from './contexts/DisplayModeContext';
+import { HasInputsProvider, useHasInputs } from './contexts/HasInputsProvider';
+import { ShowValidationProvider, useSetShowValidation } from './contexts/ShowValidationProvider';
+import { useSetStepHasInputs } from './contexts/StepHasInputsProvider';
+import { useStepShowValidation } from './contexts/StepShowValidationProvider';
+import { useSetStepHasValidationError } from './contexts/StepValidationProvider';
+import { useHasValidationError, ValidationProvider } from './contexts/ValidationProvider';
+import { HiddenFn, useInputHidden } from './inputs/Input';
 
 export interface StepProps {
   label: string;
@@ -26,7 +16,7 @@ export interface StepProps {
   id: string;
   hidden?: HiddenFn;
   autohide?: boolean;
-  steps?: any
+  steps?: React.ReactNode[];
 }
 
 export function Step(props: StepProps) {

--- a/packages/react-form-wizard/src/Wizard.tsx
+++ b/packages/react-form-wizard/src/Wizard.tsx
@@ -232,7 +232,7 @@ function WizardInternal({
   const steps = useMemo(() => {
     const steps: StepComponent[] = stepComponents.map((component) => {
       if (component.props.steps) {
-        const subSteps: SubStepComponent[] = (component.props?.steps as ReactElement[]).map(
+        const subSteps: SubStepComponent[] = (component.props.steps as ReactElement[]).map(
           (step: ReactElement) => {
             return {
               id: step.props.id,

--- a/packages/react-form-wizard/src/Wizard.tsx
+++ b/packages/react-form-wizard/src/Wizard.tsx
@@ -85,16 +85,18 @@ export interface WizardProps {
   submitButtonText?: string;
   submittingButtonText?: string;
   onStepChange?: (event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) => void;
-  setUseWizardContext?: any;
+  setUseWizardContext?: (context: WizardContextType) => void;
 }
 
 export type WizardSubmit = (data: unknown) => Promise<void>;
 export type WizardCancel = () => void;
 
+type WizardContextType = ReturnType<typeof useWizardContext>;
+
 export function Wizard(props: WizardProps & { showHeader?: boolean; showYaml?: boolean }) {
   const [data, setData] = useState(props.defaultData ? klona(props.defaultData) : {});
   const update = useCallback(
-    (newData: any) => setData((data: unknown) => klona(newData ?? data)),
+    (newData?: object) => setData((data: unknown) => klona(newData ?? data)),
     []
   );
   const [drawerExpanded, setDrawerExpanded] = useState<boolean>(false);
@@ -155,12 +157,18 @@ export function Wizard(props: WizardProps & { showHeader?: boolean; showYaml?: b
   );
 }
 
+type SubStepComponent = {
+  id: string;
+  name: ReactNode;
+  component: ReactNode;
+};
+
 type StepComponent = {
   id: string;
   name: ReactNode;
   component?: ReactNode;
   isExpandable?: boolean;
-  subSteps?: any;
+  subSteps?: SubStepComponent[];
   expandableStepComponent?: React.ReactElement<WizardStepProps>[];
 };
 
@@ -169,7 +177,7 @@ type WizardFooterProps = {
   submitButtonText?: string;
   submittingButtonText?: string;
   steps: ReactElement[];
-  setUseWizardContext?: any;
+  setUseWizardContext?: (context: WizardContextType) => void;
 };
 
 type WizardInternalProps = Omit<WizardFooterProps, 'steps'> & {
@@ -178,7 +186,7 @@ type WizardInternalProps = Omit<WizardFooterProps, 'steps'> & {
   onCancel: WizardCancel;
   hasButtons?: boolean;
   onStepChange?: (event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) => void;
-  setUseWizardContext?: any;
+  setUseWizardContext?: (context: WizardContextType) => void;
 };
 
 function WizardInternal({
@@ -224,26 +232,27 @@ function WizardInternal({
   const steps = useMemo(() => {
     const steps: StepComponent[] = stepComponents.map((component) => {
       if (component.props.steps) {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        const subSteps = component.props?.steps.map((step: any) => {
-          return {
-            id: step.props.id,
-            name: (
-              <Split hasGutter>
-                <SplitItem isFilled>{step.props?.label}</SplitItem>
-                {(showValidation || stepShowValidation[step.props?.id]) &&
-                  stepHasValidationError[step.props?.id] && (
-                    <SplitItem>
-                      <Icon status="danger">
-                        <ExclamationCircleIcon />
-                      </Icon>
-                    </SplitItem>
-                  )}
-              </Split>
-            ),
-            component: <Fragment key={step.props?.id}>{step}</Fragment>,
-          };
-        });
+        const subSteps: SubStepComponent[] = (component.props?.steps as ReactElement[]).map(
+          (step: ReactElement) => {
+            return {
+              id: step.props.id,
+              name: (
+                <Split hasGutter>
+                  <SplitItem isFilled>{step.props?.label}</SplitItem>
+                  {(showValidation || stepShowValidation[step.props?.id]) &&
+                    stepHasValidationError[step.props?.id] && (
+                      <SplitItem>
+                        <Icon status="danger">
+                          <ExclamationCircleIcon />
+                        </Icon>
+                      </SplitItem>
+                    )}
+                </Split>
+              ),
+              component: <Fragment key={step.props?.id}>{step}</Fragment>,
+            };
+          }
+        );
         return {
           id: component.props?.id,
           name: (
@@ -316,14 +325,11 @@ function WizardInternal({
                 key={id}
                 name={name}
                 isExpandable
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-                steps={subSteps.map((subStep: any) => {
-                  return (
-                    <WizardStep id={subStep.id} key={subStep.id} name={subStep.name}>
-                      {subStep.component}
-                    </WizardStep>
-                  );
-                })}
+                steps={subSteps.map((subStep: SubStepComponent) => (
+                  <WizardStep id={subStep.id} key={subStep.id} name={subStep.name}>
+                    {subStep.component}
+                  </WizardStep>
+                ))}
               />
             );
           }
@@ -349,8 +355,7 @@ function MyFooter(props: WizardFooterProps) {
   const wizContext = useWizardContext();
 
   useEffect(() => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-    props.setUseWizardContext(wizContext);
+    props.setUseWizardContext?.(wizContext);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.setUseWizardContext]);
 

--- a/packages/react-form-wizard/src/WizardPage.tsx
+++ b/packages/react-form-wizard/src/WizardPage.tsx
@@ -5,18 +5,21 @@ import {
   Switch,
   Content,
   Title,
+  useWizardContext,
   WizardStepType,
-} from "@patternfly/react-core";
-import { ReactNode, useCallback, useState } from "react";
-import { WizardYamlEditor } from "./components/YamlEditor";
-import { Wizard, WizardProps } from "./Wizard";
+} from '@patternfly/react-core';
+import { ReactNode, useCallback, useState } from 'react';
+import { WizardYamlEditor } from './components/YamlEditor';
+import { Wizard, WizardProps } from './Wizard';
+
+type WizardContextType = ReturnType<typeof useWizardContext>;
 
 export type WizardPageProps = {
   breadcrumb?: { label: string; to?: string }[];
   yaml?: boolean;
   yamlEditor?: () => ReactNode;
   onStepChange?: (event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) => void;
-  setUseWizardContext?: any;
+  setUseWizardContext?: (context: WizardContextType) => void;
 } & WizardProps;
 
 function getWizardYamlEditor() {
@@ -27,21 +30,21 @@ export function WizardPage(props: WizardPageProps) {
   let { yamlEditor } = props;
   if (!yamlEditor) yamlEditor = getWizardYamlEditor;
   const [drawerExpanded, setDrawerExpanded] = useState(
-    props.yaml !== false && localStorage.getItem("yaml") === "true"
+    props.yaml !== false && localStorage.getItem('yaml') === 'true'
   );
   const toggleDrawerExpanded = useCallback(() => {
     setDrawerExpanded((drawerExpanded) => {
-      localStorage.setItem("yaml", (!drawerExpanded).toString());
+      localStorage.setItem('yaml', (!drawerExpanded).toString());
       return !drawerExpanded;
     });
   }, []);
   return (
-    <div style={{ height: "100vh" }}>
+    <div style={{ height: '100vh' }}>
       <PageSection variant="default">
         <Flex
-          alignItems={{ default: "alignItemsCenter" }}
+          alignItems={{ default: 'alignItemsCenter' }}
           wrap="noWrap"
-          style={{ flexWrap: "nowrap", gap: 16 }}
+          style={{ flexWrap: 'nowrap', gap: 16 }}
         >
           <Title headingLevel="h1">{props.title}</Title>
           {props.yaml !== false && (
@@ -53,9 +56,7 @@ export function WizardPage(props: WizardPageProps) {
             />
           )}
         </Flex>
-        {props.description && (
-          <Content component="small">{props.description}</Content>
-        )}
+        {props.description && <Content component="small">{props.description}</Content>}
       </PageSection>
       <Wizard
         {...props}

--- a/packages/react-form-wizard/src/contexts/DataContext.tsx
+++ b/packages/react-form-wizard/src/contexts/DataContext.tsx
@@ -1,12 +1,12 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { createContext, useContext } from "react";
+import { createContext, useContext } from 'react';
 
 export interface IDataContext {
-  update: (data?: any) => void;
+  update: (data?: object) => void;
 }
 
 export const DataContext = createContext<IDataContext>({ update: () => null });
-DataContext.displayName = "DataContext";
+DataContext.displayName = 'DataContext';
 
 export function useData() {
   return useContext(DataContext);

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -14,7 +14,15 @@ import {
 import React from 'react';
 import { ClusterWideProxySubstep } from './Steps/AdditionalSetupStep/ClusterWideProxySubstep/ClusterWideProxySubstep';
 import { ReviewStepData } from './Steps/ReviewStepData';
-import { MachineTypesDropdownType, OIDCConfig, Roles, SelectDropdownType, VPC } from '../types';
+import {
+  MachineTypesDropdownType,
+  OIDCConfig,
+  Roles,
+  SelectDropdownType,
+  VPC,
+  WizardCallbackFunctions,
+  WizardNavigationContext,
+} from '../types';
 import { WizardStepType } from '@patternfly/react-core';
 import { useTranslation } from '../../../context/TranslationContext';
 import { MachinePoolsSubstep } from './Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep';
@@ -30,9 +38,9 @@ export type BasicSetupStepProps = {
   machineTypes: MachineTypesDropdownType[];
 };
 
-type WizardStepsData = {
+export type WizardStepsData = {
   basicSetupStep: BasicSetupStepProps;
-  callbackFunctions?: any;
+  callbackFunctions?: WizardCallbackFunctions;
 };
 
 type RosaWizardProps = {
@@ -50,7 +58,9 @@ export const RosaWizard = (props: RosaWizardProps) => {
   const [, setCurrentStep] = React.useState<WizardStepType>();
   const onStepChange = (_event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) =>
     setCurrentStep(currentStep);
-  const [getUseWizardContext, setUseWizardContext] = React.useState();
+  const [getUseWizardContext, setUseWizardContext] = React.useState<
+    WizardNavigationContext | undefined
+  >();
 
   const callbackFunctions = wizardsStepsData.callbackFunctions;
 
@@ -93,9 +103,9 @@ export const RosaWizard = (props: RosaWizardProps) => {
               awsInfrastructureAccounts={wizardsStepsData.basicSetupStep.awsInfrastructureAccounts}
               awsBillingAccounts={wizardsStepsData.basicSetupStep.awsBillingAccounts}
               regions={wizardsStepsData.basicSetupStep.regions}
-              awsAccountDataCallback={callbackFunctions.onAWSAccountChange}
-              refreshAwsAccountDataCallback={callbackFunctions.refreshAwsAccountDataCallback}
-              refreshAwsBillingAccountCallback={callbackFunctions.refreshAwsBillingAccountCallback}
+              awsAccountDataCallback={callbackFunctions?.onAWSAccountChange}
+              refreshAwsAccountDataCallback={callbackFunctions?.refreshAwsAccountDataCallback}
+              refreshAwsBillingAccountCallback={callbackFunctions?.refreshAwsBillingAccountCallback}
             />
           </Step>,
           <Step

--- a/src/components/Wizards/RosaWizard/RosaWizardWithYamlEditor.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardWithYamlEditor.tsx
@@ -14,25 +14,10 @@ import {
 import React from 'react';
 import { ClusterWideProxySubstep } from './Steps/AdditionalSetupStep/ClusterWideProxySubstep/ClusterWideProxySubstep';
 import { ReviewStepData } from './Steps/ReviewStepData';
-import { MachineTypesDropdownType, OIDCConfig, Roles, SelectDropdownType, VPC } from '../types';
+import { WizardNavigationContext } from '../types';
 import { WizardStepType } from '@patternfly/react-core';
 import { YamlEditorStep } from './Steps/YamlEditorStep';
-
-export type BasicSetupStepProps = {
-  openShiftVersions: SelectDropdownType[];
-  awsInfrastructureAccounts: SelectDropdownType[];
-  awsBillingAccounts: SelectDropdownType[];
-  vpcList: VPC[];
-  regions: SelectDropdownType[];
-  roles: Roles;
-  oicdConfig: OIDCConfig[];
-  machineTypes: MachineTypesDropdownType[];
-};
-
-type WizardStepsData = {
-  basicSetupStep: BasicSetupStepProps;
-  callbackFunctions?: any;
-};
+import { WizardStepsData } from './RosaWizard';
 
 type RosaWizardWithYamlEditorProps = {
   onSubmit: WizardSubmit;
@@ -48,7 +33,9 @@ export const RosaWizardWithYamlEditor = (props: RosaWizardWithYamlEditorProps) =
   const [, setCurrentStep] = React.useState<WizardStepType>();
   const onStepChange = (_event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) =>
     setCurrentStep(currentStep);
-  const [getUseWizardContext, setUseWizardContext] = React.useState();
+  const [getUseWizardContext, setUseWizardContext] = React.useState<
+    WizardNavigationContext | undefined
+  >();
 
   const callbackFunction = wizardsStepsData.callbackFunctions;
 

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
-import { Section, WizRadioGroup, Radio } from '@patternfly-labs/react-form-wizard';
-import { useInput } from '@patternfly-labs/react-form-wizard/inputs/Input';
+import { Section, WizRadioGroup, Radio, useItem } from '@patternfly-labs/react-form-wizard';
 import { useData } from '@patternfly-labs/react-form-wizard';
 import {
   Button,
@@ -17,17 +16,21 @@ import {
 } from '@patternfly/react-core';
 import { useTranslation } from '../../../../../../context/TranslationContext';
 import parseUpdateSchedule from './parseUpdateSchedule';
+import { RosaWizardFormData, WizardNavigationContext } from '../../../../types';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
 
 const daysOptions = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const hoursOptions = Array.from(Array(24).keys());
 
-export const ClusterUpdatesSubstep = (props: any) => {
+type ClusterUpdatesSubstepProps = {
+  goToStepId?: WizardNavigationContext;
+};
+
+export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
   const { t } = useTranslation();
-  const { value } = useInput(props);
+  const { cluster } = useItem<RosaWizardFormData>();
   const { update } = useData();
-  const { cluster } = value;
 
   const [daySelectOpen, setDaySelectOpen] = useState(false);
   const [timeSelectOpen, setTimeSelectOpen] = useState(false);
@@ -91,7 +94,7 @@ export const ClusterUpdatesSubstep = (props: any) => {
         {t(`The OpenShift version ${cluster.cluster_version} that you selected in the`)}{' '}
         {
           <Button
-            onClick={() => props.goToStepId.goToStepById('basic-setup-step-details')}
+            onClick={() => props.goToStepId?.goToStepById('basic-setup-step-details')}
             variant="link"
             isInline
           >
@@ -101,7 +104,7 @@ export const ClusterUpdatesSubstep = (props: any) => {
         {t('will apply to the managed control plane and the machine pools configured in the')}{' '}
         {
           <Button
-            onClick={() => props.goToStepId.goToStepById('networking-sub-step')}
+            onClick={() => props.goToStepId?.goToStepById('networking-sub-step')}
             variant="link"
             isInline
           >

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/EncryptionSubstep/EncryptionSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/EncryptionSubstep/EncryptionSubstep.tsx
@@ -1,21 +1,21 @@
 import {
   Radio,
   Section,
+  useItem,
   WizCheckbox,
   WizRadioGroup,
   WizTextInput,
 } from '@patternfly-labs/react-form-wizard';
-import { useInput } from '@patternfly-labs/react-form-wizard/inputs/Input';
 import { Alert, Flex, FlexItem, Grid, GridItem } from '@patternfly/react-core';
 import { useTranslation } from '../../../../../../context/TranslationContext';
 import { validateAWSKMSKeyARN } from '../../../validators';
+import { RosaWizardFormData } from '../../../../types';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
 
-export const EncryptionSubstep = (props: any) => {
+export const EncryptionSubstep = () => {
   const { t } = useTranslation();
-  const { value } = useInput(props);
-  const { cluster } = value;
+  const { cluster } = useItem<RosaWizardFormData>();
 
   return (
     <Section

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -13,9 +13,9 @@ type DetailsSubStepProps = {
   awsInfrastructureAccounts: SelectDropdownType[];
   awsBillingAccounts: SelectDropdownType[];
   regions: SelectDropdownType[];
-  awsAccountDataCallback: any;
-  refreshAwsAccountDataCallback: () => void;
-  refreshAwsBillingAccountCallback: () => void;
+  awsAccountDataCallback?: (value: unknown) => void;
+  refreshAwsAccountDataCallback?: () => void;
+  refreshAwsBillingAccountCallback?: () => void;
 };
 
 export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import {
   Radio,
   Section,
+  useItem,
   WizMachinePoolSelect,
   WizNumberInput,
   WizRadioGroup,
   WizSelect,
 } from '@patternfly-labs/react-form-wizard';
-import { useInput } from '@patternfly-labs/react-form-wizard/inputs/Input';
 import {
   Content,
   ContentVariants,
@@ -17,17 +17,21 @@ import {
 } from '@patternfly/react-core';
 import { useTranslation } from '../../../../../../context/TranslationContext';
 import { subnetsFilter } from '../../../helpers';
-import { Subnet, VPC } from '../../../../types';
+import { MachineTypesDropdownType, RosaWizardFormData, Subnet, VPC } from '../../../../types';
 import { AutoscalingField } from './Autoscaling/AutoscalingField';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
 import { Indented } from '@patternfly-labs/react-form-wizard/components/Indented';
 import { validateRootDiskSize } from '../../../validators';
 
-export const MachinePoolsSubstep = (props: any) => {
+type MachinePoolsSubstepProps = {
+  vpcList: VPC[];
+  machineTypes: MachineTypesDropdownType[];
+};
+
+export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
   const { t } = useTranslation();
-  const { value } = useInput(props);
-  const { cluster } = value;
+  const { cluster } = useItem<RosaWizardFormData>();
 
   const selectedVPC = props.vpcList.find((vpc: VPC) => vpc.id === cluster?.selected_vpc);
 
@@ -66,12 +70,10 @@ export const MachinePoolsSubstep = (props: any) => {
                   <ExternalLink href={links.ROSA_SHARED_VPC}>Learn more about VPCs.</ExternalLink>
                 </>
               }
-              options={props.vpcList.map((vpc: any) => {
-                return {
-                  label: vpc.name,
-                  value: vpc.id,
-                };
-              })}
+              options={props.vpcList.map((vpc: VPC) => ({
+                label: vpc.name,
+                value: vpc.id,
+              }))}
             />
           </GridItem>
         </Grid>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -33,7 +33,9 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
   const { t } = useTranslation();
   const { cluster } = useItem<RosaWizardFormData>();
 
-  const selectedVPC = props.vpcList.find((vpc: VPC) => vpc.id === cluster?.selected_vpc);
+  const vpcRef = cluster?.selected_vpc;
+  const selectedVPC =
+    typeof vpcRef === 'string' ? props.vpcList.find((vpc: VPC) => vpc.id === vpcRef) : vpcRef;
 
   const { privateSubnets } = subnetsFilter(selectedVPC);
 

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
@@ -1,14 +1,14 @@
 import {
   Radio,
   Section,
+  useItem,
   WizCheckbox,
   WizRadioGroup,
   WizSelect,
   WizTextInput,
 } from '@patternfly-labs/react-form-wizard';
 import { LabelHelp } from '@patternfly-labs/react-form-wizard/components/LabelHelp';
-import { useInput } from '@patternfly-labs/react-form-wizard/inputs/Input';
-import { Subnet, VPC } from '../../../../types';
+import { RosaWizardFormData, Subnet, VPC } from '../../../../types';
 import { useTranslation } from '../../../../../../context/TranslationContext';
 import { constructSelectedSubnets, subnetsFilter } from '../../../helpers';
 import {
@@ -36,10 +36,15 @@ import {
 } from '../../../validators';
 import { Indented } from '@patternfly-labs/react-form-wizard/components/Indented';
 
-export const NetworkingAndSubnetsSubStep = (props: any) => {
+type NetworkingAndSubnetsSubStepProps = {
+  vpcList: VPC[];
+  machineTypes?: unknown[];
+  setIsClusterWideProxySelected: (value: boolean) => void;
+};
+
+export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepProps) => {
   const { t } = useTranslation();
-  const { value } = useInput(props);
-  const { cluster } = value;
+  const { cluster } = useItem<RosaWizardFormData>();
   const { setIsClusterWideProxySelected } = props;
   const selectedVPC = props.vpcList.find((vpc: VPC) => vpc.id === cluster?.selected_vpc);
 

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
@@ -46,7 +46,9 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
   const { t } = useTranslation();
   const { cluster } = useItem<RosaWizardFormData>();
   const { setIsClusterWideProxySelected } = props;
-  const selectedVPC = props.vpcList.find((vpc: VPC) => vpc.id === cluster?.selected_vpc);
+  const vpcRef = cluster?.selected_vpc;
+  const selectedVPC =
+    typeof vpcRef === 'string' ? props.vpcList.find((vpc: VPC) => vpc.id === vpcRef) : vpcRef;
 
   const { publicSubnets } = subnetsFilter(selectedVPC);
 

--- a/src/components/Wizards/RosaWizard/Steps/ReviewAndCreateStep/ReviewAndCreateStepItem.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/ReviewAndCreateStep/ReviewAndCreateStepItem.tsx
@@ -3,7 +3,7 @@ import LockIcon from '@patternfly/react-icons/dist/esm/icons/lock-icon';
 
 type ReviewAndCreateStepItemProps = {
   label: string;
-  value: string;
+  value: string | number | boolean | undefined;
   hasIcon?: boolean;
 };
 
@@ -17,7 +17,7 @@ export const ReviewAndCreateStepItem: React.FunctionComponent<ReviewAndCreateSte
       <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
         <FlexItem>{label}</FlexItem>
         <FlexItem>
-          {value} {hasIcon && <LockIcon />}
+          {String(value ?? '')} {hasIcon && <LockIcon />}
         </FlexItem>
       </Flex>
     </StackItem>

--- a/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
@@ -15,10 +15,15 @@ import { LockIcon } from '@patternfly/react-icons';
 import { ReviewAndCreateStepItem } from './ReviewAndCreateStep/ReviewAndCreateStepItem';
 import { MachinePoolsReviewAndCreateStepItem } from './ReviewAndCreateStep/MachinePoolsReviewAndCreateStepItem';
 import { useTranslation } from '../../../../context/TranslationContext';
+import { RosaWizardFormData, WizardNavigationContext } from '../../types';
 
-export const ReviewStepData = (props: any) => {
+type ReviewStepDataProps = {
+  goToStepId?: WizardNavigationContext;
+};
+
+export const ReviewStepData = (props: ReviewStepDataProps) => {
   const { t } = useTranslation();
-  const { cluster } = useItem();
+  const { cluster } = useItem<RosaWizardFormData>();
 
   const [isDetailsSectionExpanded, setIsDetailsSectionExpanded] = React.useState<boolean>(true);
   const [isRolesAndPoliciesExpanded, setIsRolesAndPoliciesExpanded] = React.useState<boolean>(true);
@@ -106,7 +111,7 @@ export const ReviewStepData = (props: any) => {
         </SplitItem>
         <SplitItem>
           <Button
-            onClick={() => props.goToStepId.goToStepById('basic-setup-step-details')}
+            onClick={() => props.goToStepId?.goToStepById('basic-setup-step-details')}
             variant="link"
             isInline
           >
@@ -148,7 +153,7 @@ export const ReviewStepData = (props: any) => {
 
         <SplitItem>
           <Button
-            onClick={() => props.goToStepId.goToStepById('roles-and-policies-sub-step')}
+            onClick={() => props.goToStepId?.goToStepById('roles-and-policies-sub-step')}
             variant="link"
             isInline
           >
@@ -225,7 +230,7 @@ export const ReviewStepData = (props: any) => {
 
         <SplitItem>
           <Button
-            onClick={() => props.goToStepId.goToStepById('networking-sub-step')}
+            onClick={() => props.goToStepId?.goToStepById('networking-sub-step')}
             variant="link"
             isInline
           >
@@ -260,7 +265,7 @@ export const ReviewStepData = (props: any) => {
         </SplitItem>
         <SplitItem>
           <Button
-            onClick={() => props.goToStepId.goToStepById('additional-setup-encryption')}
+            onClick={() => props.goToStepId?.goToStepById('additional-setup-encryption')}
             variant="link"
             isInline
           >
@@ -307,7 +312,7 @@ export const ReviewStepData = (props: any) => {
         </SplitItem>
         <SplitItem>
           <Button
-            onClick={() => props.goToStepId.goToStepById('additional-setup-networking')}
+            onClick={() => props.goToStepId?.goToStepById('additional-setup-networking')}
             variant="link"
             isInline
           >
@@ -343,7 +348,7 @@ export const ReviewStepData = (props: any) => {
         </SplitItem>
         <SplitItem>
           <Button
-            onClick={() => props.goToStepId.goToStepById('additional-setup-cluster-updates')}
+            onClick={() => props.goToStepId?.goToStepById('additional-setup-cluster-updates')}
             variant="link"
             isInline
           >

--- a/src/components/Wizards/RosaWizard/common/AssociateAWSAccountInfo.tsx
+++ b/src/components/Wizards/RosaWizard/common/AssociateAWSAccountInfo.tsx
@@ -1,7 +1,13 @@
 import { ExpandableSection, Title } from '@patternfly/react-core';
 import React from 'react';
 
-export const AssociateAWSAccountInfo = (props: any) => {
+type AssociateAWSAccountInfoProps = {
+  title: string;
+  initiallyExpanded?: boolean;
+  children: React.ReactNode;
+};
+
+export const AssociateAWSAccountInfo = (props: AssociateAWSAccountInfoProps) => {
   const { title } = props;
   const [isExpanded, setIsExpanded] = React.useState(props.initiallyExpanded);
   const onToggle = (_: React.MouseEvent<Element, MouseEvent>, isExpanded: boolean) => {
@@ -10,7 +16,9 @@ export const AssociateAWSAccountInfo = (props: any) => {
   return (
     <>
       <ExpandableSection
-        onToggle={(event: any, isExpanded: boolean) => onToggle(event, isExpanded)}
+        onToggle={(event: React.MouseEvent<Element, MouseEvent>, isExpanded: boolean) =>
+          onToggle(event, isExpanded)
+        }
         isExpanded={isExpanded}
         toggleContent={
           <Title headingLevel="h3" size="md">

--- a/src/components/Wizards/RosaWizard/common/StepDrawer.tsx
+++ b/src/components/Wizards/RosaWizard/common/StepDrawer.tsx
@@ -19,7 +19,14 @@ import { OCMRole } from './OCMRole';
 import { UserRole } from './UserRole';
 import { AccountRoles } from './AccountRoles';
 
-export const StepDrawer = (props: any) => {
+type StepDrawerProps = {
+  isDrawerExpanded: boolean;
+  setIsDrawerExpanded: (expanded: boolean) => void;
+  onWizardExpand: () => void;
+  children: React.ReactNode;
+};
+
+export const StepDrawer = (props: StepDrawerProps) => {
   const { isDrawerExpanded, onWizardExpand, setIsDrawerExpanded } = props;
   return (
     <Drawer isInline isExpanded={isDrawerExpanded} onExpand={onWizardExpand}>

--- a/src/components/Wizards/RosaWizard/helpers.ts
+++ b/src/components/Wizards/RosaWizard/helpers.ts
@@ -59,23 +59,23 @@ const constructSelectedSubnets = (formValues?: ClusterFormData): CIDRSubnet[] =>
     .map((obj: MachinePoolSubnetEntry) => obj.machine_pool_subnet)
     .filter((id: string) => id !== undefined && id !== '');
 
-  const publicSubnetIds = formValues?.cluster_privacy_public_subnet_id;
+  // single subnet id from WizSelect — always a string, not an array
+  const publicSubnetId = formValues?.cluster_privacy_public_subnet_id;
 
-  // at runtime selected_vpc can hold the full VPC object (set-value merges nested structures),
-  // so we cast defensively to access aws_subnets
-  const vpcData = formValues.selected_vpc as unknown as
-    | (VPC & { aws_subnets?: CIDRSubnet[] })
-    | undefined;
-  if (!vpcData?.aws_subnets) {
+  const selectedVpc = formValues.selected_vpc;
+  if (typeof selectedVpc === 'string' || !selectedVpc?.aws_subnets) {
     return [];
   }
 
-  const privateSubnets = vpcData.aws_subnets.filter((obj: CIDRSubnet) =>
+  // aws_subnets contains CIDRSubnet data at runtime even though VPC types it as Subnet[]
+  const subnets = selectedVpc.aws_subnets as unknown as CIDRSubnet[];
+
+  const privateSubnets = subnets.filter((obj: CIDRSubnet) =>
     privateSubnetIds.includes(obj.subnet_id)
   );
 
-  const publicSubnets = vpcData.aws_subnets.filter((obj: CIDRSubnet) =>
-    publicSubnetIds ? obj.subnet_id === publicSubnetIds : false
+  const publicSubnets = subnets.filter((obj: CIDRSubnet) =>
+    publicSubnetId ? obj.subnet_id === publicSubnetId : false
   );
 
   return privateSubnets.concat(publicSubnets);

--- a/src/components/Wizards/RosaWizard/helpers.ts
+++ b/src/components/Wizards/RosaWizard/helpers.ts
@@ -1,4 +1,4 @@
-import { CIDRSubnet, Subnet, VPC } from '../types';
+import { CIDRSubnet, ClusterFormData, MachinePoolSubnetEntry, Subnet, VPC } from '../types';
 import { MAX_CUSTOM_OPERATOR_ROLES_PREFIX_LENGTH } from './constants';
 
 const OPERATOR_ROLES_HASH_LENGTH = 4;
@@ -50,46 +50,38 @@ const parseCIDRSubnetLength = (value?: string): number | undefined => {
   return parseInt(value.split('/').pop() ?? '', 10);
 };
 
-const constructSelectedSubnets = (formValues?: Record<string, any>) => {
-  type MachinePoolSubnet = {
-    availability_zone: string;
-    machine_pool_subnet: string;
-    publicSubnetId: string;
-  };
-  const usePrivateLink = formValues?.use_privatelink;
-
-  let privateSubnets: CIDRSubnet[] = [];
-  let publicSubnets: CIDRSubnet[] = [];
-  let selectedSubnets: CIDRSubnet[] = [];
-
-  if (formValues?.selected_vpc) {
-    const privateSubnetIds = formValues?.machine_pools_subnets
-      .map((obj: MachinePoolSubnet) => obj.machine_pool_subnet)
-      .filter((id: string) => id !== undefined && id !== '');
-
-    const publicSubnetIds = formValues?.cluster_privacy_public_subnet_id;
-
-    if (formValues?.selected_vpc?.aws_subnets) {
-      privateSubnets = formValues?.selected_vpc?.aws_subnets.filter((obj: Subnet) =>
-        privateSubnetIds.includes(obj.subnet_id)
-      );
-
-      publicSubnets = formValues?.selected_vpc?.aws_subnets.filter((obj: Subnet) =>
-        publicSubnetIds.includes(obj.subnet_id)
-      );
-    }
-
-    if (usePrivateLink) {
-      selectedSubnets = privateSubnets;
-    } else {
-      selectedSubnets = privateSubnets.concat(publicSubnets);
-    }
+const constructSelectedSubnets = (formValues?: ClusterFormData): CIDRSubnet[] => {
+  if (!formValues?.selected_vpc) {
+    return [];
   }
 
-  return selectedSubnets;
+  const privateSubnetIds = (formValues?.machine_pools_subnets ?? [])
+    .map((obj: MachinePoolSubnetEntry) => obj.machine_pool_subnet)
+    .filter((id: string) => id !== undefined && id !== '');
+
+  const publicSubnetIds = formValues?.cluster_privacy_public_subnet_id;
+
+  // at runtime selected_vpc can hold the full VPC object (set-value merges nested structures),
+  // so we cast defensively to access aws_subnets
+  const vpcData = formValues.selected_vpc as unknown as
+    | (VPC & { aws_subnets?: CIDRSubnet[] })
+    | undefined;
+  if (!vpcData?.aws_subnets) {
+    return [];
+  }
+
+  const privateSubnets = vpcData.aws_subnets.filter((obj: CIDRSubnet) =>
+    privateSubnetIds.includes(obj.subnet_id)
+  );
+
+  const publicSubnets = vpcData.aws_subnets.filter((obj: CIDRSubnet) =>
+    publicSubnetIds ? obj.subnet_id === publicSubnetIds : false
+  );
+
+  return privateSubnets.concat(publicSubnets);
 };
 
-const subnetsFilter = (selectedVPC: VPC) => {
+const subnetsFilter = (selectedVPC: VPC | undefined) => {
   const privateSubnets = selectedVPC?.aws_subnets.filter((privateSubnet: Subnet) =>
     privateSubnet.name.includes('private')
   );

--- a/src/components/Wizards/WizardWrapper.tsx
+++ b/src/components/Wizards/WizardWrapper.tsx
@@ -1,15 +1,15 @@
 import { WizardCancel, WizardSubmit } from '@patternfly-labs/react-form-wizard';
 import { RosaWizard } from './RosaWizard/RosaWizard';
 import { RosaWizardWithYamlEditor } from './RosaWizard/RosaWizardWithYamlEditor';
+import { WizardType } from './types';
+import { WizardStepsData } from './RosaWizard/RosaWizard';
 
 type WizardWrapperProps = {
-  type: string;
+  type: WizardType;
   onSubmit: WizardSubmit;
   onCancel: WizardCancel;
   title: string;
-  defaultData: any;
-  stepProps: any;
-  wizardsStepsData: any;
+  wizardsStepsData: WizardStepsData;
 };
 
 export const WizardWrapper: React.FunctionComponent<WizardWrapperProps> = (props) => {

--- a/src/components/Wizards/index.ts
+++ b/src/components/Wizards/index.ts
@@ -1,1 +1,20 @@
 export * from './WizardWrapper';
+export type {
+  ClusterFormData,
+  RosaWizardFormData,
+  MachinePoolSubnetEntry,
+  WizardCallbackFunctions,
+  WizardNavigationContext,
+  WizardType,
+  SelectDropdownType,
+  MachineTypesDropdownType,
+  Roles,
+  OIDCConfig,
+  VPC,
+  Subnet,
+  CIDRSubnet,
+  Region,
+  OpenShiftVersions,
+  AWSInfrastructureAccounts,
+} from './types';
+export type { BasicSetupStepProps, WizardStepsData } from './RosaWizard/RosaWizard';

--- a/src/components/Wizards/types.ts
+++ b/src/components/Wizards/types.ts
@@ -1,3 +1,7 @@
+import { useWizardContext } from '@patternfly/react-core';
+
+// -- dropdown / select option types --
+
 export type Region = {
   label: string;
   value: string;
@@ -38,6 +42,8 @@ export type Roles = {
   workerRoles: SelectDropdownType[];
 };
 
+// -- networking / VPC types --
+
 export type Subnet = {
   subnet_id: string;
   name: string;
@@ -55,3 +61,85 @@ export type VPC = {
   name: string;
   aws_subnets: Subnet[];
 };
+
+// -- machine pool entry used in the wizard form --
+
+export type MachinePoolSubnetEntry = {
+  machine_pool_subnet: string;
+};
+
+// -- cluster form data: the full shape of the wizard's form state --
+
+export type ClusterFormData = {
+  name?: string;
+  cluster_version?: string;
+  associated_aws_id?: string;
+  billing_account_id?: string;
+  region?: string;
+
+  // roles & policies
+  installer_role_arn?: string;
+  support_role_arn?: string;
+  worker_role_arn?: string;
+  byo_oidc_config_id?: string;
+  custom_operator_roles_prefix?: string;
+
+  // machine pools
+  selected_vpc?: string;
+  machine_pools_subnets?: MachinePoolSubnetEntry[];
+  machine_type?: string;
+  autoscaling?: boolean;
+  nodes_compute?: number;
+  min_replicas?: number;
+  max_replicas?: number;
+  compute_root_volume?: number;
+  imds?: string;
+
+  // networking
+  cluster_privacy?: 'external' | 'internal';
+  cluster_privacy_public_subnet_id?: string;
+  cidr_default?: boolean;
+  network_machine_cidr?: string;
+  network_service_cidr?: string;
+  network_pod_cidr?: string;
+  network_host_prefix?: string;
+  configure_proxy?: boolean;
+  multi_az?: string;
+  hypershift?: string;
+
+  // proxy
+  http_proxy_url?: string;
+  https_proxy_url?: string;
+  no_proxy_domains?: string;
+  additional_trust_bundle?: string;
+
+  // encryption
+  encryption_keys?: 'default' | 'custom';
+  kms_key_arn?: string;
+  etcd_encryption?: boolean;
+  etcd_key_arn?: string;
+
+  // cluster updates
+  upgrade_policy?: 'automatic' | 'manual';
+  upgrade_schedule?: string;
+};
+
+export type RosaWizardFormData = {
+  cluster: ClusterFormData;
+};
+
+// -- wizard type discriminator for WizardWrapper --
+
+export type WizardType = 'rosa-hcp' | 'rosa-yaml-editor';
+
+// -- callback functions passed into the wizard by consumers --
+
+export type WizardCallbackFunctions = {
+  onAWSAccountChange?: (value: unknown) => void;
+  refreshAwsAccountDataCallback?: () => void;
+  refreshAwsBillingAccountCallback?: () => void;
+};
+
+// -- wizard context: the PatternFly useWizardContext() return type --
+
+export type WizardNavigationContext = ReturnType<typeof useWizardContext>;

--- a/src/components/Wizards/types.ts
+++ b/src/components/Wizards/types.ts
@@ -84,8 +84,8 @@ export type ClusterFormData = {
   byo_oidc_config_id?: string;
   custom_operator_roles_prefix?: string;
 
-  // machine pools
-  selected_vpc?: string;
+  // machine pools — WizSelect stores the full VPC object at runtime via keyPath
+  selected_vpc?: string | VPC;
   machine_pools_subnets?: MachinePoolSubnetEntry[];
   machine_type?: string;
   autoscaling?: boolean;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Adds comprehensive TypeScript types to the ROSA HCP wizard, replacing all `any` usage across wizard components, step props, callbacks, and internal state. This gives ACM/OCM consumers a typed contract for what data the wizard needs and what it returns on submit.
Also adds an integration guide (docs/ROSA_WIZARD_INTEGRATION.md) documenting the input/output types with usage examples so consuming teams don't have to read wizard source code to integrate.

**Jira issue #** 
https://issues.redhat.com/browse/FCN-98

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation update
- [ ] UI/UX improvement
- [X] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Run `npm run storybook` and walk through the ROSA HCP wizard (both `rosa-hcp` and `rosa-yaml-editor` variants) end to end, filling in all fields and submitting
2. Verify the wizard steps render correctly: Details, Roles and Policies, Machine Pools, Networking, Cluster-wide Proxy (when enabled), Encryption, Cluster Updates, YAML Editor (yaml variant), and Review
3. On the Review step, verify all "Edit Step" navigation links work correctly
4. Verify `npm run build` produces a clean dist output
5. Verify `npm run build-storybook` builds without errors


**Test Environment:**
- [X] Tested locally
- [X] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [X] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->

### After
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have removed any console logs and debugging code
- [X] My changes generate no new warnings or errors
- [X] I have checked for and fixed any linting errors (npm run lint)
- [X] Code formatting is correct (npm run prettier:fix)

### Documentation
- [X] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [X] I have updated TypeScript types/interfaces

### Accessibility
- [X] My changes follow accessibility best practices
- [X] Interactive elements are keyboard accessible
- [X] Proper ARIA labels and roles are used where needed
- [X] Color contrast meets WCAG standards

### Dependencies
- [X] Any dependent changes have been merged and published
- [X] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [X] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

Key changes across 19 files:
New types (`src/components/Wizards/types.ts`): `ClusterFormData`, `RosaWizardFormData`, `MachinePoolSubnetEntry`, `WizardCallbackFunctions`, `WizardNavigationContext`, `WizardType`
Typed component props (previously props: any): `MachinePoolsSubstep`, `NetworkingAndSubnetsSubStep`, `EncryptionSubstep`, `ClusterUpdatesSubstep`, `ReviewStepData`, `StepDrawer`, `AssociateAWSAccountInfo`
react-form-wizard package: `setUseWizardContext`, `subSteps`, `update()`, and `Step.steps` all typed properly. Removed `eslint-disable` comments that were masking any usage.
Refactored: Step components that were using `useInput(props)` without a path prop (a hack to access form data) now use `useItem<RosaWizardFormData>()` which is the correct API.
All consumer-facing types are exported from the library so ACM/OCM teams can import them directly. See docs/ROSA_WIZARD_INTEGRATION.md for the full integration guide.

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- src/components/Wizards/types.ts - the new ClusterFormData type; make sure it covers all fields you're aware of
- docs/ROSA_WIZARD_INTEGRATION.md - accuracy of the integration guide for ACM/OCM consumers
- The `useInput(props)` to `useItem<RosaWizardFormData>()` refactor in step components - this is the only change that touches runtime behavior (though both access the same React context)

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- Are there any cluster form fields we're missing in ClusterFormData?
- Should we export any additional types that consumers might need?


---
<!-- Thank you for contributing to nxtcm-components! -->

## Summary by Sourcery

Add strong TypeScript typing for the ROSA HCP wizard data flow, props, and callbacks, and expose these types and documentation for external consumers integrating the wizard.

Bug Fixes:
- Adjust subnet selection helper logic to operate over the typed ClusterFormData shape and handle missing VPC/subnet data more defensively.

Enhancements:
- Define structured form data, wizard metadata, and callback types for the ROSA HCP wizard and use them across wizard components instead of any.
- Tighten react-form-wizard context, step, and data update typings to use explicit context and object types, reducing unsafe casts and eslint overrides.
- Refine wizard step component props to consume typed wizard form state via useItem<RosaWizardFormData>() rather than generic useInput hacks.
- Export all consumer-facing ROSA wizard types and step configuration types from the Wizards entrypoint for reuse by ACM/OCM.
- Loosen review display components to accept multiple primitive value types while ensuring safe string rendering.

Documentation:
- Add a ROSA wizard integration guide documenting the typed input/output contracts and usage examples for ACM/OCM consumers.