### PR TITLE
FCN-153 Stabilize rosa wizard integration docs (storybook + compile-checked example)

### DIFF
--- a/docs/ROSA_WIZARD_INTEGRATION.md
+++ b/docs/ROSA_WIZARD_INTEGRATION.md
@@ -1,295 +1,73 @@
-# ROSA HCP Wizard — Integration Guide for ACM/OCM Consumers
+# ROSA HCP Wizard Integration Quick-Start
 
-This guide covers the typed interfaces that ACM and OCM applications use when integrating the ROSA HCP cluster creation wizard from `nxtcm-components`.
+Use this page as a quick integration checklist. Detailed typed contract examples live in Storybook and compile-checked example files so they stay aligned with code.
 
-## Overview
+## Use These as Source of Truth
 
-The wizard accepts structured data describing AWS accounts, OpenShift versions, VPCs, roles, and other configuration options. On submit, it returns the full cluster configuration the user built. Both the input and output shapes are fully typed so consumers get compile-time validation and autocomplete.
+- Typed Storybook contract example:
+  - `src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx`
+- Compile-only typed integration example:
+  - `src/examples/rosaWizardIntegration.example.tsx`
+- Exported types and public API surface:
+  - `src/components/Wizards/index.ts`
+  - `src/components/Wizards/types.ts`
 
-All types referenced below are exported from the library:
+## Minimal Integration Shape
 
