### PR TITLE
FCN-139: autoscaling field min max nodes

### DIFF
--- a/packages/react-form-wizard/src/contexts/HasInputsProvider.tsx
+++ b/packages/react-form-wizard/src/contexts/HasInputsProvider.tsx
@@ -31,9 +31,11 @@ export function HasInputsProvider(props: { children: ReactNode }) {
     setHasInputsState(true);
   }, [setHasInputsState]);
 
+useLayoutEffect(() => {
   if (hasInputs && !parentHasInputs) {
     parentSetHasInputs();
   }
+}, [hasInputs, parentHasInputs, parentSetHasInputs]);
 
   const updateHasInputs = useCallback(() => {
     setHasInputsState(false);

--- a/packages/react-form-wizard/src/inputs/Input.ts
+++ b/packages/react-form-wizard/src/inputs/Input.ts
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 import get from 'get-value';
-import { ReactNode, useCallback, useContext, useState } from 'react';
+import { ReactNode, useCallback, useContext, useLayoutEffect, useState } from 'react';
 import set from 'set-value';
 import { EditMode } from '..';
 import { useData } from '../contexts/DataContext';
@@ -111,17 +111,21 @@ export function useInput(props: InputCommonProps) {
   const hasInputs = useHasInputs();
   const updateHasInputs = useUpdateHasInputs();
 
+  useLayoutEffect(() => {
   if (!hidden && !hasInputs) {
     setHasInputs();
   }
+}, [hidden, hasInputs, setHasInputs]);
 
   const { validated, error } = useInputValidation(props);
 
   const hasValidationError = useHasValidationError();
   const setHasValidationError = useSetHasValidationError();
+useLayoutEffect(() => {
   if (!hidden && error && !hasValidationError) {
     setHasValidationError();
   }
+}, [hidden, error, hasValidationError, setHasValidationError]);
 
   // if value changes we need to validate in the case of a checkbox which hides child inputs
   // if hidden changes we need to validate in the case of a inputs which hides child inputs
@@ -131,24 +135,26 @@ export function useInput(props: InputCommonProps) {
   const [previousError, setPreviousError] = useState(error);
   const validate = useValidate();
 
-  if (value !== previousValue || hidden !== previousHidden || error !== previousError) {
-    setPreviousValue(value);
-    setPreviousHidden(hidden);
-    setPreviousError(error);
-    if (hidden && !previousHidden) {
-      updateHasInputs();
-    }
-    validate();
+ useLayoutEffect(() => {
+  if (hidden && !previousHidden) {
+    updateHasInputs();
   }
+  validate();
+  setPreviousValue(value);
+  setPreviousHidden(hidden);
+  setPreviousError(error);
+}, [value, hidden, error, previousValue, previousHidden, previousError, updateHasInputs, validate]);
 
   const id = convertId(props);
 
   const hasValue = useHasValue();
   const setHasValue = useSetHasValue();
   // anything other than empty array counts as having a value
+useLayoutEffect(() => {
   if (!hasValue && value && (!Array.isArray(value) || value.length > 0)) {
     setHasValue();
   }
+}, [hasValue, value, setHasValue]);
 
   let disabled = props.disabled;
   if (editMode === EditMode.Edit) {

--- a/packages/react-form-wizard/src/inputs/WizMachinePoolSelect.tsx
+++ b/packages/react-form-wizard/src/inputs/WizMachinePoolSelect.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
 import get from 'get-value';
-import { Fragment, useCallback, useContext, useMemo, useState } from 'react';
+import { Fragment, useCallback, useContext, useLayoutEffect, useMemo, useState } from 'react';
 import { useData } from '../contexts/DataContext';
 import { ItemContext } from '../contexts/ItemContext';
 import { DisplayMode } from '../contexts/DisplayModeContext';
@@ -86,11 +86,13 @@ export function WizMachinePoolSelect(props: WizMachinePoolSelectProps) {
     [setValue, update, values]
   );
 
+useLayoutEffect(() => {
   if (values.length < minItems && values.length === 0) {
     for (let i = 0; i < minItems; i++) {
       addItem(props.newValue ?? { machine_pool_subnet: '' });
     }
   }
+}, [values.length, minItems, addItem, props.newValue]);
 
   const removeItem = useCallback(
     (index: number) => {
@@ -226,19 +228,24 @@ function MachinePoolRow(props: MachinePoolRowProps) {
 
   const [previousHasError, setPreviousHasError] = useState(hasError);
 
+useLayoutEffect(() => {
   if (hasError !== previousHasError) {
     setPreviousHasError(hasError);
     validate();
   }
+}, [hasError, previousHasError, validate]);
 
+useLayoutEffect(() => {
   if (hasError) {
     setHasValidationError();
   }
+}, [hasError, setHasValidationError]);
 
   const validated = showValidation && hasError ? 'error' : undefined;
   const errorMessage = hasError ? requiredErrorMessage : undefined;
 
   const selectOptionsTyped: OptionType<string>[] | undefined = useMemo(() => {
+    if (!subnetOptions) return [];
     return subnetOptions
       ?.filter((option) => {
         return option.value === value || !selectedSubnets?.includes(option.value);
@@ -281,7 +288,7 @@ function MachinePoolRow(props: MachinePoolRowProps) {
                   disabled={false}
                   validated={validated}
                   placeholder={selectPlaceholder}
-                  options={selectOptionsTyped ?? []}
+                  options={selectOptionsTyped}
                   setOptions={setFilteredOptions}
                   toggleRef={toggleRef}
                   value={value}

--- a/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
@@ -6,6 +6,7 @@ const mockOpenShiftVersions = [
   { label: 'OpenShift 4.12.0', value: '4.12.0' },
   { label: 'OpenShift 4.11.5', value: '4.11.5' },
   { label: 'OpenShift 4.10.8', value: '4.10.8' },
+  { label: 'OpenShift 4.21.8', value: '4.21.8' },
 ];
 
 const mockAwsInfrastructureAccounts = [

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/EncryptionSubstep/EncryptionSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/EncryptionSubstep/EncryptionSubstep.tsx
@@ -71,6 +71,7 @@ export const EncryptionSubstep = (props: any) => {
       )}
 
       <WizCheckbox
+        id="etcd-encryption"
         path="cluster.etcd_encryption"
         title={t('etcd encryption')}
         label={t('Enable additional etcd encryption')}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
@@ -16,7 +16,7 @@ type AutoscalingFieldProps = {
 };
 
 export const MAX_NODES_HCP_DEFAULT = 500;
-export const MAX_NODES_HCP_INSUFFICIEN_VERSION = 90;
+export const MAX_NODES_HCP_INSUFFICIENT_VERSION = 90;
 
 const scaleMinNodesOnMachinePoolNumber = (machinePoolsNumber: number) =>
   machinePoolsNumber > 1 ? 1 : 2;
@@ -42,7 +42,7 @@ const scaleMaxNodesBasedOnOpenshiftVersion = (openshiftVersion: number) => {
 //Minimal versions to allow more then 90 nodes - 4.15.15, 4.14.28
 export const getAutoscalingMaxNodes = (openshiftVersion?: number) => {
   if (openshiftVersion && !scaleMaxNodesBasedOnOpenshiftVersion(openshiftVersion)) {
-    return MAX_NODES_HCP_INSUFFICIEN_VERSION;
+    return MAX_NODES_HCP_INSUFFICIENT_VERSION;
   }
   return MAX_NODES_HCP_DEFAULT;
 };

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
@@ -1,4 +1,4 @@
-import { WizCheckbox, WizNumberInput } from '@patternfly-labs/react-form-wizard';
+import { useData, WizCheckbox, WizNumberInput } from '@patternfly-labs/react-form-wizard';
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { useTranslation } from '../../../../../../../context/TranslationContext';
 import {
@@ -11,16 +11,52 @@ import links from '../../../../externalLinks';
 
 type AutoscalingFieldProps = {
   autoscaling: boolean;
+  machinePoolsNumber: number;
+  openshiftVersion: number;
+};
+
+export const MAX_NODES_HCP_DEFAULT = 500;
+export const MAX_NODES_HCP_INSUFFICIEN_VERSION = 90;
+
+const scaleMinNodesOnMachinePoolNumber = (machinePoolsNumber: number) =>
+  machinePoolsNumber > 1 ? 1 : 2;
+
+const scaleMaxNodesBasedOnOpenshiftVersion = (openshiftVersion: number) => {
+  const majorMinor = parseFloat(openshiftVersion.toString());
+  const versionPatch = Number(openshiftVersion.toString().split('.')[2]);
+  if (majorMinor >= 4.16) {
+    return true;
+  }
+  if (majorMinor <= 4.13) {
+    return false;
+  }
+  if (majorMinor === 4.14) {
+    return versionPatch >= 28;
+  }
+  if (majorMinor === 4.15) {
+    return versionPatch >= 15;
+  }
+  return true;
+};
+
+//Minimal versions to allow more then 90 nodes - 4.15.15, 4.14.28
+export const getAutoscalingMaxNodes = (openshiftVersion?: number) => {
+  if (openshiftVersion && !scaleMaxNodesBasedOnOpenshiftVersion(openshiftVersion)) {
+    return MAX_NODES_HCP_INSUFFICIEN_VERSION;
+  }
+  return MAX_NODES_HCP_DEFAULT;
 };
 
 export const AutoscalingField = (props: AutoscalingFieldProps) => {
   const { t } = useTranslation();
+  const { update } = useData();
 
-  const { autoscaling } = props;
+  const { autoscaling, openshiftVersion } = props;
 
   return (
     <>
       <WizCheckbox
+        id="autoscaling-checkbox"
         title={t('Autoscaling')}
         helperText={
           <>
@@ -37,12 +73,16 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
         onValueChange={(checked, item) => {
           if (checked) {
             delete item.cluster.nodes_compute;
-            item.cluster.min_replicas = 2;
+            item.cluster.min_replicas = scaleMinNodesOnMachinePoolNumber(
+              item.cluster.machine_pools_subnets.length
+            );
             item.cluster.max_replicas = 4;
+            update();
           } else {
             delete item.cluster.min_replicas;
             delete item.cluster.max_replicas;
             item.cluster.nodes_compute = 2;
+            update();
           }
         }}
       />
@@ -80,7 +120,7 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
                 </>
               }
               min={1}
-              max={500}
+              max={getAutoscalingMaxNodes(openshiftVersion)}
               validation={validateMaxReplicas}
             />
           </FlexItem>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
@@ -51,7 +51,7 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
   const { t } = useTranslation();
   const { update } = useData();
 
-  const { autoscaling, openshiftVersion } = props;
+  const { autoscaling, openshiftVersion, machinePoolsNumber } = props;
 
   return (
     <>
@@ -73,9 +73,7 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
         onValueChange={(checked, item) => {
           if (checked) {
             delete item.cluster.nodes_compute;
-            item.cluster.min_replicas = scaleMinNodesOnMachinePoolNumber(
-              item.cluster.machine_pools_subnets.length
-            );
+            item.cluster.min_replicas = scaleMinNodesOnMachinePoolNumber(machinePoolsNumber);
             item.cluster.max_replicas = 4;
             update();
           } else {
@@ -101,8 +99,8 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
                   </ExternalLink>
                 </>
               }
-              min={1}
-              max={500}
+              min={scaleMinNodesOnMachinePoolNumber(machinePoolsNumber)}
+              max={getAutoscalingMaxNodes(openshiftVersion)}
               validation={validateMinReplicas}
             />
           </FlexItem>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
@@ -53,6 +53,8 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
 
   const { autoscaling, openshiftVersion, machinePoolsNumber } = props;
 
+  const maxNodeBasedOnOpenshiftVersion = getAutoscalingMaxNodes(openshiftVersion);
+
   return (
     <>
       <WizCheckbox
@@ -100,7 +102,7 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
                 </>
               }
               min={scaleMinNodesOnMachinePoolNumber(machinePoolsNumber)}
-              max={getAutoscalingMaxNodes(openshiftVersion)}
+              max={maxNodeBasedOnOpenshiftVersion}
               validation={validateMinReplicas}
             />
           </FlexItem>
@@ -118,8 +120,10 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
                 </>
               }
               min={1}
-              max={getAutoscalingMaxNodes(openshiftVersion)}
-              validation={validateMaxReplicas}
+              max={maxNodeBasedOnOpenshiftVersion}
+              validation={(value, item) =>
+                validateMaxReplicas(value as number, item, maxNodeBasedOnOpenshiftVersion)
+              }
             />
           </FlexItem>
         </Flex>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
@@ -103,7 +103,9 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
               }
               min={scaleMinNodesOnMachinePoolNumber(machinePoolsNumber)}
               max={maxNodeBasedOnOpenshiftVersion}
-              validation={validateMinReplicas}
+              validation={(value: number, item) =>
+                validateMinReplicas(value, item, machinePoolsNumber)
+              }
             />
           </FlexItem>
           <FlexItem>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -122,8 +122,8 @@ export const MachinePoolsSubstep = (props: any) => {
 
         <AutoscalingField
           autoscaling={cluster?.autoscaling}
-          machinePoolsNumber={cluster.machine_pools_subnets}
-          openshiftVersion={cluster.cluster_version}
+          machinePoolsNumber={cluster?.machine_pools_subnets?.length}
+          openshiftVersion={cluster?.cluster_version}
         />
       </Section>
 

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -120,7 +120,11 @@ export const MachinePoolsSubstep = (props: any) => {
           </GridItem>
         </Grid>
 
-        <AutoscalingField autoscaling={cluster?.autoscaling} />
+        <AutoscalingField
+          autoscaling={cluster?.autoscaling}
+          machinePoolsNumber={cluster.machine_pools_subnets}
+          openshiftVersion={cluster.cluster_version}
+        />
       </Section>
 
       <ExpandableSection toggleText="Advanced machine pool configuration (optional)">

--- a/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
@@ -337,7 +337,7 @@ export const ReviewStepData = (props: any) => {
               />
             </Stack>
             <span style={{ display: 'none' }}>
-              <WizCheckbox path={''} />
+              <WizCheckbox path={''} id="non-displayed-checkbox" />
             </span>
           </ExpandableSection>
         </SplitItem>

--- a/src/components/Wizards/RosaWizard/common/PopoverHitWithTitle.tsx
+++ b/src/components/Wizards/RosaWizard/common/PopoverHitWithTitle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, Content, ContentVariants, Popover, PopoverProps } from '@patternfly/react-core';
+import { Button, Popover, PopoverProps } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 
@@ -23,7 +23,7 @@ const PopoverHintWithTitle = ({
   ...popoverProps
 }: PopoverHintProps) => (
   <div className="popover-with-title-div">
-    <Content component={ContentVariants.p}>
+    <span>
       <Popover
         bodyContent={bodyContent}
         footerContent={footer}
@@ -57,7 +57,7 @@ const PopoverHintWithTitle = ({
           hasNoPadding
         />
       </Popover>
-    </Content>
+    </span>
   </div>
 );
 

--- a/src/components/Wizards/RosaWizard/validators.ts
+++ b/src/components/Wizards/RosaWizard/validators.ts
@@ -506,13 +506,18 @@ export const validateMinReplicas = (
 
 export const validateMaxReplicas = (
   value: number | undefined,
-  item?: unknown
+  item?: unknown,
+  maxNodeBasedOnOpenshiftVersion?: number
 ): string | undefined => {
   const positiveError = validatePositiveInteger(value);
   if (positiveError) return positiveError;
   const typedItem = item as { cluster?: { min_replicas?: number } } | undefined;
-  if (value !== undefined && value > 500) {
-    return 'Input cannot be more than 500.';
+  if (
+    value !== undefined &&
+    maxNodeBasedOnOpenshiftVersion !== undefined &&
+    value > maxNodeBasedOnOpenshiftVersion
+  ) {
+    return `Input cannot be more than ${maxNodeBasedOnOpenshiftVersion}.`;
   }
   if (value !== undefined && typedItem?.cluster?.min_replicas !== undefined) {
     if (value < typedItem?.cluster?.min_replicas) {

--- a/src/components/Wizards/RosaWizard/validators.ts
+++ b/src/components/Wizards/RosaWizard/validators.ts
@@ -488,7 +488,8 @@ export const validatePositiveInteger = (value: number | undefined): string | und
 
 export const validateMinReplicas = (
   value: number | undefined,
-  item?: unknown
+  item?: unknown,
+  machinePoolsNumber?: number
 ): string | undefined => {
   const positiveError = validatePositiveInteger(value);
   if (positiveError) return positiveError;
@@ -500,6 +501,9 @@ export const validateMinReplicas = (
     if (value > typedItem?.cluster?.max_replicas) {
       return 'Min nodes cannot be greater than max nodes.';
     }
+  }
+  if (machinePoolsNumber && machinePoolsNumber < 2 && value !== undefined && value < 2) {
+    return 'Input cannot be less than 2 nodes.';
   }
   return undefined;
 };


### PR DESCRIPTION
## Description
The min max nodes for the autoscaling field are setup as follows.
1. If machine pool is selected (singe machine pool) the min nodes amount is 2
2. Based on the openshift version max nodes are either 90 or 500
3. I tried to check two machine pools and set it up to be 1 min instead of 2. (in theory it works now)


**Jira issue #** 

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1.  Storybook in details screen select openshift version
2. Navigate to Machine pools screen.
3.  Select a VPC and a machine pool for it
4. Click on autoscaling checkbox and confirm that the min node is setup to 2

**Test Environment:**
- [ ] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->

### After
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

## Summary by Sourcery

Adjust ROSA wizard autoscaling behavior and related form infrastructure to support dynamic min/max node limits and more robust validation handling.

New Features:
- Configure autoscaling min nodes based on the number of selected machine pools and max nodes based on the chosen OpenShift version.
- Expose additional OpenShift version option in the ROSA wizard story configuration.

Bug Fixes:
- Prevent autoscaling replica values from exceeding a version-dependent maximum and align validation messaging accordingly.
- Ensure form input and machine pool selection side effects (hasInputs, validation, default items, value tracking) run reliably using layout effects and correct option handling.
- Avoid invalid or empty option lists in machine pool subnet selection and adjust popover hint markup for safer embedding.
- Assign explicit IDs to hidden and etcd-encryption checkboxes to improve testability and DOM targeting.

Enhancements:
- Wire machine pool count and OpenShift version into the autoscaling field so review and setup steps reflect the correct constraints.
- Trigger wizard data updates when toggling autoscaling to keep review data in sync with cluster configuration.