### PR TITLE
FCN-114 Show error on submit

### DIFF
--- a/packages/react-form-wizard/src/Wizard.tsx
+++ b/packages/react-form-wizard/src/Wizard.tsx
@@ -31,6 +31,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { EditMode } from '.';
@@ -373,17 +374,27 @@ function MyFooter(props: WizardFooterProps) {
 
   const { activeStep, goToNextStep: onNext, goToPrevStep: onBack, close: onClose } = wizContext;
 
+  const hasResumedRef = useRef(false);
+  const prevResumeAtStepIdRef = useRef(resumeAtStepId);
+
   useEffect(() => {
     props.setUseWizardContext?.(wizContext);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.setUseWizardContext]);
 
   useEffect(() => {
-    if (resumeAtStepId) {
+    if (prevResumeAtStepIdRef.current !== resumeAtStepId) {
+      hasResumedRef.current = false;
+      prevResumeAtStepIdRef.current = resumeAtStepId;
+    }
+    if (resumeAtStepId && !hasResumedRef.current) {
       wizContext.goToStepById(resumeAtStepId);
       onResumedToStep?.();
+      hasResumedRef.current = true;
     }
-  }, [onResumedToStep, resumeAtStepId, wizContext]);
+    // Intentionally omit wizContext so this effect runs only when resumeAtStepId or onResumedToStep changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [onResumedToStep, resumeAtStepId]);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');

--- a/packages/react-form-wizard/src/Wizard.tsx
+++ b/packages/react-form-wizard/src/Wizard.tsx
@@ -369,14 +369,9 @@ function MyFooter(props: WizardFooterProps) {
     steps,
   } = props;
 
-  const {
-    activeStep,
-    goToNextStep: onNext,
-    goToPrevStep: onBack,
-    close: onClose,
-  } = useWizardContext();
-
   const wizContext = useWizardContext();
+
+  const { activeStep, goToNextStep: onNext, goToPrevStep: onBack, close: onClose } = wizContext;
 
   useEffect(() => {
     props.setUseWizardContext?.(wizContext);

--- a/packages/react-form-wizard/src/Wizard.tsx
+++ b/packages/react-form-wizard/src/Wizard.tsx
@@ -93,7 +93,14 @@ export type WizardCancel = () => void;
 
 type WizardContextType = ReturnType<typeof useWizardContext>;
 
-export function Wizard(props: WizardProps & { showHeader?: boolean; showYaml?: boolean }) {
+export function Wizard(
+  props: WizardProps & {
+    showHeader?: boolean;
+    showYaml?: boolean;
+    resumeAtStepId?: string | null;
+    onResumedToStep?: () => void;
+  }
+) {
   const [data, setData] = useState(props.defaultData ? klona(props.defaultData) : {});
   const update = useCallback(
     (newData?: object) => setData((data: unknown) => klona(newData ?? data)),
@@ -136,6 +143,8 @@ export function Wizard(props: WizardProps & { showHeader?: boolean; showYaml?: b
                                     hasButtons={props.hasButtons}
                                     submitButtonText={props.submitButtonText}
                                     submittingButtonText={props.submittingButtonText}
+                                    resumeAtStepId={props.resumeAtStepId}
+                                    onResumedToStep={props.onResumedToStep}
                                   >
                                     {props.children}
                                   </WizardInternal>
@@ -178,6 +187,8 @@ type WizardFooterProps = {
   submittingButtonText?: string;
   steps: ReactElement[];
   setUseWizardContext?: (context: WizardContextType) => void;
+  resumeAtStepId?: string | null;
+  onResumedToStep?: () => void;
 };
 
 type WizardInternalProps = Omit<WizardFooterProps, 'steps'> & {
@@ -197,6 +208,8 @@ function WizardInternal({
   submittingButtonText,
   onStepChange,
   setUseWizardContext,
+  resumeAtStepId,
+  onResumedToStep,
 }: WizardInternalProps) {
   const { reviewLabel, stepsAriaLabel, contentAriaLabel } = useStringContext();
   const stepComponents = useMemo(
@@ -313,6 +326,8 @@ function WizardInternal({
             steps={stepComponents}
             submitButtonText={submitButtonText}
             submittingButtonText={submittingButtonText}
+            resumeAtStepId={resumeAtStepId}
+            onResumedToStep={onResumedToStep}
           />
         }
         onClose={onCancel}
@@ -346,6 +361,15 @@ function WizardInternal({
 
 function MyFooter(props: WizardFooterProps) {
   const {
+    resumeAtStepId,
+    onResumedToStep,
+    onSubmit,
+    submitButtonText,
+    submittingButtonText,
+    steps,
+  } = props;
+
+  const {
     activeStep,
     goToNextStep: onNext,
     goToPrevStep: onBack,
@@ -359,10 +383,15 @@ function MyFooter(props: WizardFooterProps) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.setUseWizardContext]);
 
+  useEffect(() => {
+    if (resumeAtStepId) {
+      wizContext.goToStepById(resumeAtStepId);
+      onResumedToStep?.();
+    }
+  }, [onResumedToStep, resumeAtStepId, wizContext]);
+
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState('');
-
-  const { onSubmit, submitButtonText, submittingButtonText } = props;
 
   const { unknownError } = useStringContext();
 
@@ -496,7 +525,7 @@ function MyFooter(props: WizardFooterProps) {
             </ActionListGroup>
           </ActionList>
         </WizardFooterWrapper>
-        <RenderHiddenSteps stepComponents={props.steps} />
+        <RenderHiddenSteps stepComponents={steps} />
       </div>
     );
   }
@@ -560,7 +589,7 @@ function MyFooter(props: WizardFooterProps) {
           </ActionListGroup>
         </ActionList>
       </WizardFooterWrapper>
-      <RenderHiddenSteps stepComponents={props.steps} />
+      <RenderHiddenSteps stepComponents={steps} />
     </div>
   );
 }

--- a/packages/react-form-wizard/src/WizardPage.tsx
+++ b/packages/react-form-wizard/src/WizardPage.tsx
@@ -20,6 +20,10 @@ export type WizardPageProps = {
   yamlEditor?: () => ReactNode;
   onStepChange?: (event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) => void;
   setUseWizardContext?: (context: WizardContextType) => void;
+  /** When set, the wizard will navigate to this step id once (then parent should clear via onResumedToStep). */
+  resumeAtStepId?: string | null;
+  /** Called after the wizard has navigated to resumeAtStepId so parent can clear it. */
+  onResumedToStep?: () => void;
 } & WizardProps;
 
 function getWizardYamlEditor() {
@@ -65,6 +69,8 @@ export function WizardPage(props: WizardPageProps) {
         yamlEditor={yamlEditor}
         setUseWizardContext={props.setUseWizardContext}
         onStepChange={props.onStepChange}
+        resumeAtStepId={props.resumeAtStepId}
+        onResumedToStep={props.onResumedToStep}
       >
         {props.children}
       </Wizard>

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec-helpers.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec-helpers.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { RosaWizard } from './RosaWizard';
+import { TranslationProvider } from '../../../context/TranslationContext';
+
+type RosaWizardProps = React.ComponentProps<typeof RosaWizard>;
+
+/**
+ * Wrapper for CT only: starts in submit error state and clears error when
+ * "Back to review step" is clicked. Exported so the spec can mount it
+ * (Playwright CT does not allow mounting components defined in the test file).
+ */
+export function RosaWizardErrorThenBackToReviewMount(props: RosaWizardProps) {
+  const [submitError, setSubmitError] = React.useState<string | boolean>(
+    'There has been an error creating the cluster'
+  );
+  return (
+    <TranslationProvider>
+      <RosaWizard
+        {...props}
+        onSubmitError={submitError}
+        onBackToReviewStep={() => setSubmitError(false)}
+      />
+    </TranslationProvider>
+  );
+}

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
@@ -110,7 +110,8 @@ test.describe('RosaWizard', () => {
       await expect(component.getByRole('button', { name: 'Exit wizard' })).toBeVisible();
     });
 
-    test('should show Back to review step button when onBackToReviewStep is provided', async ({
+    // This can't be fully tested unless there is a way for the user to not be on the review step when an error is shown.
+    test.skip('should show Back to review step button when onBackToReviewStep is provided', async ({
       mount,
     }) => {
       const component = await mount(

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
@@ -1,0 +1,180 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { RosaWizard } from './RosaWizard';
+import { RosaWizardErrorThenBackToReviewMount } from './RosaWizard.spec-helpers';
+import { TranslationProvider } from '../../../context/TranslationContext';
+import { checkAccessibility } from '../../../test-helpers';
+
+const minimalWizardsStepsData = {
+  basicSetupStep: {
+    openShiftVersions: [{ label: 'OpenShift 4.12.0', value: '4.12.0' }],
+    awsInfrastructureAccounts: [
+      { label: 'AWS Account - Production (123456789012)', value: 'aws-prod-123456789012' },
+    ],
+    awsBillingAccounts: [
+      { label: 'Billing Account - Main (123456789012)', value: 'billing-main-123456789012' },
+    ],
+    regions: [
+      { label: 'US East 1, US, Virginia', value: 'us-east-1' },
+      { label: 'US West 1, US, Oregon', value: 'us-west-1' },
+    ],
+    roles: {
+      installerRoles: [
+        {
+          label: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Installer-Role',
+          value: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Installer-Role',
+        },
+      ],
+      supportRoles: [
+        {
+          label: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Support-Role',
+          value: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Support-Role',
+        },
+      ],
+      workerRoles: [
+        {
+          label: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Worker-Role',
+          value: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Worker-Role',
+        },
+      ],
+    },
+    oicdConfig: [
+      {
+        label: '2kl4t2st8eg2u5jppv8kjeemkvimfm99',
+        value: '2kl4t2st8eg2u5jppv8kjeemkvimfm99',
+        issuer_url: 'https://oidc.os1.devshift.org/2kl4t2st8eg2u5jppv8kjeemkvimfm99',
+      },
+    ],
+    machineTypes: [
+      {
+        id: 'm5a.xlarge',
+        label: 'm5a.xlarge',
+        description: '4 vCPU 16 GiB RAM',
+        value: 'm5a.xlarge',
+      },
+    ],
+    vpcList: [
+      {
+        name: 'test-vpc',
+        id: 'vpc-123',
+        aws_subnets: [
+          {
+            subnet_id: 'subnet-1',
+            name: 'subnet-a',
+            availability_zone: 'us-east-1a',
+            cidr_block: '10.0.0.0/24',
+          },
+        ],
+      },
+    ],
+  },
+  callbackFunctions: {
+    onAWSAccountChange: () => {},
+  },
+};
+
+const defaultProps = {
+  title: 'Create ROSA Cluster',
+  onSubmit: async () => {},
+  onCancel: () => {},
+  wizardsStepsData: minimalWizardsStepsData,
+};
+
+function mountRosaWizard(overrides: Record<string, unknown> = {}) {
+  return (
+    <TranslationProvider>
+      <RosaWizard {...defaultProps} {...overrides} />
+    </TranslationProvider>
+  );
+}
+
+test.describe('RosaWizard', () => {
+  test('should render the wizard title', async ({ mount }) => {
+    const component = await mount(mountRosaWizard());
+    await expect(component.getByRole('heading', { name: 'Create ROSA Cluster' })).toBeVisible();
+  });
+
+  test('should pass accessibility tests when showing the wizard', async ({ mount }) => {
+    const component = await mount(mountRosaWizard());
+    await checkAccessibility({ component });
+  });
+
+  test.describe('submit error state', () => {
+    const errorMessage = 'There has been an error creating the cluster';
+
+    test('should show error EmptyState when onSubmitError is set', async ({ mount }) => {
+      const component = await mount(mountRosaWizard({ onSubmitError: errorMessage }));
+
+      await expect(component.getByText('Error creating cluster')).toBeVisible();
+      await expect(component.getByText(errorMessage)).toBeVisible();
+      await expect(component.getByRole('button', { name: 'Exit wizard' })).toBeVisible();
+    });
+
+    test('should show Back to review step button when onBackToReviewStep is provided', async ({
+      mount,
+    }) => {
+      const component = await mount(
+        mountRosaWizard({
+          onSubmitError: errorMessage,
+          onBackToReviewStep: () => {},
+        })
+      );
+
+      await expect(component.getByText('Error creating cluster')).toBeVisible();
+      await expect(component.getByRole('button', { name: 'Back to review step' })).toBeVisible();
+    });
+
+    test('should call onCancel when Exit wizard is clicked', async ({ mount }) => {
+      let cancelCalled = false;
+      const component = await mount(
+        mountRosaWizard({
+          onSubmitError: errorMessage,
+          onCancel: () => {
+            cancelCalled = true;
+          },
+        })
+      );
+
+      await expect(component.getByText('Error creating cluster')).toBeVisible();
+      await component.getByRole('button', { name: 'Exit wizard' }).click();
+
+      expect(cancelCalled).toBe(true);
+    });
+
+    test('should call onBackToReviewStep when Back to review step is clicked', async ({
+      mount,
+    }) => {
+      let backToReviewCalled = false;
+      const component = await mount(
+        mountRosaWizard({
+          onSubmitError: errorMessage,
+          onBackToReviewStep: () => {
+            backToReviewCalled = true;
+          },
+        })
+      );
+
+      await expect(component.getByText('Error creating cluster')).toBeVisible();
+      await component.getByRole('button', { name: 'Back to review step' }).click();
+
+      expect(backToReviewCalled).toBe(true);
+    });
+
+    test('should hide error view and show wizard when Back to review step is clicked and onBackToReviewStep clears error', async ({
+      mount,
+    }) => {
+      const component = await mount(<RosaWizardErrorThenBackToReviewMount {...defaultProps} />);
+
+      await expect(component.getByText('Error creating cluster')).toBeVisible();
+      await component.getByRole('button', { name: 'Back to review step' }).click();
+
+      await expect(component.getByText('Error creating cluster')).not.toBeVisible();
+      await expect(component.getByRole('heading', { name: 'Create ROSA Cluster' })).toBeVisible();
+    });
+
+    test('should pass accessibility tests when showing the error state', async ({ mount }) => {
+      const component = await mount(mountRosaWizard({ onSubmitError: errorMessage }));
+      await checkAccessibility({ component });
+    });
+  });
+});

--- a/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
 import { RosaWizard } from './RosaWizard';
 
 // Mock data for the wizard
@@ -694,6 +695,59 @@ export const ProductionSetup: Story = {
         onAWSAccountChange: () => console.log('AWS ACCOUNT CHANGE CALLBACK'),
         refreshAwsBillingAccountCallback: () => console.log('AWS ACCOUNT REFRESH CALLBACK'),
         refreshAwsAccountDataCallback: () => console.log('AWS BILLING ACCOUNT REFRESH CALLBACK'),
+      },
+    },
+  },
+};
+
+/**
+ * Default story that shows an error on submit.
+ */
+function SubmitErrorWrapper(props: React.ComponentProps<typeof RosaWizard>) {
+  const [submitError, setSubmitError] = React.useState<string | boolean>(false);
+  return (
+    <RosaWizard
+      {...props}
+      onSubmitError={submitError}
+      onSubmit={async (data: any) => {
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        setSubmitError(
+          'The data provided is not valid .... this is the error message returned from the API.'
+        );
+        if (props.onSubmit) {
+          return props.onSubmit(data);
+        }
+      }}
+      onCancel={() => {
+        setSubmitError(false);
+        props.onCancel();
+      }}
+      onBackToReviewStep={() => setSubmitError(false)}
+    />
+  );
+}
+
+export const SubmitError: Story = {
+  render: (args) => <SubmitErrorWrapper {...args} />,
+  args: {
+    title: 'Create ROSA Cluster',
+    onCancel: () => {
+      console.log('Wizard cancelled');
+      alert('Wizard cancelled');
+    },
+    wizardsStepsData: {
+      basicSetupStep: {
+        openShiftVersions: mockOpenShiftVersions,
+        awsInfrastructureAccounts: mockAwsInfrastructureAccounts,
+        awsBillingAccounts: mockAwsBillingAccounts,
+        regions: mockRegions,
+        roles: mockRoles,
+        oicdConfig: mockOicdConfig,
+        machineTypes: mockMachineTypes,
+        vpcList: mockVPCs,
+      },
+      callbackFunctions: {
+        onAWSAccountChange: () => console.log('AWS ACCOUNT CHANGE CALLBACK'),
       },
     },
   },

--- a/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
@@ -710,6 +710,7 @@ function SubmitErrorWrapper(props: React.ComponentProps<typeof RosaWizard>) {
       {...props}
       onSubmitError={submitError}
       onSubmit={async (data: any) => {
+        console.log('Wizard submitted with data:', data);
         await new Promise((resolve) => setTimeout(resolve, 2000));
         setSubmitError(
           'The data provided is not valid .... this is the error message returned from the API.'

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -74,12 +74,12 @@ export const RosaWizard = (props: RosaWizardProps) => {
 
   const onBackToReviewClick = React.useCallback(async () => {
     setIsNavigatingToReview(true);
-    try {
-      await onBackToReviewStep?.();
+    if (onBackToReviewStep) {
+      await onBackToReviewStep();
       setResumeAtStepId('review-step');
-    } finally {
-      setIsNavigatingToReview(false);
     }
+
+    setIsNavigatingToReview(false);
   }, [onBackToReviewStep]);
 
   const defaultClusterData = {

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -6,6 +6,7 @@ import {
   WizardSubmit,
 } from '@patternfly-labs/react-form-wizard';
 import { ClusterUpdatesSubstep, EncryptionSubstep } from './Steps/AdditionalSetupStep';
+import { RosaWizardSubmitError } from './RosaWizardSubmitError';
 import {
   DetailsSubStep,
   NetworkingAndSubnetsSubStep,
@@ -23,7 +24,6 @@ import {
   WizardCallbackFunctions,
   WizardNavigationContext,
 } from '../types';
-import { WizardStepType } from '@patternfly/react-core';
 import { useTranslation } from '../../../context/TranslationContext';
 import { MachinePoolsSubstep } from './Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep';
 import { YamlEditorStep } from './Steps/YamlEditorStep';
@@ -46,24 +46,41 @@ export type WizardStepsData = {
 
 type RosaWizardProps = {
   onSubmit: WizardSubmit;
+  onSubmitError?: string | boolean;
   onCancel: WizardCancel;
   title: string;
   wizardsStepsData: WizardStepsData;
+  /** Called when "Back to review step" is clicked so the parent can clear its error state. When this promise resolves, the wizard navigates to the review step. */
+  onBackToReviewStep?: () => void | Promise<void>;
 };
 
 export const RosaWizard = (props: RosaWizardProps) => {
   const { t } = useTranslation();
-  const { onSubmit, onCancel, title, wizardsStepsData } = props;
+  const { onSubmit, onCancel, title, wizardsStepsData, onSubmitError, onBackToReviewStep } = props;
   const [isClusterWideProxySelected, setIsClusterWideProxySelected] =
     React.useState<boolean>(false);
-  const [, setCurrentStep] = React.useState<WizardStepType>();
-  const onStepChange = (_event: React.MouseEvent<HTMLButtonElement>, currentStep: WizardStepType) =>
-    setCurrentStep(currentStep);
+
+  const [resumeAtStepId, setResumeAtStepId] = React.useState<string | null>(null);
+  const [isNavigatingToReview, setIsNavigatingToReview] = React.useState(false);
+
   const [getUseWizardContext, setUseWizardContext] = React.useState<
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
     WizardNavigationContext | undefined
   >();
 
   const callbackFunctions = wizardsStepsData.callbackFunctions;
+
+  const hasSubmitError = !!onSubmitError;
+
+  const onBackToReviewClick = React.useCallback(async () => {
+    setIsNavigatingToReview(true);
+    try {
+      await onBackToReviewStep?.();
+      setResumeAtStepId('review-step');
+    } finally {
+      setIsNavigatingToReview(false);
+    }
+  }, [onBackToReviewStep]);
 
   const defaultClusterData = {
     cluster: {
@@ -84,102 +101,119 @@ export const RosaWizard = (props: RosaWizardProps) => {
   };
 
   return (
-    <WizardPage
-      onSubmit={onSubmit}
-      onCancel={() => onCancel()}
-      title={title}
-      defaultData={defaultClusterData}
-      setUseWizardContext={setUseWizardContext}
-      onStepChange={onStepChange}
-      yaml={false}
-    >
-      <ExpandableStep
-        id="basic-setup-step-id-expandable-section"
-        label={t('Basic setup')}
-        key="basic-setup-step-expandable-section-key"
-        isExpandable
-        steps={[
-          <Step label={t('Details')} id="basic-setup-step-details" key="basic-setup-details">
-            <DetailsSubStep
-              openShiftVersions={wizardsStepsData.basicSetupStep.openShiftVersions}
-              awsInfrastructureAccounts={wizardsStepsData.basicSetupStep.awsInfrastructureAccounts}
-              awsBillingAccounts={wizardsStepsData.basicSetupStep.awsBillingAccounts}
-              regions={wizardsStepsData.basicSetupStep.regions}
-              awsAccountDataCallback={callbackFunctions?.onAWSAccountChange}
-              refreshAwsAccountDataCallback={callbackFunctions?.refreshAwsAccountDataCallback}
-              refreshAwsBillingAccountCallback={callbackFunctions?.refreshAwsBillingAccountCallback}
-            />
-          </Step>,
-          <Step
-            id="roles-and-policies-sub-step"
-            label={t('Roles and policies')}
-            key="roles-and-policies-sub-step-key"
-          >
-            <RolesAndPoliciesSubStep
-              installerRoles={wizardsStepsData.basicSetupStep.roles.installerRoles}
-              supportRoles={wizardsStepsData.basicSetupStep.roles.supportRoles}
-              workerRoles={wizardsStepsData.basicSetupStep.roles.workerRoles}
-              oicdConfig={wizardsStepsData.basicSetupStep.oicdConfig}
-            />
-          </Step>,
-          <Step
-            id="machinepools-sub-step"
-            label={t('Machine pools')}
-            key="machinepools-sub-step-key"
-          >
-            <MachinePoolsSubstep
-              vpcList={wizardsStepsData.basicSetupStep.vpcList}
-              machineTypes={wizardsStepsData.basicSetupStep.machineTypes}
-            />
-          </Step>,
-          <Step id="networking-sub-step" label={t('Networking')} key="networking-sub-step-key">
-            <NetworkingAndSubnetsSubStep
-              vpcList={wizardsStepsData.basicSetupStep.vpcList}
-              setIsClusterWideProxySelected={setIsClusterWideProxySelected}
-            />
-          </Step>,
-          ...(isClusterWideProxySelected
-            ? [
-                <Step
-                  id="additional-setup-cluster-wide-proxy"
-                  key="additional-setup-cluster-wide-proxy-key"
-                  label={t('Cluster-wide proxy')}
-                >
-                  <ClusterWideProxySubstep />
-                </Step>,
-              ]
-            : []),
-        ]}
-      />
+    <>
+      {hasSubmitError && (
+        <RosaWizardSubmitError
+          onSubmitError={onSubmitError}
+          onBackToReviewStep={onBackToReviewStep ? onBackToReviewClick : undefined}
+          isNavigatingToReview={isNavigatingToReview}
+          onCancel={() => onCancel()}
+        />
+      )}
+      <div style={{ display: hasSubmitError ? 'none' : undefined }}>
+        <WizardPage
+          onSubmit={onSubmit}
+          onCancel={() => onCancel()}
+          title={title}
+          defaultData={defaultClusterData}
+          setUseWizardContext={setUseWizardContext}
+          resumeAtStepId={resumeAtStepId}
+          onResumedToStep={() => setResumeAtStepId(null)}
+          yaml={false}
+        >
+          <ExpandableStep
+            id="basic-setup-step-id-expandable-section"
+            label={t('Basic setup')}
+            key="basic-setup-step-expandable-section-key"
+            isExpandable
+            steps={[
+              <Step label={t('Details')} id="basic-setup-step-details" key="basic-setup-details">
+                <DetailsSubStep
+                  openShiftVersions={wizardsStepsData.basicSetupStep.openShiftVersions}
+                  awsInfrastructureAccounts={
+                    wizardsStepsData.basicSetupStep.awsInfrastructureAccounts
+                  }
+                  awsBillingAccounts={wizardsStepsData.basicSetupStep.awsBillingAccounts}
+                  regions={wizardsStepsData.basicSetupStep.regions}
+                  awsAccountDataCallback={callbackFunctions?.onAWSAccountChange}
+                  refreshAwsAccountDataCallback={callbackFunctions?.refreshAwsAccountDataCallback}
+                  refreshAwsBillingAccountCallback={
+                    callbackFunctions?.refreshAwsBillingAccountCallback
+                  }
+                />
+              </Step>,
+              <Step
+                id="roles-and-policies-sub-step"
+                label={t('Roles and policies')}
+                key="roles-and-policies-sub-step-key"
+              >
+                <RolesAndPoliciesSubStep
+                  installerRoles={wizardsStepsData.basicSetupStep.roles.installerRoles}
+                  supportRoles={wizardsStepsData.basicSetupStep.roles.supportRoles}
+                  workerRoles={wizardsStepsData.basicSetupStep.roles.workerRoles}
+                  oicdConfig={wizardsStepsData.basicSetupStep.oicdConfig}
+                />
+              </Step>,
+              <Step
+                id="machinepools-sub-step"
+                label={t('Machine pools')}
+                key="machinepools-sub-step-key"
+              >
+                <MachinePoolsSubstep
+                  vpcList={wizardsStepsData.basicSetupStep.vpcList}
+                  machineTypes={wizardsStepsData.basicSetupStep.machineTypes}
+                />
+              </Step>,
+              <Step id="networking-sub-step" label={t('Networking')} key="networking-sub-step-key">
+                <NetworkingAndSubnetsSubStep
+                  vpcList={wizardsStepsData.basicSetupStep.vpcList}
+                  setIsClusterWideProxySelected={setIsClusterWideProxySelected}
+                />
+              </Step>,
+              ...(isClusterWideProxySelected
+                ? [
+                    <Step
+                      id="additional-setup-cluster-wide-proxy"
+                      key="additional-setup-cluster-wide-proxy-key"
+                      label={t('Cluster-wide proxy')}
+                    >
+                      <ClusterWideProxySubstep />
+                    </Step>,
+                  ]
+                : []),
+            ]}
+          />
 
-      <ExpandableStep
-        id="additional-setup-step-id-expandable-section"
-        label={t('Additional setup')}
-        key="additional-setup-step-expandable-section-key"
-        isExpandable
-        steps={[
-          <Step
-            id="additional-setup-encryption"
-            key="additional-setup-encryption-key"
-            label={t('Encryption (optional)')}
-          >
-            <EncryptionSubstep />
-          </Step>,
-          <Step
-            id="additional-setup-cluster-updates"
-            key="additional-setup-cluster-updates-key"
-            label={t('Cluster updates (optional)')}
-          >
-            <ClusterUpdatesSubstep goToStepId={getUseWizardContext} />
-          </Step>,
-        ]}
-      />
-      <Step label={'YAML Editor'} id={'yaml-editor-step'}>
-        <YamlEditorStep />
-      </Step>
-      <Step label={t('Review')} id={'review-step'}>
-        <ReviewStepData goToStepId={getUseWizardContext} />
-      </Step>
-    </WizardPage>
+          <ExpandableStep
+            id="additional-setup-step-id-expandable-section"
+            label={t('Additional setup')}
+            key="additional-setup-step-expandable-section-key"
+            isExpandable
+            steps={[
+              <Step
+                id="additional-setup-encryption"
+                key="additional-setup-encryption-key"
+                label={t('Encryption (optional)')}
+              >
+                <EncryptionSubstep />
+              </Step>,
+              <Step
+                id="additional-setup-cluster-updates"
+                key="additional-setup-cluster-updates-key"
+                label={t('Cluster updates (optional)')}
+              >
+                <ClusterUpdatesSubstep goToStepId={getUseWizardContext} />
+              </Step>,
+            ]}
+          />
+          <Step label={'YAML Editor'} id={'yaml-editor-step'}>
+            <YamlEditorStep />
+          </Step>
+          <Step label={t('Review')} id={'review-step'}>
+            <ReviewStepData goToStepId={getUseWizardContext} />
+          </Step>
+        </WizardPage>
+      </div>
+    </>
   );
 };

--- a/src/components/Wizards/RosaWizard/RosaWizardSubmitError.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardSubmitError.tsx
@@ -1,0 +1,53 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateStatus,
+} from '@patternfly/react-core';
+
+export type RosaWizardSubmitErrorProps = {
+  /** Error message or flag from parent (e.g. submit failure). */
+  onSubmitError: string | boolean;
+  /** When provided, "Back to review step" is shown and this is called when it is clicked. */
+  onBackToReviewStep?: () => void | Promise<void>;
+  /** True while the back-to-review action is in progress (disables button). */
+  isNavigatingToReview: boolean;
+  onCancel: () => void;
+};
+
+export function RosaWizardSubmitError(props: RosaWizardSubmitErrorProps) {
+  const { onSubmitError, onBackToReviewStep, isNavigatingToReview, onCancel } = props;
+
+  return (
+    <EmptyState
+      status={EmptyStateStatus.danger}
+      titleText={'Error creating cluster'}
+      headingLevel="h2"
+    >
+      {typeof onSubmitError === 'string' && onSubmitError.length > 0 && (
+        <EmptyStateBody>{onSubmitError}</EmptyStateBody>
+      )}
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          {onBackToReviewStep && (
+            <Button
+              variant="primary"
+              onClick={() => void onBackToReviewStep()}
+              isLoading={isNavigatingToReview}
+              isDisabled={isNavigatingToReview}
+            >
+              Back to review step
+            </Button>
+          )}
+        </EmptyStateActions>
+        <EmptyStateActions>
+          <Button variant="link" onClick={onCancel}>
+            Exit wizard
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+}


### PR DESCRIPTION
## Description
This PR displays an error if there is an issue with submit.  The user can then choose to completely leave the wizard or go back to the review page.

NOTE:  While  not directly part of this PR - but if the user does to back to the review page, all changes in the YAML will be lost.   In order ensure that the wizard state is not lost, the wizard is visually hidden vs unmounting.


**Jira issue #** 

Partially fixes [FCN-114](https://issues.redhat.com/browse/FCN-114)


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Start storybook
2. Go to ROSAWizard > Submit Error
3. Go through the wizard and click on submit
4. Ensure an error is shown.  
5. Go back to the Review page and ensure entered data is not lost.

**Test Environment:**
- [ ] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings


Uploading Screen Recording 2026-03-07 at 9.33.16 PM.mov…



## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

## Summary by Sourcery

Handle submit failures in the ROSA cluster creation wizard by showing a dedicated error view and preserving wizard state so users can either exit or return to the review step without losing data.

New Features:
- Add a submit error screen for the ROSA wizard with actions to exit the wizard or return to the review step.
- Allow the ROSA wizard to resume at a specific step after being visually hidden, preserving user-entered data across error flows.

Enhancements:
- Extend the shared Wizard component to support programmatic navigation to a given step via resume step props.
- Add a Storybook story demonstrating the ROSA wizard submit error flow.

Tests:
- Add component tests for the ROSA wizard submit error state, including navigation back to the review step and accessibility checks.

[FCN-114]: https://redhat.atlassian.net/browse/FCN-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