-```ts
-import type {
-  WizardStepsData,
-  BasicSetupStepProps,
-  ClusterFormData,
-  RosaWizardFormData,
-  WizardCallbackFunctions,
-  WizardType,
-  SelectDropdownType,
-  MachineTypesDropdownType,
-  VPC,
-  Subnet,
-  Roles,
-  OIDCConfig,
-} from 'nxtcm-components';
-```
-
-## Rendering the Wizard
+`WizardWrapper` types `onSubmit` as `(data: RosaWizardFormData) => Promise<void>` (not `unknown`). The prop name is `wizardsStepsData` (matches `RosaWizard`).
 
 ```tsx
 import { WizardWrapper } from 'nxtcm-components';
+import type { RosaWizardFormData, WizardStepsData } from 'nxtcm-components';
 
-<WizardWrapper
-  type="rosa-hcp"
-  title="Create ROSA HCP cluster"
-  wizardsStepsData={stepsData}
-  onSubmit={handleSubmit}
-  onCancel={handleCancel}
-/>
-```
-
-`type` is a union of `'rosa-hcp' | 'rosa-yaml-editor'`. The first renders the standard step-by-step wizard, the second adds a YAML editor step before review.
-
-## Input: `WizardStepsData`
-
-This is the top-level shape passed via the `wizardsStepsData` prop.
-
-```ts
-type WizardStepsData = {
-  basicSetupStep: BasicSetupStepProps;
-  callbackFunctions?: WizardCallbackFunctions;
-};
-```
-
-### `BasicSetupStepProps`
-
-All the dropdown and selection data the wizard needs to render its steps.
-
-```ts
-type BasicSetupStepProps = {
-  openShiftVersions: SelectDropdownType[];
-  awsInfrastructureAccounts: SelectDropdownType[];
-  awsBillingAccounts: SelectDropdownType[];
-  regions: SelectDropdownType[];
-  vpcList: VPC[];
-  roles: Roles;
-  oicdConfig: OIDCConfig[];
-  machineTypes: MachineTypesDropdownType[];
-};
-```
-
-### Option types
-
-Most dropdowns use `SelectDropdownType`:
-
-```ts
-type SelectDropdownType = {
-  label: string;       // display text
-  value: string;       // stored value
-  description?: string; // optional secondary text
-};
-```
-
-Machine types have an extra `id` field:
-
-```ts
-type MachineTypesDropdownType = {
-  id: string;
-  label: string;
-  description: string;
-  value: string;
-};
-```
-
-### VPC and Subnet data
-
-```ts
-type VPC = {
-  id: string;
-  name: string;
-  aws_subnets: Subnet[];
-};
-
-type Subnet = {
-  subnet_id: string;
-  name: string;            // should contain 'private' or 'public' for filtering
-  availability_zone: string;
-};
-```
-
-The wizard filters subnets by name to separate private and public subnets. Subnet names containing `'private'` are used for machine pool selection, and those containing `'public'` are used for the public subnet dropdown when the cluster is set to external access.
-
-### Roles
-
-```ts
-type Roles = {
-  installerRoles: SelectDropdownType[];
-  supportRoles: SelectDropdownType[];
-  workerRoles: SelectDropdownType[];
-};
-```
-
-### OIDC Config
-
-```ts
-type OIDCConfig = {
-  label: string;
-  value: string;
-  issuer_url: string; // shown as description in the dropdown
-};
-```
-
-### Callback Functions (optional)
-
-```ts
-type WizardCallbackFunctions = {
-  onAWSAccountChange?: (value: unknown) => void;
-  refreshAwsAccountDataCallback?: () => void;
-  refreshAwsBillingAccountCallback?: () => void;
-};
-```
-
-- `onAWSAccountChange` fires when the user selects a different AWS infrastructure account. Use this to reload roles, VPCs, or other account-dependent data.
-- `refreshAwsAccountDataCallback` is wired to the refresh button on the AWS infrastructure account dropdown.
-- `refreshAwsBillingAccountCallback` is wired to the refresh button on the AWS billing account dropdown.
-
-## Output: `ClusterFormData`
-
-The `onSubmit` callback receives the full form state wrapped as `RosaWizardFormData`:
-
-```ts
-type RosaWizardFormData = {
-  cluster: ClusterFormData;
-};
-```
-
-`ClusterFormData` contains every field the wizard collects:
-
-```ts
-type ClusterFormData = {
-  // details
-  name?: string;
-  cluster_version?: string;
-  associated_aws_id?: string;
-  billing_account_id?: string;
-  region?: string;
-
-  // roles and policies
-  installer_role_arn?: string;
-  support_role_arn?: string;
-  worker_role_arn?: string;
-  byo_oidc_config_id?: string;
-  custom_operator_roles_prefix?: string;
-
-  // machine pools
-  selected_vpc?: string;
-  machine_pools_subnets?: MachinePoolSubnetEntry[];
-  machine_type?: string;
-  autoscaling?: boolean;
-  nodes_compute?: number;
-  min_replicas?: number;
-  max_replicas?: number;
-  compute_root_volume?: number;
-  imds?: string;
-
-  // networking
-  cluster_privacy?: 'external' | 'internal';
-  cluster_privacy_public_subnet_id?: string;
-  cidr_default?: boolean;
-  network_machine_cidr?: string;
-  network_service_cidr?: string;
-  network_pod_cidr?: string;
-  network_host_prefix?: string;
-  configure_proxy?: boolean;
-
-  // proxy (only present if configure_proxy is true)
-  http_proxy_url?: string;
-  https_proxy_url?: string;
-  no_proxy_domains?: string;
-  additional_trust_bundle?: string;
-
-  // encryption
-  encryption_keys?: 'default' | 'custom';
-  kms_key_arn?: string;
-  etcd_encryption?: boolean;
-  etcd_key_arn?: string;
-
-  // cluster updates
-  upgrade_policy?: 'automatic' | 'manual';
-  upgrade_schedule?: string; // cron format, e.g. "00 14 * * 3"
-};
-```
-
-All fields are optional because the user fills them in progressively. By the time `onSubmit` fires, required fields will have been validated by the wizard's built-in validation.
-
-## Full Example
-
-```tsx
-import { WizardWrapper } from 'nxtcm-components';
-import type {
-  WizardStepsData,
-  ClusterFormData,
-} from 'nxtcm-components';
-
-function CreateClusterPage() {
-  const stepsData: WizardStepsData = {
+function CreateRosaHcpCluster() {
+  const wizardsStepsData: WizardStepsData = {
     basicSetupStep: {
-      openShiftVersions: [
-        { label: '4.15.2', value: '4.15.2' },
-        { label: '4.14.8', value: '4.14.8' },
-      ],
-      awsInfrastructureAccounts: [
-        { label: 'prod-account (123456789)', value: '123456789' },
-      ],
-      awsBillingAccounts: [
-        { label: 'billing-main (987654321)', value: '987654321' },
-      ],
-      regions: [
-        { label: 'US East (N. Virginia)', value: 'us-east-1' },
-        { label: 'US West (Oregon)', value: 'us-west-2' },
-      ],
-      vpcList: [
-        {
-          id: 'vpc-abc123',
-          name: 'production-vpc',
-          aws_subnets: [
-            { subnet_id: 'subnet-priv1', name: 'private-us-east-1a', availability_zone: 'us-east-1a' },
-            { subnet_id: 'subnet-pub1', name: 'public-us-east-1a', availability_zone: 'us-east-1a' },
-          ],
+      clusterNameValidation: { error: null, isFetching: false },
+      userRole: { error: null, isFetching: false },
+      versions: {
+        data: {
+          latest: { label: 'OpenShift 4.16.2', value: '4.16.2' },
+          default: { label: 'OpenShift 4.16.0', value: '4.16.0' },
+          others: [{ label: 'OpenShift 4.15.8', value: '4.15.8' }],
         },
-      ],
-      roles: {
-        installerRoles: [{ label: 'ManagedOpenShift-Installer-Role', value: 'arn:aws:iam::role/installer' }],
-        supportRoles: [{ label: 'ManagedOpenShift-Support-Role', value: 'arn:aws:iam::role/support' }],
-        workerRoles: [{ label: 'ManagedOpenShift-Worker-Role', value: 'arn:aws:iam::role/worker' }],
+        error: null,
+        isFetching: false,
+        fetch: async () => {},
       },
-      oicdConfig: [
-        { label: 'oidc-abc123', value: 'abc123', issuer_url: 'https://oidc.example.com' },
-      ],
-      machineTypes: [
-        { id: 'm5.xlarge', label: 'm5.xlarge', description: '4 vCPU, 16 GiB', value: 'm5.xlarge' },
-        { id: 'm5.2xlarge', label: 'm5.2xlarge', description: '8 vCPU, 32 GiB', value: 'm5.2xlarge' },
-      ],
-    },
-    callbackFunctions: {
-      onAWSAccountChange: (accountId) => {
-        // reload roles, VPCs, etc. for the selected account
-      },
-      refreshAwsAccountDataCallback: () => {
-        // re-fetch AWS infrastructure accounts
-      },
-      refreshAwsBillingAccountCallback: () => {
-        // re-fetch AWS billing accounts
-      },
+      awsInfrastructureAccounts: { data: [], error: null, isFetching: false },
+      awsBillingAccounts: { data: [], error: null, isFetching: false },
+      regions: { data: [], error: null, isFetching: false },
+      roles: { data: [], error: null, isFetching: false, fetch: async (_awsAccount: string) => {} },
+      oidcConfig: { data: [], error: null, isFetching: false },
+      machineTypes: { data: [], error: null, isFetching: false },
+      vpcList: { data: [], error: null, isFetching: false },
+      subnets: { data: [], error: null, isFetching: false },
+      securityGroups: { data: [], error: null, isFetching: false },
     },
   };
 
-  const handleSubmit = async (data: unknown) => {
-    const { cluster } = data as { cluster: ClusterFormData };
-    // cluster.name, cluster.region, cluster.machine_type, etc.
-    // are all typed and available here
-    await createCluster(cluster);
+  const onSubmit = async (data: RosaWizardFormData): Promise<void> => {
+    void data.cluster;
   };
 
   return (
     <WizardWrapper
       type="rosa-hcp"
       title="Create ROSA HCP cluster"
-      wizardsStepsData={stepsData}
-      onSubmit={handleSubmit}
-      onCancel={() => navigate('/clusters')}
+      wizardsStepsData={wizardsStepsData}
+      onSubmit={onSubmit}
+      onCancel={() => undefined}
     />
   );
 }
 ```
+
+## Notes
+
+- `BasicSetupStepProps` requires `versions.fetch()` and `roles.fetch(awsAccount)`; other resources use optional `fetch` on `Resource` when refresh is supported.
+- Machine UI still reads subnets from `vpcList.data[].aws_subnets` today; `subnets` and `securityGroups` are separate `Resource` shapes for future separation without another top-level API reshape.
+- Subnet names are filtered by substring: names containing `private` drive machine pool subnets; names containing `public` drive the public subnet dropdown when cluster privacy is external.
+- `WizardType` includes `rosa-yaml-editor`, but `WizardWrapper` currently only renders `rosa-hcp`; other values return `null` until that path is wired.
+- Keep validation wiring and per-field async behavior (for example cluster name uniqueness) in the host app as those flows are implemented field-by-field.
+- Prefer updating the Storybook contract story and compile-only example when the integration shape evolves; keep this file concise.

--- a/src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import type { WizardSubmit } from '@patternfly-labs/react-form-wizard';
 import { RosaWizard } from './RosaWizard';
 import type {
   OIDCConfig,
@@ -15,7 +16,6 @@ const mockResource = <TData,>(data: TData): Resource<TData> => ({
   data,
   error: null,
   isFetching: false,
-  fetch: async () => {},
 });
 
 const mockFetchResource = <TData, TArgs extends unknown[] = []>(
@@ -97,6 +97,11 @@ const wizardStepsData: WizardStepsData = {
   },
 };
 
+// cast only on the prop: react-form-wizard still types submit as unknown
+const integrationContractOnSubmit = async (data: RosaWizardFormData): Promise<void> => {
+  void data.cluster;
+};
+
 const meta: Meta<typeof RosaWizard> = {
   title: 'Wizards/RosaWizard/Integration Contract',
   component: RosaWizard,
@@ -111,7 +116,7 @@ Type-safe integration contract for consumers.
 - Output contract on submit: \`RosaWizardFormData\`
 - Source of truth for exported types: \`src/components/Wizards/index.ts\`
 
-This story intentionally keeps args strongly typed so TypeScript catches drift when wizard props or exports change.
+This story keeps \`wizardsStepsData\` and the submit handler body typed like consumer code (\`WizardWrapper\` uses the same \`RosaWizardFormData\` shape). The handler is cast to \`WizardSubmit\` only at the prop boundary because react-form-wizard types submit as \`unknown\`.
 `,
       },
     },
@@ -125,10 +130,7 @@ export const TypedConsumerExample: Story = {
   args: {
     title: 'Typed ROSA Wizard Integration',
     wizardsStepsData: wizardStepsData,
-    onSubmit: async (data: unknown) => {
-      const typedData = data as RosaWizardFormData;
-      void typedData.cluster;
-    },
+    onSubmit: integrationContractOnSubmit as WizardSubmit,
     onCancel: () => {
       void 0;
     },

--- a/src/examples/rosaWizardIntegration.example.tsx
+++ b/src/examples/rosaWizardIntegration.example.tsx
@@ -15,7 +15,6 @@ const mockResource = <TData,>(data: TData): Resource<TData> => ({
   data,
   error: null,
   isFetching: false,
-  fetch: async () => {},
 });
 
 const mockFetchResource = <TData, TArgs extends unknown[] = []>(
@@ -92,9 +91,10 @@ const wizardStepsData: WizardStepsData = {
   },
 };
 
-const onSubmit = (data: unknown): Promise<void> => {
-  const typedData = data as RosaWizardFormData;
-  void typedData.cluster.name;
+const onSubmit: ComponentProps<typeof WizardWrapper>['onSubmit'] = (
+  data: RosaWizardFormData
+): Promise<void> => {
+  void data.cluster.name;
   return Promise.resolve();
 };
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
FCN-153 stabilize rosa wizard integration docs (storybook + compile-checked example)


**Jira issue #** 
https://redhat.atlassian.net/browse/FCN-153


**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. 
2. 
3. 

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->

### After
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [x] I have updated the documentation accordingly
- [x] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

How drift is caught: `src/examples/rosaWizardIntegration.example.tsx` is typed against `ComponentProps<typeof WizardWrapper>` and lives under `src/`, so the existing `tsc --noEmit` CI step compiles it on every PR. If exported types or wizard props change, this file fails to compile and the Type Check job goes red. No extra CI config was added.

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

