### PR TITLE
FCN-65 provide translations into the wizard

### DIFF
--- a/packages/react-form-wizard/src/inputs/WizNumberInput.tsx
+++ b/packages/react-form-wizard/src/inputs/WizNumberInput.tsx
@@ -11,7 +11,7 @@ import { DisplayMode } from '../contexts/DisplayModeContext';
 import { getEnterPlaceholder, InputCommonProps, useInput } from './Input';
 import { WizFormGroup } from './WizFormGroup';
 
-export type WizNumberInputProps<T> = InputCommonProps<T> & {
+export type WizNumberInputProps<T = number | undefined> = InputCommonProps<T> & {
   label: string;
   placeholder?: string;
   secret?: boolean;
@@ -20,7 +20,7 @@ export type WizNumberInputProps<T> = InputCommonProps<T> & {
   zeroIsUndefined?: boolean;
 };
 
-export function WizNumberInput<T>(props: WizNumberInputProps<T>) {
+export function WizNumberInput<T = number | undefined>(props: WizNumberInputProps<T>) {
   const {
     displayMode: mode,
     value,

--- a/src/components/Wizards/RosaWizard/RosaWizard.ct.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.ct.tsx
@@ -3,17 +3,14 @@
  * Exports a wrapper so the spec can mount a component from a file other than the spec.
  */
 import React from 'react';
-import { TranslationProvider } from '@/context/TranslationContext';
 import { RosaWizard } from './RosaWizard';
 import { rosaWizardMockStepsData } from './rosaWizardTestMocks';
 
 export const RosaWizardMount: React.FC = () => (
-  <TranslationProvider>
-    <RosaWizard
-      title="Create cluster"
-      onSubmit={async () => {}}
-      onCancel={() => {}}
-      wizardsStepsData={rosaWizardMockStepsData}
-    />
-  </TranslationProvider>
+  <RosaWizard
+    title="Create cluster"
+    onSubmit={async () => {}}
+    onCancel={() => {}}
+    wizardsStepsData={rosaWizardMockStepsData}
+  />
 );

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec-helpers.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec-helpers.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { RosaWizard } from './RosaWizard';
-import { TranslationProvider } from '../../../context/TranslationContext';
 
 type RosaWizardProps = React.ComponentProps<typeof RosaWizard>;
 
@@ -14,12 +13,10 @@ export function RosaWizardErrorThenBackToReviewMount(props: RosaWizardProps) {
     'There has been an error creating the cluster'
   );
   return (
-    <TranslationProvider>
-      <RosaWizard
-        {...props}
-        onSubmitError={submitError}
-        onBackToReviewStep={() => setSubmitError(false)}
-      />
-    </TranslationProvider>
+    <RosaWizard
+      {...props}
+      onSubmitError={submitError}
+      onBackToReviewStep={() => setSubmitError(false)}
+    />
   );
 }

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/experimental-ct-react';
 import React from 'react';
 import { RosaWizard } from './RosaWizard';
 import { RosaWizardErrorThenBackToReviewMount } from './RosaWizard.spec-helpers';
-import { TranslationProvider } from '../../../context/TranslationContext';
 import { checkAccessibility } from '../../../test-helpers';
 import { RosaWizardMount } from './RosaWizard.ct';
 import type { BasicSetupStepProps } from './RosaWizard';
@@ -115,11 +114,7 @@ const defaultProps = {
 };
 
 function mountRosaWizard(overrides: Record<string, unknown> = {}) {
-  return (
-    <TranslationProvider>
-      <RosaWizard {...defaultProps} {...overrides} />
-    </TranslationProvider>
-  );
+  return <RosaWizard {...defaultProps} {...overrides} />;
 }
 
 test.describe('RosaWizard', () => {

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
@@ -123,6 +123,30 @@ test.describe('RosaWizard', () => {
     await expect(component.getByRole('heading', { name: 'Create ROSA Cluster' })).toBeVisible();
   });
 
+  test('should show custom Rosa strings in the nav and react-form-wizard chrome (e.g. Next)', async ({
+    mount,
+  }) => {
+    const customReviewLabel = 'Custom review step from strings prop';
+    const customNextLabel = 'CT_CUSTOM_NEXT_FROM_FORM_WIZARD_STRINGS';
+    const component = await mount(
+      mountRosaWizard({
+        strings: {
+          wizard: {
+            stepLabels: {
+              review: customReviewLabel,
+            },
+          },
+          formWizard: {
+            nextButtonText: customNextLabel,
+          },
+        },
+      })
+    );
+
+    await expect(component.getByText(customReviewLabel)).toBeVisible();
+    await expect(component.getByRole('button', { name: customNextLabel })).toBeVisible();
+  });
+
   test('should pass accessibility tests when showing the wizard', async ({ mount }) => {
     const component = await mount(mountRosaWizard());
     await checkAccessibility({ component });

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -31,7 +31,7 @@ import {
 import { MachinePoolsSubstep } from './Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep';
 import { YamlDrawerEditor } from './Steps/YamlCodeEditor';
 import { RosaWizardStringsProvider, useRosaWizardStrings } from './RosaWizardStringsContext';
-import type { RosaWizardStringsInput } from './rosaWizardStrings';
+import { buildWizardStringsForRosa, type RosaWizardStringsInput } from './rosaWizardStrings';
 
 export type BasicSetupStepProps = {
   // validation-only fields (no data, just state)
@@ -91,12 +91,26 @@ export const RosaWizard = (props: RosaWizardProps) => (
   </RosaWizardStringsProvider>
 );
 
-export const RosaWizardBody = (props: RosaWizardProps) => {
-  const { onSubmit, onCancel, title, wizardsStepsData, onSubmitError, onBackToReviewStep, yaml } =
-    props;
-  const { wizard } = useRosaWizardStrings();
+const RosaWizardBody = (props: RosaWizardProps) => {
+  const {
+    onSubmit,
+    onCancel,
+    title,
+    wizardsStepsData,
+    onSubmitError,
+    onBackToReviewStep,
+    yaml,
+    strings,
+  } = props;
+  const rosaStrings = useRosaWizardStrings();
+  const { wizard } = rosaStrings;
   const sl = wizard.stepLabels;
   const yamlEditor = yaml ? (props.yamlEditor ?? getDefaultYamlEditor) : undefined;
+  const wizardStrings = React.useMemo(
+    () => buildWizardStringsForRosa(rosaStrings, strings?.formWizard),
+    [rosaStrings, strings?.formWizard]
+  );
+
   const [isClusterWideProxySelected, setIsClusterWideProxySelected] =
     React.useState<boolean>(false);
 
@@ -161,6 +175,7 @@ export const RosaWizardBody = (props: RosaWizardProps) => {
           onResumedToStep={() => setResumeAtStepId(null)}
           yaml={yaml}
           yamlEditor={yamlEditor}
+          wizardStrings={wizardStrings}
         >
           <ExpandableStep
             id="basic-setup-step-id-expandable-section"

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -28,9 +28,10 @@ import {
   VPC,
   WizardNavigationContext,
 } from '../types';
-import { useTranslation } from '../../../context/TranslationContext';
 import { MachinePoolsSubstep } from './Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep';
 import { YamlDrawerEditor } from './Steps/YamlCodeEditor';
+import { RosaWizardStringsProvider, useRosaWizardStrings } from './RosaWizardStringsContext';
+import type { RosaWizardStringsInput } from './rosaWizardStrings';
 
 export type BasicSetupStepProps = {
   // validation-only fields (no data, just state)
@@ -77,16 +78,24 @@ type RosaWizardProps = {
   onBackToReviewStep?: () => void | Promise<void>;
   yamlEditor?: () => ReactNode;
   yaml?: boolean;
+  strings?: RosaWizardStringsInput;
 };
 
 function getDefaultYamlEditor() {
   return <YamlDrawerEditor />;
 }
 
-export const RosaWizard = (props: RosaWizardProps) => {
-  const { t } = useTranslation();
+export const RosaWizard = (props: RosaWizardProps) => (
+  <RosaWizardStringsProvider strings={props.strings}>
+    <RosaWizardBody {...props} />
+  </RosaWizardStringsProvider>
+);
+
+export const RosaWizardBody = (props: RosaWizardProps) => {
   const { onSubmit, onCancel, title, wizardsStepsData, onSubmitError, onBackToReviewStep, yaml } =
     props;
+  const { wizard } = useRosaWizardStrings();
+  const sl = wizard.stepLabels;
   const yamlEditor = yaml ? (props.yamlEditor ?? getDefaultYamlEditor) : undefined;
   const [isClusterWideProxySelected, setIsClusterWideProxySelected] =
     React.useState<boolean>(false);
@@ -155,11 +164,11 @@ export const RosaWizard = (props: RosaWizardProps) => {
         >
           <ExpandableStep
             id="basic-setup-step-id-expandable-section"
-            label={t('Basic setup')}
+            label={sl.basicSetup}
             key="basic-setup-step-expandable-section-key"
             isExpandable
             steps={[
-              <Step label={t('Details')} id="basic-setup-step-details" key="basic-setup-details">
+              <Step label={sl.details} id="basic-setup-step-details" key="basic-setup-details">
                 <DetailsSubStep
                   clusterNameValidation={basicSetupStep.clusterNameValidation}
                   openShiftVersions={buildVersionOptions(basicSetupStep.versions.data)}
@@ -173,7 +182,7 @@ export const RosaWizard = (props: RosaWizardProps) => {
               </Step>,
               <Step
                 id="roles-and-policies-sub-step"
-                label={t('Roles and policies')}
+                label={sl.rolesAndPolicies}
                 key="roles-and-policies-sub-step-key"
               >
                 <RolesAndPoliciesSubStep
@@ -183,7 +192,7 @@ export const RosaWizard = (props: RosaWizardProps) => {
               </Step>,
               <Step
                 id="machinepools-sub-step"
-                label={t('Machine pools')}
+                label={sl.machinePools}
                 key="machinepools-sub-step-key"
               >
                 <MachinePoolsSubstep
@@ -191,7 +200,7 @@ export const RosaWizard = (props: RosaWizardProps) => {
                   machineTypes={basicSetupStep.machineTypes}
                 />
               </Step>,
-              <Step id="networking-sub-step" label={t('Networking')} key="networking-sub-step-key">
+              <Step id="networking-sub-step" label={sl.networking} key="networking-sub-step-key">
                 <NetworkingAndSubnetsSubStep
                   vpcList={basicSetupStep.vpcList}
                   setIsClusterWideProxySelected={setIsClusterWideProxySelected}
@@ -202,7 +211,7 @@ export const RosaWizard = (props: RosaWizardProps) => {
                     <Step
                       id="additional-setup-cluster-wide-proxy"
                       key="additional-setup-cluster-wide-proxy-key"
-                      label={t('Cluster-wide proxy')}
+                      label={sl.clusterWideProxy}
                     >
                       <ClusterWideProxySubstep />
                     </Step>,
@@ -213,27 +222,27 @@ export const RosaWizard = (props: RosaWizardProps) => {
 
           <ExpandableStep
             id="additional-setup-step-id-expandable-section"
-            label={t('Additional setup')}
+            label={sl.additionalSetup}
             key="additional-setup-step-expandable-section-key"
             isExpandable
             steps={[
               <Step
                 id="additional-setup-encryption"
                 key="additional-setup-encryption-key"
-                label={t('Encryption (optional)')}
+                label={sl.encryptionOptional}
               >
                 <EncryptionSubstep />
               </Step>,
               <Step
                 id="additional-setup-cluster-updates"
                 key="additional-setup-cluster-updates-key"
-                label={t('Cluster updates (optional)')}
+                label={sl.clusterUpdatesOptional}
               >
                 <ClusterUpdatesSubstep goToStepId={getUseWizardContext} />
               </Step>,
             ]}
           />
-          <Step label={t('Review')} id={'review-step'}>
+          <Step label={sl.review} id={'review-step'}>
             <ReviewStepData goToStepId={getUseWizardContext} />
           </Step>
         </WizardPage>

--- a/src/components/Wizards/RosaWizard/RosaWizardStringsContext.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardStringsContext.tsx
@@ -1,0 +1,51 @@
+import React, { createContext, useContext, useMemo } from 'react';
+import {
+  buildRosaWizardStringBundles,
+  type RosaWizardStrings,
+  type RosaWizardStringsInput,
+  type RosaWizardValidatorStrings,
+} from './rosaWizardStrings';
+
+export type RosaWizardStringsContextValue = {
+  strings: RosaWizardStrings;
+  validators: RosaWizardValidatorStrings;
+};
+
+const RosaWizardStringsContext = createContext<RosaWizardStringsContextValue | null>(null);
+
+export type RosaWizardStringsProviderProps = {
+  children: React.ReactNode;
+  /** Partial overrides; omitted keys use built-in English defaults. */
+  strings?: RosaWizardStringsInput;
+};
+
+export function RosaWizardStringsProvider({
+  children,
+  strings: stringsInput,
+}: RosaWizardStringsProviderProps) {
+  const value = useMemo(
+    () => buildRosaWizardStringBundles(stringsInput),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- callers should memoize `strings` when passing inline objects
+    [stringsInput]
+  );
+
+  return (
+    <RosaWizardStringsContext.Provider value={value}>{children}</RosaWizardStringsContext.Provider>
+  );
+}
+
+export function useRosaWizardStrings(): RosaWizardStrings {
+  const ctx = useContext(RosaWizardStringsContext);
+  if (!ctx) {
+    throw new Error('useRosaWizardStrings must be used within RosaWizardStringsProvider');
+  }
+  return ctx.strings;
+}
+
+export function useRosaWizardValidators(): RosaWizardValidatorStrings {
+  const ctx = useContext(RosaWizardStringsContext);
+  if (!ctx) {
+    throw new Error('useRosaWizardValidators must be used within RosaWizardStringsProvider');
+  }
+  return ctx.validators;
+}

--- a/src/components/Wizards/RosaWizard/RosaWizardSubmitError.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardSubmitError.tsx
@@ -6,6 +6,7 @@ import {
   EmptyStateFooter,
   EmptyStateStatus,
 } from '@patternfly/react-core';
+import { useRosaWizardStrings } from './RosaWizardStringsContext';
 
 export type RosaWizardSubmitErrorProps = {
   /** Error message or flag from parent (e.g. submit failure). */
@@ -19,13 +20,10 @@ export type RosaWizardSubmitErrorProps = {
 
 export function RosaWizardSubmitError(props: RosaWizardSubmitErrorProps) {
   const { onSubmitError, onBackToReviewStep, isNavigatingToReview, onCancel } = props;
+  const { submitError } = useRosaWizardStrings();
 
   return (
-    <EmptyState
-      status={EmptyStateStatus.danger}
-      titleText={'Error creating cluster'}
-      headingLevel="h2"
-    >
+    <EmptyState status={EmptyStateStatus.danger} titleText={submitError.title} headingLevel="h2">
       {typeof onSubmitError === 'string' && onSubmitError.length > 0 && (
         <EmptyStateBody>{onSubmitError}</EmptyStateBody>
       )}
@@ -38,13 +36,13 @@ export function RosaWizardSubmitError(props: RosaWizardSubmitErrorProps) {
               isLoading={isNavigatingToReview}
               isDisabled={isNavigatingToReview}
             >
-              Back to review step
+              {submitError.backToReviewStep}
             </Button>
           )}
         </EmptyStateActions>
         <EmptyStateActions>
           <Button variant="link" onClick={onCancel}>
-            Exit wizard
+            {submitError.exitWizard}
           </Button>
         </EmptyStateActions>
       </EmptyStateFooter>

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
@@ -60,6 +60,11 @@ export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
   const formatHourLabel = (hour: number) => `${hour.toString().padStart(2, '0')}:00 UTC`;
 
   const [selectedHour, selectedDay] = parseCurrentValue();
+  const selectedDayIndex = Number(selectedDay);
+  const dayToggleLabel =
+    selectedDay === '' || Number.isNaN(selectedDayIndex)
+      ? cu.selectDayPlaceholder
+      : (cu.daysOfWeek[selectedDayIndex] ?? cu.selectDayPlaceholder);
 
   const dayToggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
@@ -68,7 +73,7 @@ export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
       isExpanded={daySelectOpen}
       isFullWidth
     >
-      {cu.daysOfWeek[Number(selectedDay)] ?? cu.selectDayPlaceholder}
+      {dayToggleLabel}
     </MenuToggle>
   );
 

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterUpdatesSubstep/ClusterUpdatesSubstep.tsx
@@ -14,13 +14,12 @@ import {
   SelectList,
   SelectOption,
 } from '@patternfly/react-core';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import parseUpdateSchedule from './parseUpdateSchedule';
 import { RosaWizardFormData, WizardNavigationContext } from '../../../../types';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
+import { useRosaWizardStrings } from '../../../RosaWizardStringsContext';
 
-const daysOptions = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 const hoursOptions = Array.from(Array(24).keys());
 
 type ClusterUpdatesSubstepProps = {
@@ -28,7 +27,7 @@ type ClusterUpdatesSubstepProps = {
 };
 
 export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
-  const { t } = useTranslation();
+  const cu = useRosaWizardStrings().clusterUpdates;
   const { cluster } = useItem<RosaWizardFormData>();
   const { update } = useData();
 
@@ -69,7 +68,7 @@ export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
       isExpanded={daySelectOpen}
       isFullWidth
     >
-      {daysOptions[Number(selectedDay)] ?? t('Select day')}
+      {cu.daysOfWeek[Number(selectedDay)] ?? cu.selectDayPlaceholder}
     </MenuToggle>
   );
 
@@ -88,77 +87,68 @@ export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
     <Section
       id="cluster-updates-substep-section"
       key="cluster-updates-substep-section-key"
-      label={t('Cluster update strategy')}
+      label={cu.sectionLabel}
     >
       <Content component={ContentVariants.p}>
-        {t(`The OpenShift version ${cluster.cluster_version} that you selected in the`)}{' '}
+        {cu.versionIntroPrefix} {cluster.cluster_version} {cu.versionIntroSuffix}{' '}
         {
           <Button
             onClick={() => props.goToStepId?.goToStepById('basic-setup-step-details')}
             variant="link"
             isInline
           >
-            {t(`Details step`)}
+            {cu.detailsStepLink}
           </Button>
         }{' '}
-        {t('will apply to the managed control plane and the machine pools configured in the')}{' '}
+        {cu.midSentence}{' '}
         {
           <Button
             onClick={() => props.goToStepId?.goToStepById('networking-sub-step')}
             variant="link"
             isInline
           >
-            {t(`Networking and subnets step.`)}
+            {cu.networkingStepLink}
           </Button>
         }{' '}
-        {t(`After cluster creation, you can
-        update the managed control plane and machine pools independently.`)}
+        {cu.afterCreation}
       </Content>
 
       <Content component={ContentVariants.p}>
-        {t('In the event of')}{' '}
+        {cu.cveLead}{' '}
         <ExternalLink href={links.SECURITY_CLASSIFICATION_CRITICAL}>
-          Critical security concerns
+          {cu.criticalConcernsLink}
         </ExternalLink>{' '}
-        {t(`(CVEs) that significantly impact the security or stability of the cluster, updates may be
-        automatically scheduled by Red Hat SRE to the latest z-stream version not impacted by the
-        CVE within 2 business days after customer notifications.`)}
+        {cu.cveTail}
       </Content>
 
       <WizRadioGroup path="cluster.upgrade_policy">
         <Radio
           id="cluster-upgrade-strategy-individual-radio-btn"
-          label={t('Individual updates')}
+          label={cu.individualLabel}
           value="automatic"
           description={
             <>
-              {t(
-                'Schedule each update individually. When planning updates, make sure to consider the end of life dates from the'
-              )}{' '}
-              <ExternalLink href={links.ROSA_LIFE_CYCLE}>lifecycle policy</ExternalLink>
+              {cu.individualDescriptionLead}{' '}
+              <ExternalLink href={links.ROSA_LIFE_CYCLE}>{cu.lifecycleLink}</ExternalLink>
             </>
           }
         />
         <Radio
           id="cluster-upgrade-strategy-recurring-radio-btn"
-          label={t('Recurring updates')}
+          label={cu.recurringLabel}
           value="manual"
           description={
             <>
-              {t(
-                `The cluster control plan will be automatically updated based on your preferred day and start time when new patch updates`
-              )}{' '}
-              <ExternalLink href={links.ROSA_Z_STREAM}>z-stream</ExternalLink>{' '}
-              {t(
-                `are available. When a new minor version is available, you'll be notified and must manually allow the cluster to update the next minor version. The compute nodes will need to be manually updated.`
-              )}
+              {cu.recurringDescriptionBeforeZStream}
+              <ExternalLink href={links.ROSA_Z_STREAM}>{cu.zStreamLinkText}</ExternalLink>
+              {cu.recurringDescriptionAfterZStream}
             </>
           }
         />
       </WizRadioGroup>
 
       {cluster?.upgrade_policy === 'automatic' && (
-        <FormGroup label={t('Select a day and start time')} style={{ marginLeft: '1.5rem' }}>
+        <FormGroup label={cu.dayTimeLabel} style={{ marginLeft: '1.5rem' }}>
           <Grid hasGutter>
             <GridItem sm={6} md={6}>
               <Select
@@ -170,7 +160,7 @@ export const ClusterUpdatesSubstep = (props: ClusterUpdatesSubstepProps) => {
                 toggle={dayToggle}
               >
                 <SelectList>
-                  {daysOptions.map((day, idx) => (
+                  {cu.daysOfWeek.map((day, idx) => (
                     <SelectOption key={day} value={idx.toString()}>
                       {day}
                     </SelectOption>

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterWideProxySubstep/ClusterWideProxySubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/ClusterWideProxySubstep/ClusterWideProxySubstep.tsx
@@ -1,6 +1,5 @@
 import { Section, WizTextInput, WizFileUpload, useItem } from '@patternfly-labs/react-form-wizard';
 import { Alert, Content, ContentVariants, Grid, GridItem } from '@patternfly/react-core';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import {
   checkNoProxyDomains,
   composeValidators,
@@ -9,47 +8,38 @@ import {
 } from '../../../validators';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
+import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 
 export const ClusterWideProxySubstep = () => {
-  const { t } = useTranslation();
+  const cw = useRosaWizardStrings().clusterWideProxy;
+  const v = useRosaWizardValidators();
   const { cluster } = useItem();
 
   const validateAtLeastOne = () => {
     if (!cluster.http_proxy_url && !cluster.https_proxy_url && !cluster.additional_trust_bundle) {
-      return 'Configure at least one of the cluster-wide proxy fields.';
+      return v.proxyConfigureAtLeastOne;
     }
     return undefined;
   };
-  const validateUrlHttp = (value: string) => validateUrl(value, 'http');
-  const validateUrlHttps = (value: string) => validateUrl(value, ['http', 'https']);
+  const validateUrlHttp = (value: string) => validateUrl(value, 'http', v.url);
+  const validateUrlHttps = (value: string) => validateUrl(value, ['http', 'https'], v.url);
 
   return (
     <Section
       id="cluster-wide-proxy-section-id"
       key="cluster-wide-proxy-section-key"
-      label={t('Cluster-wide proxy')}
+      label={cw.sectionLabel}
     >
-      <Content component={ContentVariants.p}>
-        {t(
-          'Enable an HTTP or HTTPS proxy to deny direct access to the internet from your cluster.'
-        )}
-      </Content>
-      <ExternalLink href={links.CONFIGURE_PROXY_URL}>
-        Learn more about configuring a cluster-wide proxy
-      </ExternalLink>
-      <Alert
-        variant="info"
-        isInline
-        isPlain
-        title={t('Configure at least 1 of the following fields:')}
-      />
+      <Content component={ContentVariants.p}>{cw.intro}</Content>
+      <ExternalLink href={links.CONFIGURE_PROXY_URL}>{cw.learnMoreLink}</ExternalLink>
+      <Alert variant="info" isInline isPlain title={cw.alertConfigureFields} />
       <Grid>
         <GridItem span={7}>
           <WizTextInput
             validation={composeValidators(validateUrlHttp, validateAtLeastOne)}
             validateOnBlur
-            label={t('HTTP proxy URL')}
-            helperText={t('Specify a proxy URL to use for HTTP connections outside the cluster.')}
+            label={cw.httpLabel}
+            helperText={cw.httpHelp}
             path="cluster.http_proxy_url"
           />
         </GridItem>
@@ -57,8 +47,8 @@ export const ClusterWideProxySubstep = () => {
           <WizTextInput
             validation={composeValidators(validateUrlHttps, validateAtLeastOne)}
             validateOnBlur
-            label={t('HTTPS proxy URL')}
-            helperText={t('Specify a proxy URL to use for HTTPS connections outside the cluster.')}
+            label={cw.httpsLabel}
+            helperText={cw.httpsHelp}
             path="cluster.https_proxy_url"
           />
         </GridItem>
@@ -66,19 +56,20 @@ export const ClusterWideProxySubstep = () => {
           <WizTextInput
             disabled={!cluster.http_proxy_url && !cluster.https_proxy_url}
             validateOnBlur
-            validation={(value) => checkNoProxyDomains(value)}
-            label={t('No Proxy domains')}
-            helperText={t(
-              'Preface a domain with . to match subdomains only. For example, .y.com matches x.y.com, but not y.com. Use * to bypass proxy for all destinations.'
-            )}
+            validation={(value) => checkNoProxyDomains(value, v.noProxyDomains)}
+            label={cw.noProxyLabel}
+            helperText={cw.noProxyHelp}
             path="cluster.no_proxy_domains"
           />
         </GridItem>
         <GridItem span={7}>
           <WizFileUpload
-            label={t('Additional trust bundle')}
+            label={cw.trustBundleLabel}
             path="cluster.additional_trust_bundle"
-            validation={composeValidators(validateCA, validateAtLeastOne)}
+            validation={composeValidators(
+              (value: string) => validateCA(value, v.ca),
+              () => validateAtLeastOne()
+            )}
           />
         </GridItem>
       </Grid>

--- a/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/EncryptionSubstep/EncryptionSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/AdditionalSetupStep/EncryptionSubstep/EncryptionSubstep.tsx
@@ -9,14 +9,15 @@ import {
 } from '@patternfly-labs/react-form-wizard';
 import { Alert, Flex, FlexItem, Grid, GridItem } from '@patternfly/react-core';
 import React from 'react';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import { validateAWSKMSKeyARN } from '../../../validators';
 import { RosaWizardFormData } from '../../../../types';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
+import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 
 export const EncryptionSubstep = () => {
-  const { t } = useTranslation();
+  const e = useRosaWizardStrings().encryption;
+  const v = useRosaWizardValidators();
   const { cluster } = useItem<RosaWizardFormData>();
   const { update } = useData();
 
@@ -38,37 +39,27 @@ export const EncryptionSubstep = () => {
 
   return (
     <Section
-      label={t('Advanced encryption')}
+      label={e.sectionLabel}
       id="encryption-substep-section"
       key="encryption-substep-section-key"
     >
       <WizRadioGroup
         id="encryption-keys-radio-group"
         path="cluster.encryption_keys"
-        label={t('Encryption Keys')}
+        label={e.keysGroupLabel}
         helperText={
           <>
-            {t(
-              'You can use your default or a custom AWS KMS key to encrypt the root disks for your OpenShift nodes.'
-            )}{' '}
-            <ExternalLink href={links.AWS_DATA_PROTECTION}>Learn more</ExternalLink>
+            {e.keysHelperLead}{' '}
+            <ExternalLink href={links.AWS_DATA_PROTECTION}>{e.keysLearnMore}</ExternalLink>
           </>
         }
       >
         <Flex direction={{ default: 'column' }}>
           <FlexItem>
-            <Radio
-              id="default-aws-kms-key-radio-btn"
-              label={t('Use default AWS KMS key')}
-              value="default"
-            />
+            <Radio id="default-aws-kms-key-radio-btn" label={e.defaultKms} value="default" />
           </FlexItem>
           <FlexItem>
-            <Radio
-              id="custom-aws-kms-key-radio-btn"
-              label={t('Use custom AWS KMS key')}
-              value="custom"
-            />
+            <Radio id="custom-aws-kms-key-radio-btn" label={e.customKms} value="custom" />
           </FlexItem>
         </Flex>
       </WizRadioGroup>
@@ -77,13 +68,11 @@ export const EncryptionSubstep = () => {
           <GridItem span={8}>
             <WizTextInput
               path="cluster.kms_key_arn"
-              label={t('Key ARN')}
+              label={e.keyArnLabel}
               validateOnBlur
-              validation={(value) => validateAWSKMSKeyARN(value, cluster.region, t)}
+              validation={(value) => validateAWSKMSKeyARN(value, cluster.region, v.kmsKeyArn)}
               required
-              labelHelp={t(
-                'The key ARN is the Amazon Resource Name (ARN) of a CMK. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.'
-              )}
+              labelHelp={e.keyArnHelp}
             />
           </GridItem>
         </Grid>
@@ -92,12 +81,12 @@ export const EncryptionSubstep = () => {
       <WizCheckbox
         id="etcd-encryption"
         path="cluster.etcd_encryption"
-        title={t('etcd encryption')}
-        label={t('Enable additional etcd encryption')}
+        title={e.etcdTitle}
+        label={e.etcdLabel}
         helperText={
           <>
-            {t('Optionally, add a unique customer-managed AWS KMS key to encrypt etcd.')}{' '}
-            <ExternalLink href={links.ROSA_SERVICE_ETCD_ENCRYPTION}>Learn more</ExternalLink>
+            {e.etcdHelperLead}{' '}
+            <ExternalLink href={links.ROSA_SERVICE_ETCD_ENCRYPTION}>{e.etcdLearnMore}</ExternalLink>
           </>
         }
       />
@@ -107,26 +96,18 @@ export const EncryptionSubstep = () => {
           <GridItem span={8}>
             <WizTextInput
               path="cluster.etcd_key_arn"
-              validation={(value) => validateAWSKMSKeyARN(value, cluster.region, t)}
-              label={t('Key ARN')}
+              validation={(value) => validateAWSKMSKeyARN(value, cluster.region, v.kmsKeyArn)}
+              label={e.keyArnLabel}
               validateOnBlur
               required
-              labelHelp={t(
-                'The key ARN is the Amazon Resource Name (ARN) of a CMK. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.'
-              )}
+              labelHelp={e.keyArnHelp}
             />
           </GridItem>
         </Grid>
       )}
       <Grid>
         <GridItem span={9}>
-          <Alert
-            variant="info"
-            title={t(
-              'Take a note of the keys associated with your cluster. If you delete your keys, the cluster will not be available'
-            )}
-            ouiaId="encryptionKeysAlert"
-          />
+          <Alert variant="info" title={e.keysNoteAlert} ouiaId="encryptionKeysAlert" />
         </GridItem>
       </Grid>
     </Section>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -3,10 +3,10 @@ import { Button, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core
 import React from 'react';
 import { StepDrawer } from '../../../common/StepDrawer';
 import { Resource, Role, SelectDropdownType, ValidationResource } from '../../../../types';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import { validateClusterName } from '../../../validators';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
+import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 
 type DetailsSubStepProps = {
   clusterNameValidation: ValidationResource;
@@ -31,13 +31,15 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
   awsBillingAccounts,
   regions,
 }) => {
-  const { t } = useTranslation();
+  const d = useRosaWizardStrings().details;
+  const v = useRosaWizardValidators();
+
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState<boolean>(false);
   const drawerRef = React.useRef<HTMLSpanElement>(null);
   const onWizardExpand = () => drawerRef.current && drawerRef.current.focus();
 
   return (
-    <Section label={t('Details')}>
+    <Section label={d.sectionLabel}>
       <StepDrawer
         isDrawerExpanded={isDrawerExpanded}
         setIsDrawerExpanded={setIsDrawerExpanded}
@@ -52,13 +54,11 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                     validateClusterName(name, item) || clusterNameValidation.error || undefined
                   }
                   path="cluster.name"
-                  label={t('Cluster name')}
+                  label={d.clusterNameLabel}
                   validateOnBlur
-                  placeholder={t('Enter the cluster name')}
+                  placeholder={d.clusterNamePlaceholder}
                   required
-                  labelHelp={t(
-                    'This will be how we refer to your cluster in the OpenShift cluster list and will form part of the cluster console subdomain.'
-                  )}
+                  labelHelp={d.clusterNameHelp}
                 />
               </GridItem>
             </Grid>
@@ -70,8 +70,8 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                 <WizSelect
                   isFill
                   path="cluster.cluster_version"
-                  label={t('OpenShift version')}
-                  placeholder={t('Select an OpenShift version')}
+                  label={d.openShiftVersionLabel}
+                  placeholder={d.openShiftVersionPlaceholder}
                   options={openShiftVersions}
                   disabled={versionsIsPending}
                   refreshCallback={refreshVersionsCallback}
@@ -87,15 +87,12 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                 <WizSelect
                   isFill
                   path="cluster.associated_aws_id"
-                  label={t('Associated AWS infrastructure account')}
-                  placeholder={t('Select an AWS infrastructure account')}
-                  labelHelp={t(
-                    "Your cluster's cloud resources will be created in the associated AWS infrastructure account. To continue, you must associate at least 1 account."
-                  )}
+                  label={d.awsInfraLabel}
+                  placeholder={d.awsInfraPlaceholder}
+                  labelHelp={d.awsInfraHelp}
                   options={awsInfrastructureAccounts.data}
                   disabled={awsInfrastructureAccounts.isFetching}
                   onValueChange={(_newAccountId, item) => {
-                    // reset downstream role arns when account changes
                     item.cluster.installer_role_arn = undefined;
                     item.cluster.worker_role_arn = undefined;
                     item.cluster.support_role_arn = undefined;
@@ -119,7 +116,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                 variant="link"
                 onClick={() => setIsDrawerExpanded((prevExpanded) => !prevExpanded)}
               >
-                {t('Associate a new AWS account')}
+                {d.associateNewAccount}
               </Button>
             )}
           </StackItem>
@@ -130,11 +127,9 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                 <WizSelect
                   isFill
                   path="cluster.billing_account_id"
-                  label={t('Associated AWS billing account')}
-                  placeholder={t('Select an AWS billing account')}
-                  labelHelp={t(
-                    'The AWS billing account is often the same as your Associated AWS infrastructure account, but does not have to be.'
-                  )}
+                  label={d.billingLabel}
+                  placeholder={d.billingPlaceholder}
+                  labelHelp={d.billingHelp}
                   options={awsBillingAccounts.data}
                   disabled={awsBillingAccounts.isFetching}
                   required
@@ -149,7 +144,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
               className="pf-v6-u-mt-md"
               href={links.AWS_CONSOLE_ROSA_HOME}
             >
-              Connect ROSA to a new AWS billing account
+              {d.connectBillingLink}
             </ExternalLink>
           </StackItem>
           <StackItem>
@@ -158,11 +153,9 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                 <WizSelect
                   isFill
                   path="cluster.region"
-                  label={t('Region')}
-                  placeholder={t('Select a region')}
-                  labelHelp={t(
-                    'The AWS Region where your compute nodes and control plane will be located. (should be link: Learn more abut AWS Regions.)'
-                  )}
+                  label={d.regionLabel}
+                  placeholder={d.regionPlaceholder}
+                  labelHelp={d.regionHelp}
                   options={regions.data}
                   disabled={regions.isFetching}
                   required

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -6,7 +6,7 @@ import { Resource, Role, SelectDropdownType, ValidationResource } from '../../..
 import { validateClusterName } from '../../../validators';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
-import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
+import { useRosaWizardStrings } from '../../../RosaWizardStringsContext';
 
 type DetailsSubStepProps = {
   clusterNameValidation: ValidationResource;
@@ -32,7 +32,6 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
   regions,
 }) => {
   const d = useRosaWizardStrings().details;
-  const v = useRosaWizardValidators();
 
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState<boolean>(false);
   const drawerRef = React.useRef<HTMLSpanElement>(null);

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/Autoscaling/AutoscalingField.tsx
@@ -1,6 +1,5 @@
 import { useData, WizCheckbox, WizNumberInput } from '@patternfly-labs/react-form-wizard';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import { useTranslation } from '../../../../../../../context/TranslationContext';
 import {
   validateMinReplicas,
   validateMaxReplicas,
@@ -8,6 +7,10 @@ import {
 } from '../../../../validators';
 import ExternalLink from '../../../../common/ExternalLink';
 import links from '../../../../externalLinks';
+import {
+  useRosaWizardStrings,
+  useRosaWizardValidators,
+} from '../../../../RosaWizardStringsContext';
 
 type AutoscalingFieldProps = {
   autoscaling: boolean;
@@ -39,7 +42,6 @@ const scaleMaxNodesBasedOnOpenshiftVersion = (openshiftVersion: number) => {
   return true;
 };
 
-//Minimal versions to allow more then 90 nodes - 4.15.15, 4.14.28
 export const getAutoscalingMaxNodes = (openshiftVersion?: number) => {
   if (openshiftVersion && !scaleMaxNodesBasedOnOpenshiftVersion(openshiftVersion)) {
     return MAX_NODES_HCP_INSUFFICIENT_VERSION;
@@ -48,7 +50,8 @@ export const getAutoscalingMaxNodes = (openshiftVersion?: number) => {
 };
 
 export const AutoscalingField = (props: AutoscalingFieldProps) => {
-  const { t } = useTranslation();
+  const a = useRosaWizardStrings().autoscaling;
+  const v = useRosaWizardValidators();
   const { update } = useData();
 
   const { autoscaling, openshiftVersion, machinePoolsNumber } = props;
@@ -59,19 +62,17 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
     <>
       <WizCheckbox
         id="autoscaling-checkbox"
-        title={t('Autoscaling')}
+        title={a.title}
         helperText={
           <>
-            {t(
-              'Autoscaling automatically adds and removes nodes from the machine pool based on resource requirements.'
-            )}{' '}
+            {a.helperLead}{' '}
             <ExternalLink href={links.ROSA_CLUSTER_AUTOSCALING}>
-              Learn more about autscaling with ROSA.
+              {a.learnMoreAutoscaling}
             </ExternalLink>
           </>
         }
         path="cluster.autoscaling"
-        label={t('Enable autoscaling')}
+        label={a.enableLabel}
         onValueChange={(checked, item) => {
           if (checked) {
             delete item.cluster.nodes_compute;
@@ -92,19 +93,19 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
             <WizNumberInput
               required
               path="cluster.min_replicas"
-              label={t('Min compute node count')}
+              label={a.minLabel}
               labelHelp={
                 <>
-                  {t('The number of compute nodes to provision for your initial machine pool.')}
+                  {a.minHelp}
                   <ExternalLink href={links.ROSA_WORKER_NODE_COUNT}>
-                    Learn more about compute node count
+                    {a.learnMoreNodeCount}
                   </ExternalLink>
                 </>
               }
               min={scaleMinNodesOnMachinePoolNumber(machinePoolsNumber)}
               max={maxNodeBasedOnOpenshiftVersion}
               validation={(value: number, item) =>
-                validateMinReplicas(value, item, machinePoolsNumber)
+                validateMinReplicas(value, item, machinePoolsNumber, v.replicas)
               }
             />
           </FlexItem>
@@ -112,19 +113,24 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
             <WizNumberInput
               required
               path="cluster.max_replicas"
-              label={t('Max compute node count')}
+              label={a.maxLabel}
               labelHelp={
                 <>
-                  {t('The number of compute nodes to provision for your initial machine pool.')}
+                  {a.maxHelp}
                   <ExternalLink href={links.ROSA_WORKER_NODE_COUNT}>
-                    Learn more about compute node count
+                    {a.learnMoreNodeCount}
                   </ExternalLink>
                 </>
               }
               min={1}
               max={maxNodeBasedOnOpenshiftVersion}
               validation={(value, item) =>
-                validateMaxReplicas(value as number, item, maxNodeBasedOnOpenshiftVersion)
+                validateMaxReplicas(
+                  value as number,
+                  item,
+                  maxNodeBasedOnOpenshiftVersion,
+                  v.replicas
+                )
               }
             />
           </FlexItem>
@@ -133,17 +139,17 @@ export const AutoscalingField = (props: AutoscalingFieldProps) => {
         <WizNumberInput
           required
           path="cluster.nodes_compute"
-          label={t('Compute node count')}
+          label={a.computeCountLabel}
           labelHelp={
             <>
-              {t('The number of compute nodes to provision for your initial machine pool.')}
+              {a.computeCountHelp}
               <ExternalLink href={links.ROSA_WORKER_NODE_COUNT}>
-                Learn more about compute node count
+                {a.learnMoreNodeCount}
               </ExternalLink>
             </>
           }
           min={1}
-          validation={validateComputeNodes}
+          validation={(value) => validateComputeNodes(value, v.replicas)}
         />
       )}
     </>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { MachinePoolsSubstep } from './MachinePoolsSubstep';
-import { TranslationProvider } from '../../../../../../context/TranslationContext';
+import { RosaWizardStringsProvider } from '../../../RosaWizardStringsContext';
 import { ItemContext } from '@patternfly-labs/react-form-wizard/contexts/ItemContext';
 import { DataContext } from '@patternfly-labs/react-form-wizard/contexts/DataContext';
 import {
@@ -127,7 +127,7 @@ export const MachinePoolsSubstepStory: React.FC<MachinePoolsSubstepStoryProps> =
   }, []);
 
   return (
-    <TranslationProvider>
+    <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
         <DisplayModeContext.Provider value={DisplayMode.Step}>
           <ItemContext.Provider value={data}>
@@ -139,6 +139,6 @@ export const MachinePoolsSubstepStory: React.FC<MachinePoolsSubstepStoryProps> =
           </ItemContext.Provider>
         </DisplayModeContext.Provider>
       </DataContext.Provider>
-    </TranslationProvider>
+    </RosaWizardStringsProvider>
   );
 };

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -15,7 +15,6 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import { subnetsFilter } from '../../../helpers';
 import {
   MachineTypesDropdownType,
@@ -30,6 +29,7 @@ import links from '../../../externalLinks';
 import { Indented } from '@patternfly-labs/react-form-wizard/components/Indented';
 import { validateRootDiskSize } from '../../../validators';
 import { SecurityGroupsSection } from './SecurityGroupSection/SecurityGroupSection';
+import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 
 type MachinePoolsSubstepProps = {
   vpcList: Resource<VPC[]>;
@@ -37,7 +37,8 @@ type MachinePoolsSubstepProps = {
 };
 
 export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
-  const { t } = useTranslation();
+  const mp = useRosaWizardStrings().machinePools;
+  const v = useRosaWizardValidators();
   const { cluster } = useItem<RosaWizardFormData>();
 
   const vpcRef = cluster?.selected_vpc;
@@ -46,7 +47,6 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
 
   const { privateSubnets } = subnetsFilter(selectedVPC);
 
-  // Resets cluster_privacy_public_subnet_id when user selects private
   React.useEffect(() => {
     if (cluster?.cluster_privacy === 'internal') {
       cluster.cluster_privacy_public_subnet_id = '';
@@ -56,12 +56,8 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
 
   return (
     <>
-      <Section label={t('Machine pools')} id="machine-pools-section" key="machine-pools-key">
-        <Content component={ContentVariants.p}>
-          {t(
-            'Create machine pools and specify the private subnet for each machine pool. To allow high availability for your workloads, add machine pools on different availablity zones.'
-          )}
-        </Content>
+      <Section label={mp.sectionLabel} id="machine-pools-section" key="machine-pools-key">
+        <Content component={ContentVariants.p}>{mp.intro}</Content>
 
         <Grid>
           <GridItem span={5}>
@@ -71,17 +67,15 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
                   item.cluster.security_groups_worker = [];
                 }
               }}
-              label={`${t('Select a VPC to install your machine pools into your selected regions:')} ${cluster?.region}`}
+              label={`${mp.vpcLabelPrefix} ${cluster?.region}`}
               path="cluster.selected_vpc"
               keyPath="id"
-              placeholder={t('Select a VPC to install your machine pools into')}
+              placeholder={mp.vpcPlaceholder}
               required
               labelHelp={
                 <>
-                  {t(
-                    'To create a cluster hosted by Red Hat, you must have a Virtual Private Cloud (VPC) available to create clusters on.'
-                  )}{' '}
-                  <ExternalLink href={links.ROSA_SHARED_VPC}>Learn more about VPCs.</ExternalLink>
+                  {mp.vpcHelpLead}{' '}
+                  <ExternalLink href={links.ROSA_SHARED_VPC}>{mp.vpcLearnMoreLink}</ExternalLink>
                 </>
               }
               options={props.vpcList.data.map((vpc: VPC) => ({
@@ -96,10 +90,10 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
         <WizMachinePoolSelect
           required
           path="cluster.machine_pools_subnets"
-          machinePoolLabel={t('Machine pool')}
-          subnetLabel={t('Private subnet name')}
-          addMachinePoolBtnLabel={t('Add machine pool')}
-          selectPlaceholder={t('Select private subnet')}
+          machinePoolLabel={mp.machinePoolLabel}
+          subnetLabel={mp.subnetLabel}
+          addMachinePoolBtnLabel={mp.addPoolButton}
+          selectPlaceholder={mp.subnetPlaceholder}
           subnetOptions={privateSubnets?.map((subnet: Subnet) => ({
             label: subnet.name,
             value: subnet.subnet_id,
@@ -109,27 +103,23 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
         />
       </Section>
       <Section
-        label={t('Machine pools settings')}
+        label={mp.settingsSectionLabel}
         id="machine-pools-settings-section"
         key="machine-pools-settings-key"
       >
-        <Content component={ContentVariants.p}>
-          {t(
-            'The following settings apply to all machine pools created during cluster install. Additional machine pools can be created after cluster creation.'
-          )}
-        </Content>
+        <Content component={ContentVariants.p}>{mp.settingsIntro}</Content>
         <Grid>
           <GridItem span={5}>
             <WizSelect
-              label={t('Compute node instance type')}
+              label={mp.instanceTypeLabel}
               path="cluster.machine_type"
               required
               labelHelp={
                 <>
-                  {t(
-                    'Instance types are made from varying combinations of CPU, memory, storage, and networking capacity. Instance type availability depends on regional availability and your AWS account configuration.'
-                  )}{' '}
-                  <ExternalLink href={links.ROSA_INSTANCE_TYPES}>Learn more.</ExternalLink>
+                  {mp.instanceTypeHelpLead}{' '}
+                  <ExternalLink href={links.ROSA_INSTANCE_TYPES}>
+                    {mp.instanceTypeLearnMore}
+                  </ExternalLink>
                 </>
               }
               options={props.machineTypes.data}
@@ -145,49 +135,43 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
         />
       </Section>
 
-      <ExpandableSection toggleText="Advanced machine pool configuration (optional)">
+      <ExpandableSection toggleText={mp.advancedToggle}>
         <Indented>
           <WizRadioGroup
-            labelHelpTitle="Amazon EC2 Instance Metadata Service (IMDS)"
+            labelHelpTitle={mp.imdsHelpTitle}
             labelHelp={
               <>
-                <Content component={ContentVariants.p}>
-                  Instance metadata is data that is related to an Amazon Elastic Compute Cloud
-                  (Amazon EC2) instance that applications can use to configure or manage the running
-                  instance.
-                </Content>
+                <Content component={ContentVariants.p}>{mp.imdsHelpP1}</Content>
                 <Content component={ContentVariants.p}>
                   {/* TODO: External link component is in another PR */}
                   {/* <ExternalLink href={links.AWS_IMDS}>Learn more about IMDS</ExternalLink> */}
                 </Content>
               </>
             }
-            label="Instance Metadata Service"
+            label={mp.imdsLabel}
             path="cluster.imds"
           >
             <Radio
               id="cluster-metadata-service-imdsv1-imdsv2-btn"
-              label={t('Use both IMDSv1 and IMDSv2')}
+              label={mp.imdsBothLabel}
               value="imdsv1andimdsv2"
-              description={t('Allows use of both IMDS versions for backward compatibility')}
+              description={mp.imdsBothDescription}
             />
             <Radio
               id="cluster-metadata-service-imdsv2-only-btn"
-              label={t('Use IMDSv2 only')}
+              label={mp.imdsV2Label}
               value="imdsv2only"
-              description={t('A session-oriented method with enhanced security')}
+              description={mp.imdsV2Description}
             />
           </WizRadioGroup>
 
           <WizNumberInput
             path="cluster.compute_root_volume"
-            label={t('Root disk size')}
-            labelHelp={t(
-              'Root disks are AWS EBS volumes attached as the primary disk for AWS EC2 instances. The root disk size for this machine pool group of nodes must be between 75GiB and 16384GiB.'
-            )}
+            label={mp.rootDiskLabel}
+            labelHelp={mp.rootDiskHelp}
             min={75}
             max={16384}
-            validation={validateRootDiskSize}
+            validation={(value) => validateRootDiskSize(value, v.rootDisk)}
           />
         </Indented>
       </ExpandableSection>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/EditSecurityGroups.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/EditSecurityGroups.tsx
@@ -26,6 +26,10 @@ import { validateSecurityGroups } from '../../../../validators';
 import { truncateTextWithEllipsis } from '../../../../helpers';
 import { FormGroupHelperText } from '../../../../common/FormGroupHelperText';
 import { CloudVpc } from '../../../../../types';
+import {
+  useRosaWizardStrings,
+  useRosaWizardValidators,
+} from '../../../../RosaWizardStringsContext';
 
 export interface EditSecurityGroupsProps {
   label?: string;
@@ -47,7 +51,7 @@ const getDisplayName = (securityGroupName: string) => {
 };
 
 const EditSecurityGroups = ({
-  label = 'Security groups',
+  label: labelProp,
   selectedVPC,
   selectedGroupIds = [],
   onChange,
@@ -55,6 +59,9 @@ const EditSecurityGroups = ({
   refreshVPCCallback,
   isVPCLoading,
 }: EditSecurityGroupsProps) => {
+  const sg = useRosaWizardStrings().securityGroups;
+  const v = useRosaWizardValidators();
+  const label = labelProp ?? sg.formLabel;
   const [isOpen, setIsOpen] = React.useState<boolean>(false);
 
   const vpcSecurityGroups = React.useMemo(
@@ -78,10 +85,7 @@ const EditSecurityGroups = ({
   if (isReadOnly) {
     // Shows read-only label, or an empty message if no SGs are selected
     return (
-      <SecurityGroupsViewList
-        securityGroups={selectedOptions}
-        emptyMessage="This machine pool does not have additional security groups."
-      />
+      <SecurityGroupsViewList securityGroups={selectedOptions} emptyMessage={sg.readOnlyEmpty} />
     );
   }
 
@@ -102,13 +106,13 @@ const EditSecurityGroups = ({
       isFullWidth
       badge={
         selectedGroupIds.length > 0 && (
-          <Badge screenReaderText="some items">{selectedGroupIds.length}</Badge>
+          <Badge screenReaderText={sg.badgeSrText}>{selectedGroupIds.length}</Badge>
         )
       }
-      aria-label="Options menu"
+      aria-label={sg.optionsMenuAria}
       className="security-groups-menu-toggle"
     >
-      Select security groups
+      {sg.selectToggle}
     </MenuToggle>
   );
 
@@ -128,7 +132,7 @@ const EditSecurityGroups = ({
     }
   };
 
-  const validationError = validateSecurityGroups(selectedGroupIds);
+  const validationError = validateSecurityGroups(selectedGroupIds, v.securityGroups);
 
   return (
     <GridItem>
@@ -145,7 +149,7 @@ const EditSecurityGroups = ({
                   onSelect={onSelect}
                   onOpenChange={(isOpen) => setIsOpen(isOpen)}
                   data-testid="securitygroups-id"
-                  aria-labelledby="Select AWS security groups"
+                  aria-labelledby={sg.selectAriaLabelledBy}
                   maxMenuHeight="300px"
                 >
                   <SelectList>
@@ -177,7 +181,7 @@ const EditSecurityGroups = ({
           </GridItem>
           {refreshVPCCallback && (
             <GridItem span={2} style={{ textAlign: 'left' }}>
-              <Tooltip content="Refetch Security Groups list">
+              <Tooltip content={sg.refreshTooltip}>
                 <Button
                   id="refreshSecurityGroupsButton"
                   isDisabled={isVPCLoading}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/EditSecurityGroups.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/EditSecurityGroups.tsx
@@ -149,7 +149,7 @@ const EditSecurityGroups = ({
                   onSelect={onSelect}
                   onOpenChange={(isOpen) => setIsOpen(isOpen)}
                   data-testid="securitygroups-id"
-                  aria-labelledby={sg.selectAriaLabelledBy}
+                  aria-label={sg.selectAriaLabelledBy}
                   maxMenuHeight="300px"
                 >
                   <SelectList>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupSection.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupSection.tsx
@@ -6,6 +6,7 @@ import EditSecurityGroups from './EditSecurityGroups';
 import SecurityGroupsEmptyAlert from './SecurityGroupsEmptyAlert';
 import SecurityGroupsNoEditAlert from './SecurityGroupsNoEditAlert';
 import { CloudVpc } from '../../../../../types';
+import { useRosaWizardStrings } from '../../../../RosaWizardStringsContext';
 
 export const SecurityGroupsSection = ({
   selectedVPC,
@@ -14,6 +15,7 @@ export const SecurityGroupsSection = ({
   selectedVPC: CloudVpc | undefined;
   refreshVPCs?: () => void;
 }) => {
+  const { machinePools } = useRosaWizardStrings();
   const [selectedGroupIds, setSelectedGroupIds] = useValue(
     { path: 'cluster.security_groups_worker' },
     []
@@ -37,7 +39,7 @@ export const SecurityGroupsSection = ({
 
   return (
     <ExpandableSection
-      toggleText="Additional security groups (optional)"
+      toggleText={machinePools.securityGroupsToggle}
       isExpanded={isExpanded}
       isIndented
       onToggle={() => setIsExpanded(!isExpanded)}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupsEmptyAlert.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupsEmptyAlert.tsx
@@ -1,23 +1,23 @@
 import { Alert, AlertActionLink } from '@patternfly/react-core';
 import ExternalLink from '../../../../common/ExternalLink';
 import links from '../../../../externalLinks';
+import { useRosaWizardStrings } from '../../../../RosaWizardStringsContext';
 
 type SecurityGroupsEmptyAlertProps = {
   refreshVPCCallback?: () => void;
 };
-const SecurityGroupsEmptyAlert = ({ refreshVPCCallback }: SecurityGroupsEmptyAlertProps) => (
-  <Alert
-    variant="info"
-    isInline
-    title="There are no security groups for this Virtual Private Cloud"
-  >
-    To add security groups, go to the{' '}
-    <ExternalLink href={links.AWS_CONSOLE_SECURITY_GROUPS}>Security groups section</ExternalLink> of
-    your AWS console. <br />
-    {refreshVPCCallback && (
-      <AlertActionLink onClick={refreshVPCCallback}>Refresh Security Groups</AlertActionLink>
-    )}
-  </Alert>
-);
+const SecurityGroupsEmptyAlert = ({ refreshVPCCallback }: SecurityGroupsEmptyAlertProps) => {
+  const sg = useRosaWizardStrings().securityGroups;
+  return (
+    <Alert variant="info" isInline title={sg.emptyTitle}>
+      {sg.emptyBodyPrefix}{' '}
+      <ExternalLink href={links.AWS_CONSOLE_SECURITY_GROUPS}>{sg.emptyConsoleLink}</ExternalLink> of
+      your AWS console. <br />
+      {refreshVPCCallback && (
+        <AlertActionLink onClick={refreshVPCCallback}>{sg.refreshLink}</AlertActionLink>
+      )}
+    </Alert>
+  );
+};
 
 export default SecurityGroupsEmptyAlert;

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupsEmptyAlert.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupsEmptyAlert.tsx
@@ -11,8 +11,8 @@ const SecurityGroupsEmptyAlert = ({ refreshVPCCallback }: SecurityGroupsEmptyAle
   return (
     <Alert variant="info" isInline title={sg.emptyTitle}>
       {sg.emptyBodyPrefix}{' '}
-      <ExternalLink href={links.AWS_CONSOLE_SECURITY_GROUPS}>{sg.emptyConsoleLink}</ExternalLink> of
-      your AWS console. <br />
+      <ExternalLink href={links.AWS_CONSOLE_SECURITY_GROUPS}>{sg.emptyConsoleLink}</ExternalLink>{' '}
+      {sg.emptyBodySuffix} <br />
       {refreshVPCCallback && (
         <AlertActionLink onClick={refreshVPCCallback}>{sg.refreshLink}</AlertActionLink>
       )}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupsNoEditAlert.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupsNoEditAlert.tsx
@@ -1,26 +1,24 @@
 import React from 'react';
 
 import { Alert, AlertActionLink } from '@patternfly/react-core';
-import { useTranslation } from '../../../../../../../context/TranslationContext';
 import links from '../../../../externalLinks';
+import { useRosaWizardStrings } from '../../../../RosaWizardStringsContext';
 
 const SecurityGroupsNoEditAlert = () => {
-  const { t } = useTranslation();
+  const sg = useRosaWizardStrings().securityGroups;
 
   return (
     <Alert
       variant="info"
       isInline
-      title={t(
-        'You cannot add or edit security groups associated with machine pools that were created during cluster creation.'
-      )}
+      title={sg.noEditTitle}
       actionLinks={
         <>
           <AlertActionLink component="a" href={links.ROSA_SECURITY_GROUPS} target="_blank">
-            View more information
+            {sg.noEditViewMoreInfo}
           </AlertActionLink>
           <AlertActionLink component="a" href={links.AWS_CONSOLE_SECURITY_GROUPS} target="_blank">
-            AWS security groups console
+            {sg.noEditAwsConsoleLink}
           </AlertActionLink>
         </>
       }

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { NetworkingAndSubnetsSubStep } from './NetworkingAndSubnetsSubStep';
-import { TranslationProvider } from '../../../../../../context/TranslationContext';
+import { RosaWizardStringsProvider } from '../../../RosaWizardStringsContext';
 import { ItemContext } from '@patternfly-labs/react-form-wizard/contexts/ItemContext';
 import { DataContext } from '@patternfly-labs/react-form-wizard/contexts/DataContext';
 import {
@@ -127,7 +127,7 @@ export const NetworkingSubStepStory: React.FC<NetworkingSubStepStoryProps> = ({
   );
 
   return (
-    <TranslationProvider>
+    <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
         <DisplayModeContext.Provider value={DisplayMode.Step}>
           <ItemContext.Provider value={data}>
@@ -142,6 +142,6 @@ export const NetworkingSubStepStory: React.FC<NetworkingSubStepStoryProps> = ({
           </ItemContext.Provider>
         </DisplayModeContext.Provider>
       </DataContext.Provider>
-    </TranslationProvider>
+    </RosaWizardStringsProvider>
   );
 };

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
@@ -10,7 +10,6 @@ import {
 } from '@patternfly-labs/react-form-wizard';
 import { LabelHelp } from '@patternfly-labs/react-form-wizard/components/LabelHelp';
 import { Resource, RosaWizardFormData, Subnet, VPC } from '../../../../types';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import { constructSelectedSubnets, subnetsFilter } from '../../../helpers';
 import {
   Alert,
@@ -38,6 +37,7 @@ import {
 import { Indented } from '@patternfly-labs/react-form-wizard/components/Indented';
 import links from '../../../externalLinks';
 import ExternalLink from '../../../common/ExternalLink';
+import { useRosaWizardStrings } from '../../../RosaWizardStringsContext';
 
 type NetworkingAndSubnetsSubStepProps = {
   vpcList: Resource<VPC[]>;
@@ -45,7 +45,7 @@ type NetworkingAndSubnetsSubStepProps = {
 };
 
 export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepProps) => {
-  const { t } = useTranslation();
+  const n = useRosaWizardStrings().networking;
   const { cluster } = useItem<RosaWizardFormData>();
   const { setIsClusterWideProxySelected } = props;
   const { update } = useData();
@@ -107,29 +107,20 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
 
   return (
     <>
-      <Section label={t('Networking')} id="networking-section" key="networking-section-key">
+      <Section label={n.sectionLabel} id="networking-section" key="networking-section-key">
         <WizRadioGroup
           id="public-private-subnet-radio-group"
           path="cluster.cluster_privacy"
-          helperText={t(
-            'Install your cluster with all public or private API endpoints and application routes.'
-          )}
+          helperText={n.privacyHelper}
         >
           <Radio
             id="public"
-            label={t('Public')}
+            label={n.publicLabel}
             value="external"
-            popover={
-              <LabelHelp
-                id="subnet-label-help"
-                labelHelp={t(
-                  'Access Kubernetes API endpoint and application routes from the internet.'
-                )}
-              />
-            }
+            popover={<LabelHelp id="subnet-label-help" labelHelp={n.publicPopover} />}
           >
             <WizSelect
-              label={t('Public subnet name')}
+              label={n.publicSubnetLabel}
               path="cluster.cluster_privacy_public_subnet_id"
               options={
                 props.vpcList.isFetching
@@ -139,53 +130,34 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
                       value: subnet.subnet_id,
                     }))
               }
-              placeholder={
-                props.vpcList.isFetching
-                  ? t('Loading VPC subnets...')
-                  : t('Select public subnet name')
-              }
-              disabled={props.vpcList.isFetching}
+              placeholder={n.publicSubnetPlaceholder}
             />
           </Radio>
 
           <Radio
             id="private"
-            label={t('Private')}
+            label={n.privateLabel}
             value="internal"
-            popover={
-              <LabelHelp
-                id="subnet-label-help"
-                labelHelp={t(
-                  'Access Kubernetes API endpoint and application routes from direct private connections only.'
-                )}
-              />
-            }
+            popover={<LabelHelp id="subnet-label-help" labelHelp={n.privatePopover} />}
           ></Radio>
         </WizRadioGroup>
       </Section>
 
-      <ExpandableSection toggleText="Advanced networking configuration (optional)">
+      <ExpandableSection toggleText={n.advancedToggle}>
         <Indented>
           <Stack>
             <StackItem>
               <WizCheckbox
                 id="cluster-wide-proxy"
                 path="cluster.configure_proxy"
-                label={t('Configure a cluster-wide proxy')}
-                helperText={t(
-                  'Enable an HTTP or HTTPS proxy to deny direct access to the internet from your cluster.'
-                )}
+                label={n.proxyCheckboxLabel}
+                helperText={n.proxyCheckboxHelp}
               />
             </StackItem>
             {clusterWideProxy ? (
               <Indented>
                 <StackItem>
-                  <Alert
-                    variant="info"
-                    isInline
-                    isPlain
-                    title="You will be able to configure cluster-wide proxy details in the next step"
-                  />
+                  <Alert variant="info" isInline isPlain title={n.proxyNextStepInfo} />
                 </StackItem>
               </Indented>
             ) : null}
@@ -197,18 +169,14 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
                 isExpandable
                 actionClose={<AlertActionCloseButton onClose={() => {}} />}
                 variant="warning"
-                title={t('CIDR ranges cannot be changed after you create your cluster')}
+                title={n.cidrAlertTitle}
                 ouiaId="encryptionKeysAlert"
               >
-                <Content component={ContentVariants.p}>
-                  {t(`Specify non-overlapping ranges for machine, service, and pod ranges. Make sure that
-                        your internal organization&apos;s networking ranges do not overlap with ours, which are
-                        Kubernetes. Each range should correspond to the first IP address in their subnet.`)}
-                </Content>
+                <Content component={ContentVariants.p}>{n.cidrAlertBody}</Content>
 
                 <Content component={ContentVariants.p}>
                   <ExternalLink href={links.CIDR_RANGE_DEFINITIONS_ROSA}>
-                    {t(`Learn more about configuring network settings`)}
+                    {n.cidrLearnMoreLink}
                   </ExternalLink>
                 </Content>
               </Alert>
@@ -218,10 +186,8 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
           <WizCheckbox
             id="use-cidr-default-values"
             path="cluster.cidr_default"
-            label={t('Use default values')}
-            helperText={t(
-              'The values are safe defaults. However, you must ensure that the Machine CIDR matches the selected VPC subnets.'
-            )}
+            label={n.useDefaultsLabel}
+            helperText={n.useDefaultsHelp}
           />
 
           <Grid hasGutter>
@@ -231,8 +197,8 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
                 validateOnBlur
                 id="network_machine_cidr"
                 path="cluster.network_machine_cidr"
-                label={t('Machine CIDR')}
-                helperText={t('Subnet mask must be between /16 and /25')}
+                label={n.machineCidrLabel}
+                helperText={n.machineCidrHelp}
                 disabled={defaultCidrValue}
               />
             </GridItem>
@@ -242,8 +208,8 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
                 validateOnBlur
                 id="network_service_cidr"
                 path="cluster.network_service_cidr"
-                label={t('Service CIDR')}
-                helperText={t('Subnet mask must be at most /24')}
+                label={n.serviceCidrLabel}
+                helperText={n.serviceCidrHelp}
                 disabled={defaultCidrValue}
               />
             </GridItem>
@@ -253,8 +219,8 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
                 validateOnBlur
                 id="network_pod_cidr"
                 path="cluster.network_pod_cidr"
-                label={t('Pod CIDR')}
-                helperText={t('Subnet mask must allow for at least 32 nodes')}
+                label={n.podCidrLabel}
+                helperText={n.podCidrHelp}
                 disabled={defaultCidrValue}
               />
             </GridItem>
@@ -263,8 +229,8 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
                 validation={hostPrefixValidators}
                 validateOnBlur
                 path="cluster.network_host_prefix"
-                label={t('Host prefix')}
-                helperText={t('Must be between /23 and /26')}
+                label={n.hostPrefixLabel}
+                helperText={n.hostPrefixHelp}
                 disabled={defaultCidrValue}
               />
             </GridItem>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
@@ -37,7 +37,7 @@ import {
 import { Indented } from '@patternfly-labs/react-form-wizard/components/Indented';
 import links from '../../../externalLinks';
 import ExternalLink from '../../../common/ExternalLink';
-import { useRosaWizardStrings } from '../../../RosaWizardStringsContext';
+import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 
 type NetworkingAndSubnetsSubStepProps = {
   vpcList: Resource<VPC[]>;
@@ -46,6 +46,7 @@ type NetworkingAndSubnetsSubStepProps = {
 
 export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepProps) => {
   const n = useRosaWizardStrings().networking;
+  const v = useRosaWizardValidators();
   const { cluster } = useItem<RosaWizardFormData>();
   const { setIsClusterWideProxySelected } = props;
   const { update } = useData();
@@ -74,35 +75,36 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
 
   const selectedSubnets = constructSelectedSubnets(cluster);
 
-  const machineDisjointSubnets = disjointSubnets('network_machine_cidr');
-  const serviceDisjointSubnets = disjointSubnets('network_service_cidr');
-  const podDisjointSubnets = disjointSubnets('network_pod_cidr');
-  const awsServiceSubnetMask = awsSubnetMask('network_service_cidr');
+  const machineDisjointSubnets = disjointSubnets('network_machine_cidr', v.disjointSubnets);
+  const serviceDisjointSubnets = disjointSubnets('network_service_cidr', v.disjointSubnets);
+  const podDisjointSubnets = disjointSubnets('network_pod_cidr', v.disjointSubnets);
+  const awsServiceSubnetMask = awsSubnetMask('network_service_cidr', v.serviceCidr);
 
-  const hostPrefixValidators = (value: string) => hostPrefix(value);
-  const cidrValidators = (value: string) => cidr(value) || validateRange(value) || undefined;
+  const hostPrefixValidators = (value: string) => hostPrefix(value, v.hostPrefix);
+  const cidrValidators = (value: string) =>
+    cidr(value, v.cidr) || validateRange(value, v.validateRange, v.cidr) || undefined;
 
   const machineCidrValidators = (value: string) =>
     cidrValidators(value) ||
-    awsMachineCidr(value, cluster) ||
-    validateRange(value) ||
-    subnetCidrs(value, cluster, 'network_machine_cidr', selectedSubnets) ||
+    awsMachineCidr(value, cluster, v.awsMachineCidr) ||
+    validateRange(value, v.validateRange, v.cidr) ||
+    subnetCidrs(value, cluster, 'network_machine_cidr', selectedSubnets, v.subnetCidrs) ||
     machineDisjointSubnets(value, cluster) ||
     undefined;
 
   const serviceCidrValidators = (value: string) =>
     cidrValidators(value) ||
-    serviceCidr(value) ||
+    serviceCidr(value, v.serviceCidr) ||
     serviceDisjointSubnets(value, cluster) ||
     awsServiceSubnetMask(value) ||
-    subnetCidrs(value, cluster, 'network_service_cidr', selectedSubnets) ||
+    subnetCidrs(value, cluster, 'network_service_cidr', selectedSubnets, v.subnetCidrs) ||
     undefined;
 
   const podCidrValidators = (value: string) =>
     cidrValidators(value) ||
-    podCidr(value, cluster?.network_host_prefix) ||
+    podCidr(value, cluster?.network_host_prefix, v.podCidr) ||
     podDisjointSubnets(value, cluster) ||
-    subnetCidrs(value, cluster, 'network_pod_cidr', selectedSubnets) ||
+    subnetCidrs(value, cluster, 'network_pod_cidr', selectedSubnets, v.subnetCidrs) ||
     undefined;
 
   return (
@@ -117,7 +119,7 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
             id="public"
             label={n.publicLabel}
             value="external"
-            popover={<LabelHelp id="subnet-label-help" labelHelp={n.publicPopover} />}
+            popover={<LabelHelp id="subnet-label-help-public" labelHelp={n.publicPopover} />}
           >
             <WizSelect
               label={n.publicSubnetLabel}
@@ -138,7 +140,7 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
             id="private"
             label={n.privateLabel}
             value="internal"
-            popover={<LabelHelp id="subnet-label-help" labelHelp={n.privatePopover} />}
+            popover={<LabelHelp id="subnet-label-help-private" labelHelp={n.privatePopover} />}
           ></Radio>
         </WizRadioGroup>
       </Section>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.spec-helpers.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.spec-helpers.tsx
@@ -7,7 +7,7 @@ import {
 import { ItemContext } from '@patternfly-labs/react-form-wizard/contexts/ItemContext';
 import { ShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ShowValidationProvider';
 import { ValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ValidationProvider';
-import { TranslationProvider } from '../../../../../../context/TranslationContext';
+import { RosaWizardStringsProvider } from '../../../RosaWizardStringsContext';
 import { OIDCConfig, Resource, Role } from '../../../../types';
 import { RolesAndPoliciesSubStep } from './RolesAndPoliciesSubStep';
 import {
@@ -60,7 +60,7 @@ export const RolesAndPoliciesSubStepMount = ({
   }, []);
 
   return (
-    <TranslationProvider>
+    <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
         <DisplayModeContext.Provider value={DisplayMode.Step}>
           <ItemContext.Provider value={data}>
@@ -72,6 +72,6 @@ export const RolesAndPoliciesSubStepMount = ({
           </ItemContext.Provider>
         </DisplayModeContext.Provider>
       </DataContext.Provider>
-    </TranslationProvider>
+    </RosaWizardStringsProvider>
   );
 };

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { RolesAndPoliciesSubStep } from './RolesAndPoliciesSubStep';
-import { TranslationProvider } from '../../../../../../context/TranslationContext';
+import { RosaWizardStringsProvider } from '../../../RosaWizardStringsContext';
 import { ItemContext } from '@patternfly-labs/react-form-wizard/contexts/ItemContext';
 import { DataContext } from '@patternfly-labs/react-form-wizard/contexts/DataContext';
 import {
@@ -98,7 +98,7 @@ export const RolesAndPoliciesSubStepStory: React.FC<RolesAndPoliciesSubStepStory
   }, []);
 
   return (
-    <TranslationProvider>
+    <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
         <DisplayModeContext.Provider value={DisplayMode.Step}>
           <ItemContext.Provider value={data}>
@@ -110,6 +110,6 @@ export const RolesAndPoliciesSubStepStory: React.FC<RolesAndPoliciesSubStepStory
           </ItemContext.Provider>
         </DisplayModeContext.Provider>
       </DataContext.Provider>
-    </TranslationProvider>
+    </RosaWizardStringsProvider>
   );
 };

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
@@ -17,11 +17,11 @@ import React from 'react';
 import PopoverHintWithTitle from '../../../common/PopoverHitWithTitle';
 import { OIDCConfigHint } from '../../../common/OIDCConfigHint';
 import { OIDCConfig, Resource, Role } from '../../../../types';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import { validateCustomOperatorRolesPrefix } from '../../../validators';
 import { createOperatorRolesPrefix } from '../../../helpers';
 import ExternalLink from '../../../common/ExternalLink';
 import links from '../../../externalLinks';
+import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 
 type RolesAndPoliciesSubStepProps = {
   roles: Resource<Role[], [awsAccount: string]> & {
@@ -34,8 +34,10 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
   roles,
   oidcConfig,
 }) => {
-  const installerRoles = roles.data.map((roleSet) => roleSet.installerRole);
-  const { t } = useTranslation();
+const installerRoles = roles.data.map((roleSet) => roleSet.installerRole); 
+const rp = useRosaWizardStrings().rolesAndPolicies;
+  const v = useRosaWizardValidators();
+
   const [isOperatorRolesOpen, setIsOperatorRolesOpen] = React.useState<boolean>(true);
   const [isArnsOpen, setIsArnsOpen] = React.useState<boolean>(false);
   const { cluster } = useItem();
@@ -107,13 +109,13 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
 
   return (
     <>
-      <Section label={t('Account roles')}>
+      <Section label={rp.accountRolesSection}>
         <Grid>
           <GridItem span={7}>
             <WizSelect
               isFill
               path="cluster.installer_role_arn"
-              label={t('Installer role')}
+              label={rp.installerRoleLabel}
               disabled={roles.isFetching}
               onValueChange={(installerRoleArn, _item) => {
                 if (installerRoleArn) {
@@ -128,12 +130,12 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
                 }
                 update();
               }}
-              placeholder={t('Select an Installer role')}
+              placeholder={rp.installerPlaceholder}
               labelHelp={
                 <>
-                  {t('An AWS IAM role used by the ROSA installer')}{' '}
+                  {rp.installerHelpLead}{' '}
                   <ExternalLink href={links.ROSA_ROLES_LEARN_MORE}>
-                    Learn more about roles.
+                    {rp.installerLearnMoreLink}
                   </ExternalLink>
                 </>
               }
@@ -145,18 +147,16 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
         <ExpandableSection
           isExpanded={isArnsOpen}
           onToggle={() => setIsArnsOpen(!isArnsOpen)}
-          toggleText={t('Amazon Resource Names (ARNs)')}
+          toggleText={rp.arnsToggle}
         >
           <Grid hasGutter>
             <GridItem span={7}>
               <WizSelect
                 isFill
                 path="cluster.support_role_arn"
-                label={t('Support role')}
-                placeholder={t('Select a support role')}
-                labelHelp={t(
-                  'An IAM role used by the Red Hat Site Reliability Engineering (SRE) support team. The role is used with the corresponding policy resource to provide the Red Hat SRE support team with the permissions required to support ROSA clusters.'
-                )}
+                label={rp.supportRoleLabel}
+                placeholder={rp.supportPlaceholder}
+                labelHelp={rp.supportHelp}
                 options={supportRoles}
                 disabled={roles.isFetching}
                 required
@@ -166,11 +166,9 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
               <WizSelect
                 isFill
                 path="cluster.worker_role_arn"
-                label={t('Worker role')}
-                placeholder={t('Select a worker role')}
-                labelHelp={t(
-                  'An IAM role used by the ROSA compute instances. The role is used with the corresponding policy resource to provide the compute instances with the permissions required to manage their components.'
-                )}
+                label={rp.workerRoleLabel}
+                placeholder={rp.workerPlaceholder}
+                labelHelp={rp.workerHelp}
                 options={workerRoles}
                 disabled={roles.isFetching}
                 required
@@ -179,7 +177,7 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
           </Grid>
         </ExpandableSection>
       </Section>
-      <Section label="Operator roles">
+      <Section label={rp.operatorRolesSection}>
         <Grid>
           <GridItem span={7}>
             <Stack>
@@ -187,12 +185,10 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
                 <WizSelect
                   isFill
                   path="cluster.byo_oidc_config_id"
-                  label={t('OIDC config ID')}
+                  label={rp.oidcLabel}
                   required
-                  placeholder={t('Select an OIDC config ID')}
-                  labelHelp={t(
-                    'The OIDC configuration ID created by running the command: rosa create oidc-config'
-                  )}
+                  placeholder={rp.oidcPlaceholder}
+                  labelHelp={rp.oidcHelp}
                   options={oidcConfig.data.map((config) => ({
                     label: config.label,
                     value: config.value,
@@ -204,7 +200,7 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
               <StackItem>
                 <PopoverHintWithTitle
                   displayHintIcon
-                  title={t('Create a new OIDC config id')}
+                  title={rp.oidcPopoverTitle}
                   bodyContent={<OIDCConfigHint />}
                 />
               </StackItem>
@@ -215,36 +211,36 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
         <ExpandableSection
           isExpanded={isOperatorRolesOpen}
           onToggle={() => setIsOperatorRolesOpen(!isOperatorRolesOpen)}
-          toggleText={t('Operator role prefix')}
+          toggleText={rp.operatorPrefixToggle}
         >
           <Grid>
             <GridItem span={4}>
               <WizTextInput
-                validation={validateCustomOperatorRolesPrefix}
+                validation={(value, item) =>
+                  validateCustomOperatorRolesPrefix(value, item, v.operatorRolesPrefix)
+                }
                 path="cluster.custom_operator_roles_prefix"
                 validateOnBlur
-                label={t('Operator roles prefix')}
+                label={rp.operatorPrefixLabel}
                 labelHelp={
                   <>
-                    {t('You can specify a custom prefix for the Operator AWS IAM roles.')}{' '}
+                    {rp.operatorPrefixHelpLead}{' '}
                     <ExternalLink href={links.ROSA_OIDC_LEARN_MORE}>
-                      Learn more and see examples.
+                      {rp.operatorPrefixLearnMoreLink}
                     </ExternalLink>
                   </>
                 }
-                helperText={t(
-                  '32 characters maximum. This is autogenerated by the cluster name, but you can cahnge it.'
-                )}
+                helperText={rp.operatorPrefixHelper}
                 required
               />
             </GridItem>
           </Grid>
           <ClipboardCopy
             variant="expansion"
-            copyAriaLabel="Copy read-only example"
+            copyAriaLabel={rp.clipboardCopyAria}
             isReadOnly
-            hoverTip={t('Copy')}
-            clickTip={t('Copied')}
+            hoverTip={rp.copyHover}
+            clickTip={rp.copyClicked}
             style={{ marginTop: '1rem' }}
           >
             {rosaCommand}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
@@ -34,8 +34,8 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
   roles,
   oidcConfig,
 }) => {
-const installerRoles = roles.data.map((roleSet) => roleSet.installerRole); 
-const rp = useRosaWizardStrings().rolesAndPolicies;
+  const installerRoles = roles.data.map((roleSet) => roleSet.installerRole);
+  const rp = useRosaWizardStrings().rolesAndPolicies;
   const v = useRosaWizardValidators();
 
   const [isOperatorRolesOpen, setIsOperatorRolesOpen] = React.useState<boolean>(true);

--- a/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/ReviewStepData.tsx
@@ -14,15 +14,15 @@ import {
 import { LockIcon } from '@patternfly/react-icons';
 import { ReviewAndCreateStepItem } from './ReviewAndCreateStep/ReviewAndCreateStepItem';
 import { MachinePoolsReviewAndCreateStepItem } from './ReviewAndCreateStep/MachinePoolsReviewAndCreateStepItem';
-import { useTranslation } from '../../../../context/TranslationContext';
 import { RosaWizardFormData, WizardNavigationContext } from '../../types';
+import { useRosaWizardStrings } from '../RosaWizardStringsContext';
 
 type ReviewStepDataProps = {
   goToStepId?: WizardNavigationContext;
 };
 
 export const ReviewStepData = (props: ReviewStepDataProps) => {
-  const { t } = useTranslation();
+  const r = useRosaWizardStrings().review;
   const { cluster } = useItem<RosaWizardFormData>();
 
   const [isDetailsSectionExpanded, setIsDetailsSectionExpanded] = React.useState<boolean>(true);
@@ -60,12 +60,12 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
   ]);
 
   return (
-    <Section label={t('Review your ROSA cluster')}>
+    <Section label={r.sectionLabel}>
       <Alert
         variant="info"
         title={
           <>
-            {t(`Double check your settings. Locked settings can not be changed later.`)}
+            {r.alertTitle}
             <LockIcon />
           </>
         }
@@ -79,32 +79,28 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             isWidthLimited
             isExpanded={isDetailsSectionExpanded}
             onToggle={() => setIsDetailsSectionExpanded(!isDetailsSectionExpanded)}
-            toggleText={t('Details')}
+            toggleText={r.detailsToggle}
           >
-            {/* START DETAILS DISPLAY */}
-
             <Stack hasGutter>
-              <ReviewAndCreateStepItem label={t('Cluster name')} value={cluster?.name} />
+              <ReviewAndCreateStepItem label={r.clusterName} value={cluster?.name} />
               <ReviewAndCreateStepItem
-                label={t('OpenShift version')}
+                label={r.openShiftVersion}
                 value={cluster?.cluster_version}
               />
               <ReviewAndCreateStepItem
-                label={t('Associated AWS infrastructure account')}
+                label={r.awsInfra}
                 value={cluster?.associated_aws_id}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('AWS billing account')}
+                label={r.awsBilling}
                 value={cluster?.billing_account_id}
                 hasIcon
               />
 
-              <ReviewAndCreateStepItem label={t('Region')} value={cluster?.region} hasIcon />
+              <ReviewAndCreateStepItem label={r.region} value={cluster?.region} hasIcon />
             </Stack>
-
-            {/* END DETAILS DISPLAY */}
           </ExpandableSection>
         </SplitItem>
         <SplitItem>
@@ -113,7 +109,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             variant="link"
             isInline
           >
-            {t(`Edit Step`)}
+            {r.editStep}
           </Button>
         </SplitItem>
       </Split>
@@ -125,23 +121,23 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             isWidthLimited
             isExpanded={isRolesAndPoliciesExpanded}
             onToggle={() => setIsRolesAndPoliciesExpanded(!isRolesAndPoliciesExpanded)}
-            toggleText="Roles and policies"
+            toggleText={r.rolesToggle}
           >
             <Stack hasGutter>
               <ReviewAndCreateStepItem
-                label={t('Installer role')}
+                label={r.installerRole}
                 value={cluster?.installer_role_arn}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('OIDC Config ID')}
+                label={r.oidcConfigId}
                 value={cluster?.byo_oidc_config_id}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('Operator roles prefix')}
+                label={r.operatorPrefix}
                 value={cluster?.custom_operator_roles_prefix}
                 hasIcon
               />
@@ -155,7 +151,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             variant="link"
             isInline
           >
-            {t(`Edit Step`)}
+            {r.editStep}
           </Button>
         </SplitItem>
       </Split>
@@ -167,33 +163,30 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             isWidthLimited
             isExpanded={isNetworkingAndSubnetsExpanded}
             onToggle={() => setIsNetworkingAndSubnetsExpanded(!isNetworkingAndSubnetsExpanded)}
-            toggleText={t('Networking and subnets')}
+            toggleText={r.networkingToggle}
           >
             <Stack hasGutter>
               {cluster?.cluster_privacy === 'external' && (
                 <ReviewAndCreateStepItem
-                  label={t('Public subnet name')}
+                  label={r.publicSubnet}
                   value={cluster?.cluster_privacy_public_subnet_id}
                   hasIcon
                 />
               )}
 
               <ReviewAndCreateStepItem
-                label={t('Install to selected VPC')}
+                label={r.installVpc}
                 value={cluster?.selected_vpc?.name}
                 hasIcon
               />
 
-              <ReviewAndCreateStepItem
-                label={t('Compute node instance type')}
-                value={cluster?.machine_type}
-              />
+              <ReviewAndCreateStepItem label={r.instanceType} value={cluster?.machine_type} />
 
               <ReviewAndCreateStepItem
-                label={t('Compute node count')}
+                label={r.computeCount}
                 value={
                   cluster?.autoscaling
-                    ? `Min: ${cluster?.min_replicas} Max: ${cluster?.max_replicas}`
+                    ? `${r.autoscalingMinPrefix} ${cluster?.min_replicas} ${r.autoscalingMaxPrefix} ${cluster?.max_replicas}`
                     : cluster?.nodes_compute
                 }
               />
@@ -201,7 +194,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
               <Stack hasGutter>
                 <StackItem>
                   <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-                    <FlexItem>{t(`Machine pools`)}</FlexItem>
+                    <FlexItem>{r.machinePoolsHeading}</FlexItem>
                     <FlexItem>
                       <LockIcon />
                     </FlexItem>
@@ -232,7 +225,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             variant="link"
             isInline
           >
-            {t(`Edit Step`)}
+            {r.editStep}
           </Button>
         </SplitItem>
       </Split>
@@ -244,17 +237,17 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             isIndented
             isExpanded={isEncryptionExpanded}
             onToggle={() => setIsEncryptionExpanded(!isEncryptionExpanded)}
-            toggleText={t('Encryption (optional)')}
+            toggleText={r.encryptionToggle}
           >
             <Stack hasGutter>
               <ReviewAndCreateStepItem
-                label={t('Additional etcd encryption')}
+                label={r.additionalEtcd}
                 value={cluster?.etcd_encryption}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('Encryption keys')}
+                label={r.encryptionKeys}
                 value={cluster?.encryption_keys}
                 hasIcon
               />
@@ -267,7 +260,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             variant="link"
             isInline
           >
-            {t(`Edit Step`)}
+            {r.editStep}
           </Button>
         </SplitItem>
       </Split>
@@ -279,29 +272,29 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             isIndented
             isExpanded={isOptionalNetworkingExpanded}
             onToggle={() => setIsOptionalNetworkingExpanded(!isOptionalNetworkingExpanded)}
-            toggleText={t('Networking (optional)')}
+            toggleText={r.optionalNetworkingToggle}
           >
             <Stack hasGutter>
               <ReviewAndCreateStepItem
-                label={t('Machine CIDR')}
+                label={r.machineCidr}
                 value={cluster?.network_machine_cidr}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('Service CIDR')}
+                label={r.serviceCidr}
                 value={cluster?.network_service_cidr}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('Pod CIDR')}
+                label={r.podCidr}
                 value={cluster?.network_pod_cidr}
                 hasIcon
               />
 
               <ReviewAndCreateStepItem
-                label={t('Host prefix')}
+                label={r.hostPrefix}
                 value={cluster?.network_host_prefix}
                 hasIcon
               />
@@ -314,7 +307,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             variant="link"
             isInline
           >
-            {t(`Edit Step`)}
+            {r.editStep}
           </Button>
         </SplitItem>
       </Split>
@@ -328,13 +321,13 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             onToggle={() =>
               setIsOptionalClusterUpgradesExpanded(!isOptionalClusterUpgradesExpanded)
             }
-            toggleText={t('Cluster updates (optional)')}
+            toggleText={r.clusterUpdatesToggle}
           >
             <Stack hasGutter>
               <ReviewAndCreateStepItem
-                label={t('Cluster update strategy')}
+                label={r.updateStrategy}
                 value={
-                  cluster?.upgrade_policy === 'manual' ? 'Individual updates' : 'Automatic updates'
+                  cluster?.upgrade_policy === 'manual' ? r.strategyIndividual : r.strategyAutomatic
                 }
                 hasIcon
               />
@@ -350,7 +343,7 @@ export const ReviewStepData = (props: ReviewStepDataProps) => {
             variant="link"
             isInline
           >
-            {t(`Edit Step`)}
+            {r.editStep}
           </Button>
         </SplitItem>
       </Split>

--- a/src/components/Wizards/RosaWizard/common/AccountRoles.tsx
+++ b/src/components/Wizards/RosaWizard/common/AccountRoles.tsx
@@ -2,17 +2,19 @@ import { Alert, AlertVariant, Content, ContentVariants } from '@patternfly/react
 import { CopyInstruction } from './CopyInstruction';
 import ExternalLink from './ExternalLink';
 import links from '../externalLinks';
+import { useRosaWizardStrings } from '../RosaWizardStringsContext';
 
 export const AccountRoles = () => {
+  const a = useRosaWizardStrings().accountRoles;
+
   return (
     <>
       <Content component={ContentVariants.p} className="pf-v6-u-mb-lg">
-        To create the necessary account-wide roles and policies quickly, use the default auto method
-        that&apos;s provided by the ROSA CLI.
+        {a.intro}
       </Content>
       <CopyInstruction
         data-testId="copy-rosa-create-account-role"
-        textAriaLabel={`Copyable ROSA rosa create account-roles --hosted-cp --mode auto command`}
+        textAriaLabel={a.copyAriaAccountRoles}
         className="pf-v6-u-mb-lg"
       >
         rosa create account-roles --hosted-cp --mode auto
@@ -25,10 +27,9 @@ export const AccountRoles = () => {
         className="pf-v6-u-mb-lg"
         title={
           <>
-            If you would prefer to manually create the required roles and policies within your AWS
-            account, then follow{' '}
+            {a.manualInstructionsLead}{' '}
             <ExternalLink href={links.AWS_CLI_GETTING_STARTED_MANUAL}>
-              these instructions
+              {a.manualInstructionsLink}
             </ExternalLink>
             .
           </>

--- a/src/components/Wizards/RosaWizard/common/OCMRole.tsx
+++ b/src/components/Wizards/RosaWizard/common/OCMRole.tsx
@@ -2,12 +2,15 @@ import { Alert, AlertVariant, Content, ContentVariants, Title } from '@patternfl
 import { CopyInstruction } from './CopyInstruction';
 import { TabGroup } from './TabGroup';
 import PopoverHintWithTitle from './PopoverHitWithTitle';
+import { useRosaWizardStrings } from '../RosaWizardStringsContext';
 
 export const OCMRole = () => {
+  const o = useRosaWizardStrings().ocmRole;
+
   return (
     <>
       <Title headingLevel="h3" className="pf-v6-u-mb-md" size="md">
-        First, check if a role exists and is linked with:
+        {o.checkLinkedTitle}
       </Title>
 
       <CopyInstruction>rosa list ocm-role</CopyInstruction>
@@ -16,12 +19,12 @@ export const OCMRole = () => {
         variant={AlertVariant.info}
         isInline
         isPlain
-        title={`If there is an existing role and it's already linked to your Red Hat account, you can continue to step 2.`}
+        title={o.existingLinkedInfo}
         className="pf-v6-u-mb-lg"
       />
 
       <Title headingLevel="h3" size="md">
-        Next, is there an existing role that isn&apos;t linked?
+        {o.unlinkedTitle}
       </Title>
 
       <TabGroup
@@ -29,18 +32,18 @@ export const OCMRole = () => {
           {
             'data-testid': 'copy-ocm-role-tab-no',
             id: 'copy-ocm-role-tab-no-id',
-            title: 'No, create new role',
+            title: o.tabCreateNew,
             body: (
               <>
-                <strong>Basic OCM role</strong>
+                <strong>{o.basicOcmRoleLabel}</strong>
                 <CopyInstruction
                   data-testid="copy-rosa-create-ocm-role"
                   textAriaLabel="Copyable ROSA create ocm-role"
                 >
                   rosa create ocm-role
                 </CopyInstruction>
-                <div className="pf-v6-u-mt-md pf-v6-u-mb-md">OR</div>
-                <strong>Admin OCM role</strong>
+                <div className="pf-v6-u-mt-md pf-v6-u-mb-md">{o.orDivider}</div>
+                <strong>{o.adminOcmRoleLabel}</strong>
                 <CopyInstruction
                   data-testid="copy-rosa-create-ocm-admin-role"
                   textAriaLabel="Copyable ROSA create ocm-role --admin"
@@ -48,19 +51,13 @@ export const OCMRole = () => {
                   rosa create ocm-role --admin
                 </CopyInstruction>
                 <PopoverHintWithTitle
-                  title="Help me decide"
+                  title={o.helpDecideTitle}
                   bodyContent={
                     <>
                       <Content component={ContentVariants.p} className="pf-v6-u-mb-md">
-                        The <strong>basic role</strong> enables OpenShift Cluster Manager to detect
-                        the AWS IAM roles and policies required by ROSA.
+                        {o.helpBasicBody}
                       </Content>
-                      <Content component={ContentVariants.p}>
-                        The <strong>admin role</strong> also enables the detection of the roles and
-                        policies. In addition, the admin role enables automatic deployment of the
-                        cluster-specific Operator roles and OpenID Connect (OIDC) provider by using
-                        OpenShift Cluster Manager.
-                      </Content>
+                      <Content component={ContentVariants.p}>{o.helpAdminBody}</Content>
                     </>
                   }
                 />
@@ -70,10 +67,10 @@ export const OCMRole = () => {
           {
             'data-testid': 'copy-ocm-role-tab-yes',
             id: 'copy-ocm-role-tab-yes-id',
-            title: 'Yes, link existing role',
+            title: o.tabLinkExisting,
             body: (
               <>
-                <strong> If a role exists but is not linked, link it with:</strong>
+                <strong>{o.linkExistingLead}</strong>
                 <CopyInstruction
                   data-testid="copy-rosa-link-ocm-role"
                   textAriaLabel={`Copyable rosa link ocm-role <arn> command`}
@@ -85,7 +82,7 @@ export const OCMRole = () => {
                   isInline
                   isPlain
                   className="ocm-instruction-block_alert pf-v6-u-mt-lg"
-                  title="You must have organization administrator privileges in your Red Hat account to run this command. After you link the OCM role with your Red Hat organization, it is visible for all users in the organization."
+                  title={o.orgAdminInfo}
                 />
               </>
             ),

--- a/src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx
+++ b/src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx
@@ -1,16 +1,13 @@
 import { ClipboardCopyVariant, Content, ContentVariants } from '@patternfly/react-core';
 import { CopyInstruction } from './CopyInstruction';
-import { useTranslation } from '../../../../context/TranslationContext';
+import { useRosaWizardStrings } from '../RosaWizardStringsContext';
 
 export const OIDCConfigHint = () => {
-  const { t } = useTranslation();
+  const { oidcHint } = useRosaWizardStrings();
+
   return (
     <>
-      <Content component={ContentVariants.p}>
-        {t(
-          'Create a new OIDC config ID by running the following commands in your CLI. Then, refresh and select the new config ID from the dropdown.'
-        )}
-      </Content>
+      <Content component={ContentVariants.p}>{oidcHint.instructions}</Content>
       <CopyInstruction variant={ClipboardCopyVariant.expansion}>
         rosa login --use-auth-code --url https://api.stage.openshift.com
         {/* TODO: This should be at least production */}

--- a/src/components/Wizards/RosaWizard/common/StepDrawer.tsx
+++ b/src/components/Wizards/RosaWizard/common/StepDrawer.tsx
@@ -18,6 +18,7 @@ import { AssociateAWSAccountInfo } from './AssociateAWSAccountInfo';
 import { OCMRole } from './OCMRole';
 import { UserRole } from './UserRole';
 import { AccountRoles } from './AccountRoles';
+import { useRosaWizardStrings } from '../RosaWizardStringsContext';
 
 type StepDrawerProps = {
   isDrawerExpanded: boolean;
@@ -28,13 +29,14 @@ type StepDrawerProps = {
 
 export const StepDrawer = (props: StepDrawerProps) => {
   const { isDrawerExpanded, onWizardExpand, setIsDrawerExpanded } = props;
+  const d = useRosaWizardStrings().associateAwsDrawer;
   return (
     <Drawer isInline isExpanded={isDrawerExpanded} onExpand={onWizardExpand}>
       <DrawerContent
         panelContent={
           <DrawerPanelContent isResizable={true} defaultSize="40%">
             <DrawerHead>
-              <Content component={ContentVariants.h2}>How to associate a new AWS account</Content>
+              <Content component={ContentVariants.h2}>{d.panelTitle}</Content>
               <DrawerActions>
                 <DrawerCloseButton onClick={() => setIsDrawerExpanded(false)} />
               </DrawerActions>
@@ -43,35 +45,28 @@ export const StepDrawer = (props: StepDrawerProps) => {
               <PageSection hasBodyWrapper={false}>
                 <Stack hasGutter>
                   <StackItem>
-                    <Content component={ContentVariants.p}>
-                      ROSA cluster deployments use the AWS Security Token Service for added
-                      security. Run the following required steps from a CLI authenticated with both
-                      AWS and ROSA.
-                    </Content>
-                    <Content component={ContentVariants.p}>
-                      You must use ROSA CLI version 1.2.31 or above.
-                    </Content>
+                    <Content component={ContentVariants.p}>{d.introSts}</Content>
+                    <Content component={ContentVariants.p}>{d.cliVersion}</Content>
                   </StackItem>
                   <StackItem>
-                    <AssociateAWSAccountInfo title="Step 1: OCM Role" initiallyExpanded>
+                    <AssociateAWSAccountInfo title={d.step1Title} initiallyExpanded>
                       <OCMRole />
                     </AssociateAWSAccountInfo>
                   </StackItem>
                   <StackItem>
-                    <AssociateAWSAccountInfo title="Step 2: User Role">
+                    <AssociateAWSAccountInfo title={d.step2Title}>
                       <UserRole />
                     </AssociateAWSAccountInfo>
                   </StackItem>
                   <StackItem>
-                    <AssociateAWSAccountInfo title="Step 3: User Role">
+                    <AssociateAWSAccountInfo title={d.step3Title}>
                       <AccountRoles />
                     </AssociateAWSAccountInfo>
                   </StackItem>
 
                   <StackItem>
                     <Content component={ContentVariants.p} className="pf-v6-u-mr-md">
-                      After you&apos;ve completed all the steps, close this guide and choose your
-                      account.
+                      {d.closingPrompt}
                     </Content>
                   </StackItem>
                   <StackItem>
@@ -79,7 +74,7 @@ export const StepDrawer = (props: StepDrawerProps) => {
                       variant={ButtonVariant.secondary}
                       onClick={() => setIsDrawerExpanded(false)}
                     >
-                      Close
+                      {d.closeButton}
                     </Button>
                   </StackItem>
                 </Stack>

--- a/src/components/Wizards/RosaWizard/common/UserRole.tsx
+++ b/src/components/Wizards/RosaWizard/common/UserRole.tsx
@@ -5,17 +5,20 @@ import PopoverHint from './PopoverHint';
 import ExternalLink from './ExternalLink';
 import links from '../externalLinks';
 import PopoverHintWithTitle from './PopoverHitWithTitle';
+import { useRosaWizardStrings } from '../RosaWizardStringsContext';
 
 export const UserRole = () => {
+  const u = useRosaWizardStrings().userRole;
+
   return (
     <>
       <Title headingLevel="h3" className="pf-v6-u-mb-md" size="md">
-        First, check if a role exists and is linked with:
+        {u.checkLinkedTitle}
       </Title>
 
       <CopyInstruction
         data-testId="copy-rosa-list-user-role"
-        textAriaLabel={`Copyable ROSA rosa list user-role command`}
+        textAriaLabel={u.copyAriaListUserRole}
         className="pf-v6-u-mb-lg"
       >
         rosa list user-role
@@ -25,21 +28,19 @@ export const UserRole = () => {
         variant={AlertVariant.info}
         isInline
         isPlain
-        title={`If there is an existing role and it's already linked to your Red Hat account, you can continue to step 3`}
+        title={u.existingLinkedInfo}
         className="pf-v6-u-mb-lg"
       />
 
-      <Content component={ContentVariants.h3}>
-        Next, is there an existing role that isn&apos;t linked?
-      </Content>
+      <Content component={ContentVariants.h3}>{u.unlinkedTitle}</Content>
 
       <PopoverHintWithTitle
-        title="Why do I need to link my account?"
+        title={u.whyLinkTitle}
         bodyContent={
           <>
-            The link creates a trust policy between the role and the link cluster installer.{' '}
+            {u.whyLinkBodyPrefix}{' '}
             <ExternalLink href={links.ROSA_AWS_ACCOUNT_ASSOCIATION}>
-              Review the AWS policy permissions for the basic and admin OCM roles.
+              {u.reviewPermissionsLink}
             </ExternalLink>
           </>
         }
@@ -50,11 +51,11 @@ export const UserRole = () => {
           {
             'data-testid': 'copy-user-role-tab-no',
             id: 'copy-user-role-tab-no-id',
-            title: 'No, create new role',
+            title: u.tabCreateNew,
             body: (
               <>
-                <strong>User role </strong>
-                <PopoverHint bodyContent="The user role is necessary to validate that your Red Hat user account has permissions to install a cluster in the AWS account." />
+                <strong>{u.userRoleLabel}</strong>
+                <PopoverHint bodyContent={u.userRolePopover} />
                 <CopyInstruction
                   data-testid="copy-rosa-create-user-role"
                   textAriaLabel="Copyable ROSA create user-role"
@@ -67,11 +68,11 @@ export const UserRole = () => {
           {
             'data-testid': 'copy-user-role-tab-yes',
             id: 'copy-user-role-tab-yes-id',
-            title: 'Yes, link existing role',
+            title: u.tabLinkExisting,
             body: (
               <CopyInstruction
                 data-testid="copy-rosa-link-user-role"
-                textAriaLabel="Copyable ROSA link user-role --arn"
+                textAriaLabel={u.copyAriaLinkUserRole}
               >
                 {`rosa link user-role <arn>`}
               </CopyInstruction>

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
@@ -144,11 +144,11 @@ export const defaultRosaWizardStrings: RosaWizardStrings = {
     installerLearnMoreLink: 'Learn more about roles.',
     arnsToggle: 'Amazon Resource Names (ARNs)',
     supportRoleLabel: 'Support role',
-    supportPlaceholder: 'Select an AWS infrastructure account',
+    supportPlaceholder: 'Select a support role',
     supportHelp:
       'An IAM role used by the Red Hat Site Reliability Engineering (SRE) support team. The role is used with the corresponding policy resource to provide the Red Hat SRE support team with the permissions required to support ROSA clusters.',
     workerRoleLabel: 'Worker role',
-    workerPlaceholder: 'Select an AWS infrastructure account',
+    workerPlaceholder: 'Select a worker role',
     workerHelp:
       'An IAM role used by the ROSA compute instances. The role is used with the corresponding policy resource to provide the compute instances with the permissions required to manage their components.',
     operatorRolesSection: 'Operator roles',

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
@@ -62,9 +62,9 @@ export const defaultRosaWizardStrings: RosaWizardStrings = {
     introSts:
       'ROSA cluster deployments use the AWS Security Token Service for added security. Run the following required steps from a CLI authenticated with both AWS and ROSA.',
     cliVersion: 'You must use ROSA CLI version 1.2.31 or above.',
-    step1Title: 'Step 1: OCM Role',
-    step2Title: 'Step 2: User Role',
-    step3Title: 'Step 3: User Role',
+    step1Title: 'Step 1: OCM role',
+    step2Title: 'Step 2: User role',
+    step3Title: 'Step 3: Account roles',
     closingPrompt:
       "After you've completed all the steps, close this guide and choose your account.",
     closeButton: 'Close',
@@ -134,7 +134,7 @@ export const defaultRosaWizardStrings: RosaWizardStrings = {
     regionLabel: 'Region',
     regionPlaceholder: 'Select a region',
     regionHelp:
-      'The AWS Region where your compute nodes and control plane will be located. (should be link: Learn more abut AWS Regions.)',
+      'The AWS Region where your compute nodes and control plane will be located. (should be link: Learn more about AWS Regions.)',
   },
   rolesAndPolicies: {
     accountRolesSection: 'Account roles',
@@ -253,6 +253,7 @@ export const defaultRosaWizardStrings: RosaWizardStrings = {
   securityGroups: {
     emptyTitle: 'There are no security groups for this Virtual Private Cloud',
     emptyBodyPrefix: 'To add security groups, go to the',
+    emptyBodySuffix: 'of your AWS console.',
     emptyConsoleLink: 'Security groups section',
     refreshLink: 'Refresh Security Groups',
     noEditTitle:
@@ -413,4 +414,60 @@ export const defaultRosaWizardValidatorStrings: RosaWizardValidatorStrings = {
     computeMinTwo: 'Input cannot be less than 2 nodes.',
   },
   proxyConfigureAtLeastOne: 'Configure at least one of the cluster-wide proxy fields.',
+  cidr: {
+    invalidNotation: (value: string) =>
+      `IP address range '${value}' isn't valid CIDR notation. It must follow the RFC-4632 format: '192.168.0.0/16'.`,
+  },
+  validateRange: {
+    notSubnetAddress:
+      'This is not a subnet address. The subnet prefix is inconsistent with the subnet mask.',
+  },
+  awsMachineCidr: {
+    maskTooLarge: (minMask: number) => `The subnet mask can't be larger than '/${minMask}'.`,
+    maskTooSmallMultiAz: (maxMask: number) =>
+      `The subnet mask can't be smaller than '/${maxMask}'.`,
+    maskTooSmallSingleAz: (maxMask: number) =>
+      `The subnet mask can't be smaller than '/${maxMask}'.`,
+  },
+  serviceCidr: {
+    maskTooSmall: (maxMask: number, maxServices: number) =>
+      `The subnet mask can't be smaller than '/${maxMask}', which provides up to ${maxServices} services.`,
+    subnetMaskBetween: (min: number, max: number) =>
+      `Subnet mask must be between /${min} and /${max}.`,
+    subnetMaskBetweenOneAnd: (max: number) => `Subnet mask must be between /1 and /${max}.`,
+  },
+  podCidr: {
+    maskTooSmall: (maxMask: number) => `The subnet mask can't be smaller than /${maxMask}.`,
+    notEnoughNodes: (prefixLength: number) =>
+      `The subnet mask of /${prefixLength} does not allow for enough nodes. Try changing the host prefix or the pod subnet range.`,
+  },
+  subnetCidrs: {
+    machineDoesNotIncludeStartIp: (startIp: string, subnetName: string) =>
+      `The Machine CIDR does not include the starting IP (${startIp}) of ${subnetName}`,
+    serviceOverlaps: (subnetName: string, cidrBlock: string) =>
+      `The Service CIDR overlaps with ${subnetName} CIDR '${cidrBlock}'`,
+    serviceIncludesStartIp: (startIp: string, subnetName: string) =>
+      `The Service CIDR includes the starting IP (${startIp}) of ${subnetName}`,
+    podOverlaps: (subnetName: string, cidrBlock: string) =>
+      `The Pod CIDR overlaps with ${subnetName} CIDR '${cidrBlock}'`,
+    podIncludesStartIp: (startIp: string, subnetName: string) =>
+      `The Pod CIDR includes the starting IP (${startIp}) of ${subnetName}`,
+  },
+  disjointSubnets: {
+    fieldLabelMachine: 'Machine CIDR',
+    fieldLabelService: 'Service CIDR',
+    fieldLabelPod: 'Pod CIDR',
+    overlap: (otherFieldLabelsCsv: string, plural: boolean) =>
+      `This subnet overlaps with the subnet${plural ? 's' : ''} in the ${otherFieldLabelsCsv} field${
+        plural ? 's' : ''
+      }.`,
+  },
+  hostPrefix: {
+    invalidMaskFormat: (value: string) =>
+      `The value '${value}' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'.`,
+    maskTooLarge: (maxPrefix: number, maxPodIPs: number) =>
+      `The subnet mask can't be larger than '/${maxPrefix}', which provides up to ${maxPodIPs} Pod IP addresses.`,
+    maskTooSmall: (minPrefix: number, maxPodIPs: number) =>
+      `The subnet mask can't be smaller than '/${minPrefix}', which provides up to ${maxPodIPs} Pod IP addresses.`,
+  },
 };

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
@@ -1,0 +1,416 @@
+/**
+ * Default English strings for RosaWizard (UI copy + validation messages).
+ *
+ * **Library usage:** `RosaWizard` merges these with any `strings` prop you pass; you do not need
+ * to import this file unless you want the full default object.
+ *
+ * **App localization workflow:**
+ * 1. Copy this file into your app (e.g. `myRosaWizardStrings.en.ts`).
+ * 2. Replace string values with translations; keep the same keys and structure.
+ * 3. For validator entries that are functions (`invalidFormat`, `maxExceeded`, etc.), keep the
+ *    same signatures so validation still interpolates values correctly.
+ * 4. Pass your object (or `mergeRosaWizardStrings(yourPartial)` from `rosaWizardStrings`) into
+ *    `<RosaWizard strings={...} />` or spread partial overrides only.
+ *
+ * Types: import type { RosaWizardStrings, RosaWizardValidatorStrings } from './rosaWizardStrings.types'
+ * (or from the package barrel that re-exports them).
+ */
+
+import type { RosaWizardStrings, RosaWizardValidatorStrings } from './rosaWizardStrings.types';
+
+const defaultOperatorPrefixInvalid = (label: string, value: string) =>
+  `${label} '${value}' isn't valid, must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character. For example, 'my-name', or 'abc-123'.`;
+
+const defaultOperatorPrefixTooLong = (label: string, max: number) =>
+  `${label} may not exceed ${max} characters.`;
+
+const defaultNoProxyInvalid = (domains: string, plural: boolean) =>
+  `The domain${plural ? 's' : ''} '${domains}' ${plural ? "aren't" : "isn't"} valid, 
+      must contain at least two valid lower-case DNS labels separated by dots, for example 'domain.com' or 'sub.domain.com'.`;
+
+/** Full default UI strings (English). */
+export const defaultRosaWizardStrings: RosaWizardStrings = {
+  wizard: {
+    stepLabels: {
+      basicSetup: 'Basic setup',
+      details: 'Details',
+      rolesAndPolicies: 'Roles and policies',
+      machinePools: 'Machine pools',
+      networking: 'Networking',
+      clusterWideProxy: 'Cluster-wide proxy',
+      additionalSetup: 'Additional setup',
+      encryptionOptional: 'Encryption (optional)',
+      clusterUpdatesOptional: 'Cluster updates (optional)',
+      yamlEditor: 'YAML Editor',
+      review: 'Review',
+    },
+  },
+  submitError: {
+    title: 'Error creating cluster',
+    backToReviewStep: 'Back to review step',
+    exitWizard: 'Exit wizard',
+  },
+  yamlEditor: {
+    title: 'YAML Configuration',
+    description: 'Review and edit the YAML configuration.',
+    parseErrorTitle: 'YAML Parse Error',
+    convertError: 'Error converting form data to YAML',
+    invalidYaml: 'Invalid YAML syntax',
+  },
+  associateAwsDrawer: {
+    panelTitle: 'How to associate a new AWS account',
+    introSts:
+      'ROSA cluster deployments use the AWS Security Token Service for added security. Run the following required steps from a CLI authenticated with both AWS and ROSA.',
+    cliVersion: 'You must use ROSA CLI version 1.2.31 or above.',
+    step1Title: 'Step 1: OCM Role',
+    step2Title: 'Step 2: User Role',
+    step3Title: 'Step 3: User Role',
+    closingPrompt:
+      "After you've completed all the steps, close this guide and choose your account.",
+    closeButton: 'Close',
+  },
+  ocmRole: {
+    checkLinkedTitle: 'First, check if a role exists and is linked with:',
+    existingLinkedInfo:
+      "If there is an existing role and it's already linked to your Red Hat account, you can continue to step 2.",
+    unlinkedTitle: "Next, is there an existing role that isn't linked?",
+    tabCreateNew: 'No, create new role',
+    tabLinkExisting: 'Yes, link existing role',
+    basicOcmRoleLabel: 'Basic OCM role',
+    orDivider: 'OR',
+    adminOcmRoleLabel: 'Admin OCM role',
+    helpDecideTitle: 'Help me decide',
+    helpBasicBody:
+      'The basic role enables OpenShift Cluster Manager to detect the AWS IAM roles and policies required by ROSA.',
+    helpAdminBody:
+      'The admin role also enables the detection of the roles and policies. In addition, the admin role enables automatic deployment of the cluster-specific Operator roles and OpenID Connect (OIDC) provider by using OpenShift Cluster Manager.',
+    linkExistingLead: ' If a role exists but is not linked, link it with:',
+    orgAdminInfo:
+      'You must have organization administrator privileges in your Red Hat account to run this command. After you link the OCM role with your Red Hat organization, it is visible for all users in the organization.',
+  },
+  userRole: {
+    checkLinkedTitle: 'First, check if a role exists and is linked with:',
+    existingLinkedInfo:
+      "If there is an existing role and it's already linked to your Red Hat account, you can continue to step 3",
+    unlinkedTitle: "Next, is there an existing role that isn't linked?",
+    whyLinkTitle: 'Why do I need to link my account?',
+    whyLinkBodyPrefix:
+      'The link creates a trust policy between the role and the link cluster installer.',
+    reviewPermissionsLink: 'Review the AWS policy permissions for the basic and admin OCM roles.',
+    tabCreateNew: 'No, create new role',
+    tabLinkExisting: 'Yes, link existing role',
+    userRoleLabel: 'User role ',
+    userRolePopover:
+      'The user role is necessary to validate that your Red Hat user account has permissions to install a cluster in the AWS account.',
+    copyAriaListUserRole: 'Copyable ROSA rosa list user-role command',
+    copyAriaLinkUserRole: 'Copyable ROSA link user-role --arn',
+  },
+  accountRoles: {
+    intro:
+      "To create the necessary account-wide roles and policies quickly, use the default auto method that's provided by the ROSA CLI.",
+    copyAriaAccountRoles: 'Copyable ROSA rosa create account-roles --hosted-cp --mode auto command',
+    manualInstructionsLead:
+      'If you would prefer to manually create the required roles and policies within your AWS account, then follow',
+    manualInstructionsLink: 'these instructions',
+  },
+  details: {
+    sectionLabel: 'Details',
+    clusterNameLabel: 'Cluster name',
+    clusterNamePlaceholder: 'Enter the cluster name',
+    clusterNameHelp:
+      'This will be how we refer to your cluster in the OpenShift cluster list and will form part of the cluster console subdomain.',
+    openShiftVersionLabel: 'OpenShift version',
+    openShiftVersionPlaceholder: 'Select an OpenShift version',
+    awsInfraLabel: 'Associated AWS infrastructure account',
+    awsInfraPlaceholder: 'Select an AWS infrastructure account',
+    awsInfraHelp:
+      "Your cluster's cloud resources will be created in the associated AWS infrastructure account. To continue, you must associate at least 1 account.",
+    associateNewAccount: 'Associate a new AWS account',
+    billingLabel: 'Associated AWS billing account',
+    billingPlaceholder: 'Select an AWS billing account',
+    billingHelp:
+      'The AWS billing account is often the same as your Associated AWS infrastructure account, but does not have to be.',
+    connectBillingLink: 'Connect ROSA to a new AWS billing account',
+    regionLabel: 'Region',
+    regionPlaceholder: 'Select a region',
+    regionHelp:
+      'The AWS Region where your compute nodes and control plane will be located. (should be link: Learn more abut AWS Regions.)',
+  },
+  rolesAndPolicies: {
+    accountRolesSection: 'Account roles',
+    installerRoleLabel: 'Installer role',
+    installerPlaceholder: 'Select an Installer role',
+    installerHelpLead: 'An AWS IAM role used by the ROSA installer',
+    installerLearnMoreLink: 'Learn more about roles.',
+    arnsToggle: 'Amazon Resource Names (ARNs)',
+    supportRoleLabel: 'Support role',
+    supportPlaceholder: 'Select an AWS infrastructure account',
+    supportHelp:
+      'An IAM role used by the Red Hat Site Reliability Engineering (SRE) support team. The role is used with the corresponding policy resource to provide the Red Hat SRE support team with the permissions required to support ROSA clusters.',
+    workerRoleLabel: 'Worker role',
+    workerPlaceholder: 'Select an AWS infrastructure account',
+    workerHelp:
+      'An IAM role used by the ROSA compute instances. The role is used with the corresponding policy resource to provide the compute instances with the permissions required to manage their components.',
+    operatorRolesSection: 'Operator roles',
+    oidcLabel: 'OIDC config ID',
+    oidcPlaceholder: 'Select an OIDC config ID',
+    oidcHelp: 'The OIDC configuration ID created by running the command: rosa create oidc-config',
+    oidcPopoverTitle: 'Create a new OIDC config id',
+    operatorPrefixToggle: 'Operator role prefix',
+    operatorPrefixLabel: 'Operator roles prefix',
+    operatorPrefixHelpLead: 'You can specify a custom prefix for the Operator AWS IAM roles.',
+    operatorPrefixLearnMoreLink: 'Learn more and see examples.',
+    operatorPrefixHelper:
+      '32 characters maximum. This is autogenerated by the cluster name, but you can cahnge it.',
+    clipboardCopyAria: 'Copy read-only example',
+    copyHover: 'Copy',
+    copyClicked: 'Copied',
+  },
+  oidcHint: {
+    instructions:
+      'Create a new OIDC config ID by running the following commands in your CLI. Then, refresh and select the new config ID from the dropdown.',
+  },
+  networking: {
+    sectionLabel: 'Networking',
+    privacyHelper:
+      'Install your cluster with all public or private API endpoints and application routes.',
+    publicLabel: 'Public',
+    publicPopover: 'Access Kubernetes API endpoint and application routes from the internet.',
+    publicSubnetLabel: 'Public subnet name',
+    publicSubnetPlaceholder: 'Select public subnet name',
+    privateLabel: 'Private',
+    privatePopover:
+      'Access Kubernetes API endpoint and application routes from direct private connections only.',
+    advancedToggle: 'Advanced networking configuration (optional)',
+    proxyCheckboxLabel: 'Configure a cluster-wide proxy',
+    proxyCheckboxHelp:
+      'Enable an HTTP or HTTPS proxy to deny direct access to the internet from your cluster.',
+    proxyNextStepInfo: 'You will be able to configure cluster-wide proxy details in the next step',
+    cidrAlertTitle: 'CIDR ranges cannot be changed after you create your cluster',
+    cidrAlertBody:
+      "Specify non-overlapping ranges for machine, service, and pod ranges. Make sure that your internal organization's networking ranges do not overlap with ours, which are Kubernetes. Each range should correspond to the first IP address in their subnet.",
+    cidrLearnMoreLink: 'Learn more about configuring network settings',
+    useDefaultsLabel: 'Use default values',
+    useDefaultsHelp:
+      'The values are safe defaults. However, you must ensure that the Machine CIDR matches the selected VPC subnets.',
+    machineCidrLabel: 'Machine CIDR',
+    machineCidrHelp: 'Subnet mask must be between /16 and /25',
+    serviceCidrLabel: 'Service CIDR',
+    serviceCidrHelp: 'Subnet mask must be at most /24',
+    podCidrLabel: 'Pod CIDR',
+    podCidrHelp: 'Subnet mask must allow for at least 32 nodes',
+    hostPrefixLabel: 'Host prefix',
+    hostPrefixHelp: 'Must be between /23 and /26',
+  },
+  machinePools: {
+    sectionLabel: 'Machine pools',
+    intro:
+      'Create machine pools and specify the private subnet for each machine pool. To allow high availability for your workloads, add machine pools on different availablity zones.',
+    vpcLabelPrefix: 'Select a VPC to install your machine pools into your selected regions:',
+    vpcPlaceholder: 'Select a VPC to install your machine pools into',
+    vpcHelpLead:
+      'To create a cluster hosted by Red Hat, you must have a Virtual Private Cloud (VPC) available to create clusters on.',
+    vpcLearnMoreLink: 'Learn more about VPCs.',
+    machinePoolLabel: 'Machine pool',
+    subnetLabel: 'Private subnet name',
+    addPoolButton: 'Add machine pool',
+    subnetPlaceholder: 'Select private subnet',
+    settingsSectionLabel: 'Machine pools settings',
+    settingsIntro:
+      'The following settings apply to all machine pools created during cluster install. Additional machine pools can be created after cluster creation.',
+    instanceTypeLabel: 'Compute node instance type',
+    instanceTypeHelpLead:
+      'Instance types are made from varying combinations of CPU, memory, storage, and networking capacity. Instance type availability depends on regional availability and your AWS account configuration.',
+    instanceTypeLearnMore: 'Learn more.',
+    advancedToggle: 'Advanced machine pool configuration (optional)',
+    imdsHelpTitle: 'Amazon EC2 Instance Metadata Service (IMDS)',
+    imdsHelpP1:
+      'Instance metadata is data that is related to an Amazon Elastic Compute Cloud (Amazon EC2) instance that applications can use to configure or manage the running instance.',
+    imdsLabel: 'Instance Metadata Service',
+    imdsBothLabel: 'Use both IMDSv1 and IMDSv2',
+    imdsBothDescription: 'Allows use of both IMDS versions for backward compatibility',
+    imdsV2Label: 'Use IMDSv2 only',
+    imdsV2Description: 'A session-oriented method with enhanced security',
+    rootDiskLabel: 'Root disk size',
+    rootDiskHelp:
+      'Root disks are AWS EBS volumes attached as the primary disk for AWS EC2 instances. The root disk size for this machine pool group of nodes must be between 75GiB and 16384GiB.',
+    securityGroupsToggle: 'Additional security groups (optional)',
+  },
+  autoscaling: {
+    title: 'Autoscaling',
+    helperLead:
+      'Autoscaling automatically adds and removes nodes from the machine pool based on resource requirements.',
+    learnMoreAutoscaling: 'Learn more about autscaling with ROSA.',
+    enableLabel: 'Enable autoscaling',
+    minLabel: 'Min compute node count',
+    minHelp: 'The number of compute nodes to provision for your initial machine pool.',
+    learnMoreNodeCount: 'Learn more about compute node count',
+    maxLabel: 'Max compute node count',
+    maxHelp: 'The number of compute nodes to provision for your initial machine pool.',
+    computeCountLabel: 'Compute node count',
+    computeCountHelp: 'The number of compute nodes to provision for your initial machine pool.',
+  },
+  securityGroups: {
+    emptyTitle: 'There are no security groups for this Virtual Private Cloud',
+    emptyBodyPrefix: 'To add security groups, go to the',
+    emptyConsoleLink: 'Security groups section',
+    refreshLink: 'Refresh Security Groups',
+    noEditTitle:
+      'You cannot add or edit security groups associated with machine pools that were created during cluster creation.',
+    formLabel: 'Security groups',
+    selectToggle: 'Select security groups',
+    refreshTooltip: 'Refetch Security Groups list',
+    readOnlyEmpty: 'This machine pool does not have additional security groups.',
+    badgeSrText: 'some items',
+    optionsMenuAria: 'Options menu',
+    selectAriaLabelledBy: 'Select AWS security groups',
+    noEditViewMoreInfo: 'View more information',
+    noEditAwsConsoleLink: 'AWS security groups console',
+  },
+  clusterWideProxy: {
+    sectionLabel: 'Cluster-wide proxy',
+    intro: 'Enable an HTTP or HTTPS proxy to deny direct access to the internet from your cluster.',
+    learnMoreLink: 'Learn more about configuring a cluster-wide proxy',
+    alertConfigureFields: 'Configure at least 1 of the following fields:',
+    httpLabel: 'HTTP proxy URL',
+    httpHelp: 'Specify a proxy URL to use for HTTP connections outside the cluster.',
+    httpsLabel: 'HTTPS proxy URL',
+    httpsHelp: 'Specify a proxy URL to use for HTTPS connections outside the cluster.',
+    noProxyLabel: 'No Proxy domains',
+    noProxyHelp:
+      'Preface a domain with . to match subdomains only. For example, .y.com matches x.y.com, but not y.com. Use * to bypass proxy for all destinations.',
+    trustBundleLabel: 'Additional trust bundle',
+  },
+  encryption: {
+    sectionLabel: 'Advanced encryption',
+    keysGroupLabel: 'Encryption Keys',
+    keysHelperLead:
+      'You can use your default or a custom AWS KMS key to encrypt the root disks for your OpenShift nodes.',
+    keysLearnMore: 'Learn more',
+    defaultKms: 'Use default AWS KMS key',
+    customKms: 'Use custom AWS KMS key',
+    keyArnLabel: 'Key ARN',
+    keyArnHelp:
+      'The key ARN is the Amazon Resource Name (ARN) of a CMK. It is a unique, fully qualified identifier for the CMK. A key ARN includes the AWS account, Region, and the key ID.',
+    etcdTitle: 'etcd encryption',
+    etcdLabel: 'Enable additional etcd encryption',
+    etcdHelperLead: 'Optionally, add a unique customer-managed AWS KMS key to encrypt etcd.',
+    etcdLearnMore: 'Learn more',
+    keysNoteAlert:
+      'Take a note of the keys associated with your cluster. If you delete your keys, the cluster will not be available',
+  },
+  clusterUpdates: {
+    sectionLabel: 'Cluster update strategy',
+    versionIntroPrefix: 'The OpenShift version',
+    versionIntroSuffix: 'that you selected in the',
+    detailsStepLink: 'Details step',
+    midSentence: 'will apply to the managed control plane and the machine pools configured in the',
+    networkingStepLink: 'Networking and subnets step.',
+    afterCreation:
+      'After cluster creation, you can update the managed control plane and machine pools independently.',
+    cveLead: 'In the event of',
+    criticalConcernsLink: 'Critical security concerns',
+    cveTail:
+      '(CVEs) that significantly impact the security or stability of the cluster, updates may be automatically scheduled by Red Hat SRE to the latest z-stream version not impacted by the CVE within 2 business days after customer notifications.',
+    individualLabel: 'Individual updates',
+    individualDescriptionLead:
+      'Schedule each update individually. When planning updates, make sure to consider the end of life dates from the',
+    lifecycleLink: 'lifecycle policy',
+    recurringLabel: 'Recurring updates',
+    recurringDescriptionBeforeZStream:
+      'The cluster control plan will be automatically updated based on your preferred day and start time when new patch updates ',
+    zStreamLinkText: 'z-stream',
+    recurringDescriptionAfterZStream:
+      " are available. When a new minor version is available, you'll be notified and must manually allow the cluster to update the next minor version. The compute nodes will need to be manually updated.",
+    dayTimeLabel: 'Select a day and start time',
+    selectDayPlaceholder: 'Select day',
+    daysOfWeek: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  },
+  review: {
+    sectionLabel: 'Review your ROSA cluster',
+    alertTitle: 'Double check your settings. Locked settings can not be changed later.',
+    detailsToggle: 'Details',
+    rolesToggle: 'Roles and policies',
+    networkingToggle: 'Networking and subnets',
+    encryptionToggle: 'Encryption (optional)',
+    optionalNetworkingToggle: 'Networking (optional)',
+    clusterUpdatesToggle: 'Cluster updates (optional)',
+    editStep: 'Edit Step',
+    clusterName: 'Cluster name',
+    openShiftVersion: 'OpenShift version',
+    awsInfra: 'Associated AWS infrastructure account',
+    awsBilling: 'AWS billing account',
+    region: 'Region',
+    installerRole: 'Installer role',
+    oidcConfigId: 'OIDC Config ID',
+    operatorPrefix: 'Operator roles prefix',
+    publicSubnet: 'Public subnet name',
+    installVpc: 'Install to selected VPC',
+    instanceType: 'Compute node instance type',
+    computeCount: 'Compute node count',
+    machinePoolsHeading: 'Machine pools',
+    additionalEtcd: 'Additional etcd encryption',
+    encryptionKeys: 'Encryption keys',
+    machineCidr: 'Machine CIDR',
+    serviceCidr: 'Service CIDR',
+    podCidr: 'Pod CIDR',
+    hostPrefix: 'Host prefix',
+    updateStrategy: 'Cluster update strategy',
+    strategyIndividual: 'Individual updates',
+    strategyAutomatic: 'Automatic updates',
+    autoscalingMinPrefix: 'Min:',
+    autoscalingMaxPrefix: 'Max:',
+  },
+};
+
+/** Default validation messages (English). Keep function signatures when translating. */
+export const defaultRosaWizardValidatorStrings: RosaWizardValidatorStrings = {
+  clusterName: {
+    maxLength: 'This value can contain at most 54 characters',
+    invalidChars: "This value can only contain lowercase alphanumeric characters or '-' or '.'",
+    mustStartAlphanumeric: 'This value must start with an alphanumeric character',
+    mustNotStartNumber: 'This value must not start with a number',
+    mustEndAlphanumeric: 'This value must end with an alphanumeric character',
+  },
+  operatorRolesPrefix: {
+    fieldLabel: 'Custom operator roles prefix',
+    invalidFormat: defaultOperatorPrefixInvalid,
+    tooLong: defaultOperatorPrefixTooLong,
+  },
+  kmsKeyArn: {
+    required: 'Field is required.',
+    noWhitespace: 'Value must not contain whitespaces.',
+    invalidArn:
+      'Key provided is not a valid ARN. It should be in the format "arn:aws:kms:<region>:<accountid>:key/<keyid>".',
+    wrongRegion: 'Your KMS key must contain your selected region.',
+  },
+  securityGroups: {
+    maxExceeded: (max: number) => `A maximum of ${max} security groups can be selected.`,
+  },
+  noProxyDomains: {
+    invalidDomains: defaultNoProxyInvalid,
+  },
+  url: {
+    invalid: 'Invalid URL',
+    schemePrefix: (protocolList: string) =>
+      `The URL should include the scheme prefix (${protocolList})`,
+  },
+  ca: {
+    fileTooLarge: 'File must be no larger than 4 MB',
+    invalidPem: 'Must be a PEM encoded X.509 file (.pem, .crt, .ca, .cert) and no larger than 4 MB',
+  },
+  rootDisk: {
+    notInteger: 'Root disk size must be an integer.',
+    tooSmall: 'Root disk size must be at least 75 GiB.',
+    tooLarge: 'Root disk size must not exceed 16384 GiB.',
+  },
+  replicas: {
+    notInteger: 'Input must be an integer.',
+    notPositive: 'Input must be a positive number.',
+    maxNodes: (max: number) => `Input cannot be more than ${max}.`,
+    minGreaterThanMax: 'Min nodes cannot be greater than max nodes.',
+    maxLessThanMin: 'Max nodes must be greater than or equal to min nodes.',
+    computeMinTwo: 'Input cannot be less than 2 nodes.',
+  },
+  proxyConfigureAtLeastOne: 'Configure at least one of the cluster-wide proxy fields.',
+};

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.ts
@@ -1,0 +1,66 @@
+/**
+ * Merge helpers for RosaWizard string bundles.
+ *
+ * - **Types:** {@link ./rosaWizardStrings.types}
+ * - **Default English copy (safe to copy into your app for translation):** {@link ./rosaWizardStrings.defaults}
+ *
+ * Pass partial `strings` into {@link RosaWizard} or {@link RosaWizardStringsProvider}; omitted keys
+ * are filled from {@link defaultRosaWizardStrings} and {@link defaultRosaWizardValidatorStrings}.
+ */
+
+import type {
+  DeepPartial,
+  RosaWizardStrings,
+  RosaWizardStringsInput,
+  RosaWizardValidatorStrings,
+} from './rosaWizardStrings.types';
+import {
+  defaultRosaWizardStrings,
+  defaultRosaWizardValidatorStrings,
+} from './rosaWizardStrings.defaults';
+
+export * from './rosaWizardStrings.types';
+export * from './rosaWizardStrings.defaults';
+
+function isPlainRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+function mergeDeep<T>(base: T, patch: DeepPartial<T> | undefined): T {
+  if (!patch) return base;
+  const result = { ...base } as Record<string, unknown>;
+  for (const key of Object.keys(patch) as (keyof T & string)[]) {
+    const baseVal = (base as Record<string, unknown>)[key];
+    const patchVal = (patch as Record<string, unknown>)[key];
+    if (patchVal === undefined) continue;
+    if (isPlainRecord(baseVal) && isPlainRecord(patchVal)) {
+      result[key] = mergeDeep(baseVal, patchVal as DeepPartial<typeof baseVal>);
+    } else {
+      result[key] = patchVal;
+    }
+  }
+  return result as T;
+}
+
+export function mergeRosaWizardStrings(
+  partial?: DeepPartial<RosaWizardStrings>
+): RosaWizardStrings {
+  return mergeDeep(defaultRosaWizardStrings, partial);
+}
+
+export function mergeRosaWizardValidatorStrings(
+  partial?: DeepPartial<RosaWizardValidatorStrings>
+): RosaWizardValidatorStrings {
+  return mergeDeep(defaultRosaWizardValidatorStrings, partial);
+}
+
+export function buildRosaWizardStringBundles(input?: RosaWizardStringsInput): {
+  strings: RosaWizardStrings;
+  validators: RosaWizardValidatorStrings;
+} {
+  const { validators: vPartial, ...rest } = input ?? {};
+  return {
+    strings: mergeRosaWizardStrings(rest),
+    validators: mergeRosaWizardValidatorStrings(vPartial),
+  };
+}

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.ts
@@ -8,6 +8,7 @@
  * are filled from {@link defaultRosaWizardStrings} and {@link defaultRosaWizardValidatorStrings}.
  */
 
+import { defaultStrings, type WizardStrings } from '@patternfly-labs/react-form-wizard';
 import type {
   DeepPartial,
   RosaWizardStrings,
@@ -58,9 +59,22 @@ export function buildRosaWizardStringBundles(input?: RosaWizardStringsInput): {
   strings: RosaWizardStrings;
   validators: RosaWizardValidatorStrings;
 } {
-  const { validators: vPartial, ...rest } = input ?? {};
+  const { validators: vPartial, formWizard: _formWizard, ...rest } = input ?? {};
   return {
     strings: mergeRosaWizardStrings(rest),
     validators: mergeRosaWizardValidatorStrings(vPartial),
   };
+}
+
+/**
+ * Merged strings for the `wizardStrings` prop on `WizardPage` / `Wizard` from
+ * `@patternfly-labs/react-form-wizard`. Aligns `reviewLabel` with Rosa’s review step nav label, after
+ * optional `strings.formWizard` overrides (so nav and form-wizard review label stay consistent).
+ */
+export function buildWizardStringsForRosa(
+  rosa: RosaWizardStrings,
+  formWizardPartial?: DeepPartial<WizardStrings>
+): WizardStrings {
+  const base = mergeDeep(defaultStrings, formWizardPartial);
+  return mergeDeep(base, { reviewLabel: rosa.wizard.stepLabels.review });
 }

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
@@ -1,0 +1,377 @@
+/**
+ * Type definitions for RosaWizard UI copy and validation messages.
+ * Default English values live in {@link ./rosaWizardStrings.defaults}.
+ */
+
+export type DeepPartial<T> = {
+  [K in keyof T]?: T[K] extends (...args: never[]) => unknown
+    ? T[K]
+    : T[K] extends object
+      ? DeepPartial<T[K]>
+      : T[K];
+};
+
+export type RosaWizardClusterNameValidatorStrings = {
+  maxLength: string;
+  invalidChars: string;
+  mustStartAlphanumeric: string;
+  mustNotStartNumber: string;
+  mustEndAlphanumeric: string;
+};
+
+export type RosaWizardOperatorRolesPrefixValidatorStrings = {
+  fieldLabel: string;
+  invalidFormat: (label: string, value: string) => string;
+  tooLong: (label: string, max: number) => string;
+};
+
+export type RosaWizardKmsKeyValidatorStrings = {
+  required: string;
+  noWhitespace: string;
+  invalidArn: string;
+  wrongRegion: string;
+};
+
+export type RosaWizardSecurityGroupsValidatorStrings = {
+  maxExceeded: (max: number) => string;
+};
+
+export type RosaWizardNoProxyValidatorStrings = {
+  invalidDomains: (domains: string, plural: boolean) => string;
+};
+
+export type RosaWizardUrlValidatorStrings = {
+  invalid: string;
+  schemePrefix: (protocolList: string) => string;
+};
+
+export type RosaWizardCaValidatorStrings = {
+  fileTooLarge: string;
+  invalidPem: string;
+};
+
+export type RosaWizardRootDiskValidatorStrings = {
+  notInteger: string;
+  tooSmall: string;
+  tooLarge: string;
+};
+
+export type RosaWizardReplicaValidatorStrings = {
+  notInteger: string;
+  notPositive: string;
+  maxNodes: (max: number) => string;
+  minGreaterThanMax: string;
+  maxLessThanMin: string;
+  computeMinTwo: string;
+};
+
+export type RosaWizardValidatorStrings = {
+  clusterName: RosaWizardClusterNameValidatorStrings;
+  operatorRolesPrefix: RosaWizardOperatorRolesPrefixValidatorStrings;
+  kmsKeyArn: RosaWizardKmsKeyValidatorStrings;
+  securityGroups: RosaWizardSecurityGroupsValidatorStrings;
+  noProxyDomains: RosaWizardNoProxyValidatorStrings;
+  url: RosaWizardUrlValidatorStrings;
+  ca: RosaWizardCaValidatorStrings;
+  rootDisk: RosaWizardRootDiskValidatorStrings;
+  replicas: RosaWizardReplicaValidatorStrings;
+  proxyConfigureAtLeastOne: string;
+};
+
+export type RosaWizardStrings = {
+  wizard: {
+    stepLabels: {
+      basicSetup: string;
+      details: string;
+      rolesAndPolicies: string;
+      machinePools: string;
+      networking: string;
+      clusterWideProxy: string;
+      additionalSetup: string;
+      encryptionOptional: string;
+      clusterUpdatesOptional: string;
+      yamlEditor: string;
+      review: string;
+    };
+  };
+  submitError: {
+    title: string;
+    backToReviewStep: string;
+    exitWizard: string;
+  };
+  yamlEditor: {
+    title: string;
+    description: string;
+    parseErrorTitle: string;
+    convertError: string;
+    invalidYaml: string;
+  };
+  associateAwsDrawer: {
+    panelTitle: string;
+    introSts: string;
+    cliVersion: string;
+    step1Title: string;
+    step2Title: string;
+    step3Title: string;
+    closingPrompt: string;
+    closeButton: string;
+  };
+  ocmRole: {
+    checkLinkedTitle: string;
+    existingLinkedInfo: string;
+    unlinkedTitle: string;
+    tabCreateNew: string;
+    tabLinkExisting: string;
+    basicOcmRoleLabel: string;
+    orDivider: string;
+    adminOcmRoleLabel: string;
+    helpDecideTitle: string;
+    helpBasicBody: string;
+    helpAdminBody: string;
+    linkExistingLead: string;
+    orgAdminInfo: string;
+  };
+  userRole: {
+    checkLinkedTitle: string;
+    existingLinkedInfo: string;
+    unlinkedTitle: string;
+    whyLinkTitle: string;
+    whyLinkBodyPrefix: string;
+    reviewPermissionsLink: string;
+    tabCreateNew: string;
+    tabLinkExisting: string;
+    userRoleLabel: string;
+    userRolePopover: string;
+    copyAriaListUserRole: string;
+    copyAriaLinkUserRole: string;
+  };
+  accountRoles: {
+    intro: string;
+    copyAriaAccountRoles: string;
+    manualInstructionsLead: string;
+    manualInstructionsLink: string;
+  };
+  details: {
+    sectionLabel: string;
+    clusterNameLabel: string;
+    clusterNamePlaceholder: string;
+    clusterNameHelp: string;
+    openShiftVersionLabel: string;
+    openShiftVersionPlaceholder: string;
+    awsInfraLabel: string;
+    awsInfraPlaceholder: string;
+    awsInfraHelp: string;
+    associateNewAccount: string;
+    billingLabel: string;
+    billingPlaceholder: string;
+    billingHelp: string;
+    connectBillingLink: string;
+    regionLabel: string;
+    regionPlaceholder: string;
+    regionHelp: string;
+  };
+  rolesAndPolicies: {
+    accountRolesSection: string;
+    installerRoleLabel: string;
+    installerPlaceholder: string;
+    installerHelpLead: string;
+    installerLearnMoreLink: string;
+    arnsToggle: string;
+    supportRoleLabel: string;
+    supportPlaceholder: string;
+    supportHelp: string;
+    workerRoleLabel: string;
+    workerPlaceholder: string;
+    workerHelp: string;
+    operatorRolesSection: string;
+    oidcLabel: string;
+    oidcPlaceholder: string;
+    oidcHelp: string;
+    oidcPopoverTitle: string;
+    operatorPrefixToggle: string;
+    operatorPrefixLabel: string;
+    operatorPrefixHelpLead: string;
+    operatorPrefixLearnMoreLink: string;
+    operatorPrefixHelper: string;
+    clipboardCopyAria: string;
+    copyHover: string;
+    copyClicked: string;
+  };
+  oidcHint: {
+    instructions: string;
+  };
+  networking: {
+    sectionLabel: string;
+    privacyHelper: string;
+    publicLabel: string;
+    publicPopover: string;
+    publicSubnetLabel: string;
+    publicSubnetPlaceholder: string;
+    privateLabel: string;
+    privatePopover: string;
+    advancedToggle: string;
+    proxyCheckboxLabel: string;
+    proxyCheckboxHelp: string;
+    proxyNextStepInfo: string;
+    cidrAlertTitle: string;
+    cidrAlertBody: string;
+    cidrLearnMoreLink: string;
+    useDefaultsLabel: string;
+    useDefaultsHelp: string;
+    machineCidrLabel: string;
+    machineCidrHelp: string;
+    serviceCidrLabel: string;
+    serviceCidrHelp: string;
+    podCidrLabel: string;
+    podCidrHelp: string;
+    hostPrefixLabel: string;
+    hostPrefixHelp: string;
+  };
+  machinePools: {
+    sectionLabel: string;
+    intro: string;
+    vpcLabelPrefix: string;
+    vpcPlaceholder: string;
+    vpcHelpLead: string;
+    vpcLearnMoreLink: string;
+    machinePoolLabel: string;
+    subnetLabel: string;
+    addPoolButton: string;
+    subnetPlaceholder: string;
+    settingsSectionLabel: string;
+    settingsIntro: string;
+    instanceTypeLabel: string;
+    instanceTypeHelpLead: string;
+    instanceTypeLearnMore: string;
+    advancedToggle: string;
+    imdsHelpTitle: string;
+    imdsHelpP1: string;
+    imdsLabel: string;
+    imdsBothLabel: string;
+    imdsBothDescription: string;
+    imdsV2Label: string;
+    imdsV2Description: string;
+    rootDiskLabel: string;
+    rootDiskHelp: string;
+    securityGroupsToggle: string;
+  };
+  autoscaling: {
+    title: string;
+    helperLead: string;
+    learnMoreAutoscaling: string;
+    enableLabel: string;
+    minLabel: string;
+    minHelp: string;
+    learnMoreNodeCount: string;
+    maxLabel: string;
+    maxHelp: string;
+    computeCountLabel: string;
+    computeCountHelp: string;
+  };
+  securityGroups: {
+    emptyTitle: string;
+    emptyBodyPrefix: string;
+    emptyConsoleLink: string;
+    refreshLink: string;
+    noEditTitle: string;
+    formLabel: string;
+    selectToggle: string;
+    refreshTooltip: string;
+    readOnlyEmpty: string;
+    badgeSrText: string;
+    optionsMenuAria: string;
+    selectAriaLabelledBy: string;
+    noEditViewMoreInfo: string;
+    noEditAwsConsoleLink: string;
+  };
+  clusterWideProxy: {
+    sectionLabel: string;
+    intro: string;
+    learnMoreLink: string;
+    alertConfigureFields: string;
+    httpLabel: string;
+    httpHelp: string;
+    httpsLabel: string;
+    httpsHelp: string;
+    noProxyLabel: string;
+    noProxyHelp: string;
+    trustBundleLabel: string;
+  };
+  encryption: {
+    sectionLabel: string;
+    keysGroupLabel: string;
+    keysHelperLead: string;
+    keysLearnMore: string;
+    defaultKms: string;
+    customKms: string;
+    keyArnLabel: string;
+    keyArnHelp: string;
+    etcdTitle: string;
+    etcdLabel: string;
+    etcdHelperLead: string;
+    etcdLearnMore: string;
+    keysNoteAlert: string;
+  };
+  clusterUpdates: {
+    sectionLabel: string;
+    versionIntroPrefix: string;
+    versionIntroSuffix: string;
+    detailsStepLink: string;
+    midSentence: string;
+    networkingStepLink: string;
+    afterCreation: string;
+    cveLead: string;
+    criticalConcernsLink: string;
+    cveTail: string;
+    individualLabel: string;
+    individualDescriptionLead: string;
+    lifecycleLink: string;
+    recurringLabel: string;
+    recurringDescriptionBeforeZStream: string;
+    zStreamLinkText: string;
+    recurringDescriptionAfterZStream: string;
+    dayTimeLabel: string;
+    selectDayPlaceholder: string;
+    daysOfWeek: [string, string, string, string, string, string, string];
+  };
+  review: {
+    sectionLabel: string;
+    alertTitle: string;
+    detailsToggle: string;
+    rolesToggle: string;
+    networkingToggle: string;
+    encryptionToggle: string;
+    optionalNetworkingToggle: string;
+    clusterUpdatesToggle: string;
+    editStep: string;
+    clusterName: string;
+    openShiftVersion: string;
+    awsInfra: string;
+    awsBilling: string;
+    region: string;
+    installerRole: string;
+    oidcConfigId: string;
+    operatorPrefix: string;
+    publicSubnet: string;
+    installVpc: string;
+    instanceType: string;
+    computeCount: string;
+    machinePoolsHeading: string;
+    additionalEtcd: string;
+    encryptionKeys: string;
+    machineCidr: string;
+    serviceCidr: string;
+    podCidr: string;
+    hostPrefix: string;
+    updateStrategy: string;
+    strategyIndividual: string;
+    strategyAutomatic: string;
+    autoscalingMinPrefix: string;
+    autoscalingMaxPrefix: string;
+  };
+};
+
+/** Partial overrides for {@link RosaWizard}; omitted keys use defaults from {@link ./rosaWizardStrings.defaults}. */
+export type RosaWizardStringsInput = DeepPartial<RosaWizardStrings> & {
+  validators?: DeepPartial<RosaWizardValidatorStrings>;
+};

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
@@ -6,7 +6,7 @@
 import type { WizardStrings } from '@patternfly-labs/react-form-wizard';
 
 export type DeepPartial<T> = {
-  [K in keyof T]?: T[K] extends (...args: never[]) => unknown
+  [K in keyof T]?: T[K] extends (...args: any[]) => unknown
     ? T[K]
     : T[K] extends object
       ? DeepPartial<T[K]>
@@ -67,6 +67,60 @@ export type RosaWizardReplicaValidatorStrings = {
   computeMinTwo: string;
 };
 
+/** CIDR notation validation (networking step). */
+export type RosaWizardCidrValidatorStrings = {
+  invalidNotation: (value: string) => string;
+};
+
+/** Subnet address vs mask consistency (networking step). */
+export type RosaWizardValidateRangeValidatorStrings = {
+  notSubnetAddress: string;
+};
+
+/** Machine CIDR prefix bounds (networking step). */
+export type RosaWizardAwsMachineCidrValidatorStrings = {
+  maskTooLarge: (minMask: number) => string;
+  maskTooSmallMultiAz: (maxMask: number) => string;
+  maskTooSmallSingleAz: (maxMask: number) => string;
+};
+
+/** Service CIDR and related subnet mask bounds (networking step). */
+export type RosaWizardServiceCidrValidatorStrings = {
+  maskTooSmall: (maxMask: number, maxServices: number) => string;
+  subnetMaskBetween: (min: number, max: number) => string;
+  subnetMaskBetweenOneAnd: (max: number) => string;
+};
+
+/** Pod CIDR (networking step). */
+export type RosaWizardPodCidrValidatorStrings = {
+  maskTooSmall: (maxMask: number) => string;
+  notEnoughNodes: (prefixLength: number) => string;
+};
+
+/** Machine / service / pod CIDR vs selected VPC subnets (networking step). */
+export type RosaWizardSubnetCidrsValidatorStrings = {
+  machineDoesNotIncludeStartIp: (startIp: string, subnetName: string) => string;
+  serviceOverlaps: (subnetName: string, cidrBlock: string) => string;
+  serviceIncludesStartIp: (startIp: string, subnetName: string) => string;
+  podOverlaps: (subnetName: string, cidrBlock: string) => string;
+  podIncludesStartIp: (startIp: string, subnetName: string) => string;
+};
+
+/** Non-overlapping machine, service, and pod ranges (networking step). */
+export type RosaWizardDisjointSubnetsValidatorStrings = {
+  fieldLabelMachine: string;
+  fieldLabelService: string;
+  fieldLabelPod: string;
+  overlap: (otherFieldLabelsCsv: string, plural: boolean) => string;
+};
+
+/** Host prefix / node sizing (networking step). */
+export type RosaWizardHostPrefixValidatorStrings = {
+  invalidMaskFormat: (value: string) => string;
+  maskTooLarge: (maxPrefix: number, maxPodIPs: number) => string;
+  maskTooSmall: (minPrefix: number, maxPodIPs: number) => string;
+};
+
 export type RosaWizardValidatorStrings = {
   clusterName: RosaWizardClusterNameValidatorStrings;
   operatorRolesPrefix: RosaWizardOperatorRolesPrefixValidatorStrings;
@@ -78,6 +132,14 @@ export type RosaWizardValidatorStrings = {
   rootDisk: RosaWizardRootDiskValidatorStrings;
   replicas: RosaWizardReplicaValidatorStrings;
   proxyConfigureAtLeastOne: string;
+  cidr: RosaWizardCidrValidatorStrings;
+  validateRange: RosaWizardValidateRangeValidatorStrings;
+  awsMachineCidr: RosaWizardAwsMachineCidrValidatorStrings;
+  serviceCidr: RosaWizardServiceCidrValidatorStrings;
+  podCidr: RosaWizardPodCidrValidatorStrings;
+  subnetCidrs: RosaWizardSubnetCidrsValidatorStrings;
+  disjointSubnets: RosaWizardDisjointSubnetsValidatorStrings;
+  hostPrefix: RosaWizardHostPrefixValidatorStrings;
 };
 
 export type RosaWizardStrings = {
@@ -273,6 +335,7 @@ export type RosaWizardStrings = {
   securityGroups: {
     emptyTitle: string;
     emptyBodyPrefix: string;
+    emptyBodySuffix: string;
     emptyConsoleLink: string;
     refreshLink: string;
     noEditTitle: string;

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
@@ -3,6 +3,8 @@
  * Default English values live in {@link ./rosaWizardStrings.defaults}.
  */
 
+import type { WizardStrings } from '@patternfly-labs/react-form-wizard';
+
 export type DeepPartial<T> = {
   [K in keyof T]?: T[K] extends (...args: never[]) => unknown
     ? T[K]
@@ -374,4 +376,10 @@ export type RosaWizardStrings = {
 /** Partial overrides for {@link RosaWizard}; omitted keys use defaults from {@link ./rosaWizardStrings.defaults}. */
 export type RosaWizardStringsInput = DeepPartial<RosaWizardStrings> & {
   validators?: DeepPartial<RosaWizardValidatorStrings>;
+  /**
+   * Overrides for `@patternfly-labs/react-form-wizard` chrome (footer buttons, aria labels, required
+   * message, typeahead strings, etc.). Omitted keys use that package’s English defaults.
+   * `reviewLabel` is always aligned with {@link RosaWizardStrings.wizard.stepLabels.review} after merges.
+   */
+  formWizard?: DeepPartial<WizardStrings>;
 };

--- a/src/components/Wizards/RosaWizard/validators.ts
+++ b/src/components/Wizards/RosaWizard/validators.ts
@@ -19,22 +19,28 @@ import {
 } from './constants';
 import { parseCIDRSubnetLength, stringToArray } from './helpers';
 import IPCIDR from 'ip-cidr';
-import { CIDRSubnet } from '../types';
+import type { ClusterFormData, CIDRSubnet } from '../types';
 import {
   defaultRosaWizardValidatorStrings,
+  type RosaWizardAwsMachineCidrValidatorStrings,
   type RosaWizardCaValidatorStrings,
+  type RosaWizardCidrValidatorStrings,
   type RosaWizardClusterNameValidatorStrings,
+  type RosaWizardDisjointSubnetsValidatorStrings,
+  type RosaWizardHostPrefixValidatorStrings,
   type RosaWizardKmsKeyValidatorStrings,
   type RosaWizardNoProxyValidatorStrings,
   type RosaWizardOperatorRolesPrefixValidatorStrings,
+  type RosaWizardPodCidrValidatorStrings,
   type RosaWizardReplicaValidatorStrings,
   type RosaWizardSecurityGroupsValidatorStrings,
+  type RosaWizardServiceCidrValidatorStrings,
+  type RosaWizardSubnetCidrsValidatorStrings,
   type RosaWizardUrlValidatorStrings,
+  type RosaWizardValidateRangeValidatorStrings,
 } from './rosaWizardStrings';
 
 const lowercaseAlphaNumericCharacters = 'abcdefghijklmnopqrstuvwxyz1234567890';
-
-type Networks = Parameters<typeof overlapCidr>[0];
 
 export const composeValidators =
   (...args: Array<(value: any, item?: unknown) => string | undefined>) =>
@@ -166,40 +172,41 @@ export const validateUrl = (
   } else {
     protocolArr = protocol;
   }
+  let parsed: URL;
   try {
-    // eslint-disable-next-line no-new
-    new URL(value);
-  } catch (error) {
+    parsed = new URL(value);
+  } catch {
     return msgs.invalid;
-  } finally {
-    const valueStart = value.substring(0, value.indexOf('://'));
-    if (!protocolArr.includes(valueStart)) {
-      const protocolStr = protocolArr.map((p) => `${p}://`).join(', ');
-      // eslint-disable-next-line no-unsafe-finally
-      return msgs.schemePrefix(protocolStr);
-    }
+  }
+  const scheme = parsed.protocol.slice(0, -1);
+  if (!protocolArr.includes(scheme)) {
+    const protocolStr = protocolArr.map((p) => `${p}://`).join(', ');
+    return msgs.schemePrefix(protocolStr);
   }
   return undefined;
 };
 
 export const disjointSubnets =
-  (fieldName: string) =>
-  (value: string | undefined, formData: { [name: string]: Networks }): string | undefined => {
+  (
+    fieldName: string,
+    msgs: RosaWizardDisjointSubnetsValidatorStrings = defaultRosaWizardValidatorStrings.disjointSubnets
+  ) =>
+  (value: string | undefined, formData: ClusterFormData | undefined): string | undefined => {
     if (!value) {
       return undefined;
     }
 
     const networkingFields: { [key: string]: string } = {
-      network_machine_cidr: 'Machine CIDR',
-      network_service_cidr: 'Service CIDR',
-      network_pod_cidr: 'Pod CIDR',
+      network_machine_cidr: msgs.fieldLabelMachine,
+      network_service_cidr: msgs.fieldLabelService,
+      network_pod_cidr: msgs.fieldLabelPod,
     };
     delete networkingFields[fieldName];
     const overlappingFields: string[] = [];
 
     if (CIDR_REGEXP.test(value)) {
       Object.keys(networkingFields).forEach((name) => {
-        const fieldValue = formData.name ? formData.name : null;
+        const fieldValue = (formData as Record<string, string | undefined> | undefined)?.[name];
         try {
           if (fieldValue && overlapCidr(value, fieldValue)) {
             overlappingFields.push(networkingFields[name]);
@@ -212,21 +219,22 @@ export const disjointSubnets =
 
     const plural = overlappingFields.length > 1;
     if (overlappingFields.length > 0) {
-      return `This subnet overlaps with the subnet${
-        plural ? 's' : ''
-      } in the ${overlappingFields.join(', ')} field${plural ? 's' : ''}.`;
+      return msgs.overlap(overlappingFields.join(', '), plural);
     }
     return undefined;
   };
 
 // Function to validate IP address masks
-export const hostPrefix = (value?: string): string | undefined => {
+export const hostPrefix = (
+  value?: string,
+  msgs: RosaWizardHostPrefixValidatorStrings = defaultRosaWizardValidatorStrings.hostPrefix
+): string | undefined => {
   if (!value) {
     return undefined;
   }
 
   if (!HOST_PREFIX_REGEXP.test(value)) {
-    return `The value '${value}' isn't a valid subnet mask. It must follow the RFC-4632 format: '/16'.`;
+    return msgs.invalidMaskFormat(value);
   }
 
   const prefixLength = parseCIDRSubnetLength(value);
@@ -234,11 +242,11 @@ export const hostPrefix = (value?: string): string | undefined => {
   if (prefixLength != null) {
     if (prefixLength < HOST_PREFIX_MIN) {
       const maxPodIPs = 2 ** (32 - HOST_PREFIX_MIN) - 2;
-      return `The subnet mask can't be larger than '/${HOST_PREFIX_MIN}', which provides up to ${maxPodIPs} Pod IP addresses.`;
+      return msgs.maskTooLarge(HOST_PREFIX_MIN, maxPodIPs);
     }
     if (prefixLength > HOST_PREFIX_MAX) {
       const maxPodIPs = 2 ** (32 - HOST_PREFIX_MAX) - 2;
-      return `The subnet mask can't be smaller than '/${HOST_PREFIX_MAX}', which provides up to ${maxPodIPs} Pod IP addresses.`;
+      return msgs.maskTooSmall(HOST_PREFIX_MAX, maxPodIPs);
     }
   }
 
@@ -246,15 +254,22 @@ export const hostPrefix = (value?: string): string | undefined => {
 };
 
 // Function to validate IP address blocks
-export const cidr = (value?: string): string | undefined => {
+export const cidr = (
+  value?: string,
+  msgs: RosaWizardCidrValidatorStrings = defaultRosaWizardValidatorStrings.cidr
+): string | undefined => {
   if (value && !CIDR_REGEXP.test(value)) {
-    return `IP address range '${value}' isn't valid CIDR notation. It must follow the RFC-4632 format: '192.168.0.0/16'.`;
+    return msgs.invalidNotation(value);
   }
   return undefined;
 };
 
-export const validateRange = (value?: string): string | undefined => {
-  if (cidr(value) !== undefined || !value) {
+export const validateRange = (
+  value?: string,
+  msgs: RosaWizardValidateRangeValidatorStrings = defaultRosaWizardValidatorStrings.validateRange,
+  cidrMsgs: RosaWizardCidrValidatorStrings = defaultRosaWizardValidatorStrings.cidr
+): string | undefined => {
+  if (cidr(value, cidrMsgs) !== undefined || !value) {
     return undefined;
   }
   const parts = value.split('/');
@@ -266,14 +281,15 @@ export const validateRange = (value?: string): string | undefined => {
   const maskedBinaryString = cidrBinaryString.slice(0, maskBits).padEnd(32, '0');
 
   if (maskedBinaryString !== cidrBinaryString) {
-    return 'This is not a subnet address. The subnet prefix is inconsistent with the subnet mask.';
+    return msgs.notSubnetAddress;
   }
   return undefined;
 };
 
 export const awsMachineCidr = (
   value?: string,
-  formData?: Record<string, string>
+  formData?: Record<string, string>,
+  msgs: RosaWizardAwsMachineCidrValidatorStrings = defaultRosaWizardValidatorStrings.awsMachineCidr
 ): string | undefined => {
   if (!value) {
     return undefined;
@@ -284,25 +300,28 @@ export const awsMachineCidr = (
 
   if (prefixLength != null) {
     if (prefixLength < AWS_MACHINE_CIDR_MIN) {
-      return `The subnet mask can't be larger than '/${AWS_MACHINE_CIDR_MIN}'.`;
+      return msgs.maskTooLarge(AWS_MACHINE_CIDR_MIN);
     }
 
     if (
       (isMultiAz || formData?.hypershift === 'true') &&
       prefixLength > AWS_MACHINE_CIDR_MAX_MULTI_AZ
     ) {
-      return `The subnet mask can't be smaller than '/${AWS_MACHINE_CIDR_MAX_MULTI_AZ}'.`;
+      return msgs.maskTooSmallMultiAz(AWS_MACHINE_CIDR_MAX_MULTI_AZ);
     }
 
     if (!isMultiAz && prefixLength > AWS_MACHINE_CIDR_MAX_SINGLE_AZ) {
-      return `The subnet mask can't be smaller than '/${AWS_MACHINE_CIDR_MAX_SINGLE_AZ}'.`;
+      return msgs.maskTooSmallSingleAz(AWS_MACHINE_CIDR_MAX_SINGLE_AZ);
     }
   }
 
   return undefined;
 };
 
-export const serviceCidr = (value?: string): string | undefined => {
+export const serviceCidr = (
+  value?: string,
+  msgs: RosaWizardServiceCidrValidatorStrings = defaultRosaWizardValidatorStrings.serviceCidr
+): string | undefined => {
   if (!value) {
     return undefined;
   }
@@ -312,14 +331,18 @@ export const serviceCidr = (value?: string): string | undefined => {
   if (prefixLength != null) {
     if (prefixLength > SERVICE_CIDR_MAX) {
       const maxServices = 2 ** (32 - SERVICE_CIDR_MAX) - 2;
-      return `The subnet mask can't be smaller than '/${SERVICE_CIDR_MAX}', which provides up to ${maxServices} services.`;
+      return msgs.maskTooSmall(SERVICE_CIDR_MAX, maxServices);
     }
   }
 
   return undefined;
 };
 
-export const podCidr = (value?: string, network_host_prefix?: string): string | undefined => {
+export const podCidr = (
+  value?: string,
+  network_host_prefix?: string,
+  msgs: RosaWizardPodCidrValidatorStrings = defaultRosaWizardValidatorStrings.podCidr
+): string | undefined => {
   if (!value) {
     return undefined;
   }
@@ -327,14 +350,14 @@ export const podCidr = (value?: string, network_host_prefix?: string): string | 
   const prefixLength = parseCIDRSubnetLength(value);
   if (prefixLength != null) {
     if (prefixLength > POD_CIDR_MAX) {
-      return `The subnet mask can't be smaller than /${POD_CIDR_MAX}.`;
+      return msgs.maskTooSmall(POD_CIDR_MAX);
     }
 
-    const hostPrefix = parseCIDRSubnetLength(network_host_prefix) || 23;
-    const maxPodIPs = 2 ** (32 - hostPrefix);
+    const hostPrefixLen = parseCIDRSubnetLength(network_host_prefix) || 23;
+    const maxPodIPs = 2 ** (32 - hostPrefixLen);
     const maxPodNodes = Math.floor(2 ** (32 - prefixLength) / maxPodIPs);
     if (maxPodNodes < POD_NODES_MIN) {
-      return `The subnet mask of /${prefixLength} does not allow for enough nodes. Try changing the host prefix or the pod subnet range.`;
+      return msgs.notEnoughNodes(prefixLength);
     }
   }
 
@@ -345,7 +368,8 @@ export const subnetCidrs = (
   value?: string,
   formData?: Record<string, string>,
   fieldName?: string,
-  selectedSubnets?: CIDRSubnet[]
+  selectedSubnets?: CIDRSubnet[],
+  msgs: RosaWizardSubnetCidrsValidatorStrings = defaultRosaWizardValidatorStrings.subnetCidrs
 ): string | undefined => {
   type ErroredSubnet = {
     cidr_block: string;
@@ -394,33 +418,31 @@ export const subnetCidrs = (
   if (fieldName === 'network_machine_cidr') {
     compareCidrs(true);
     if (erroredSubnets.length > 0) {
-      return `The Machine CIDR does not include the starting IP (${startingIP(
-        erroredSubnets[0].cidr_block
-      )}) of ${subnetName()}`;
+      return msgs.machineDoesNotIncludeStartIp(
+        startingIP(erroredSubnets[0].cidr_block),
+        subnetName() ?? ''
+      );
     }
   }
   if (fieldName === 'network_service_cidr') {
     compareCidrs(false);
     if (erroredSubnets.length > 0) {
       if (erroredSubnets[0]?.overlaps) {
-        return `The Service CIDR overlaps with ${subnetName()} CIDR 
-        '${erroredSubnets[0].cidr_block}'`;
+        return msgs.serviceOverlaps(subnetName() ?? '', erroredSubnets[0].cidr_block);
       }
-      return `The Service CIDR includes the starting IP (${startingIP(
-        erroredSubnets[0].cidr_block
-      )}) of ${subnetName()}`;
+      return msgs.serviceIncludesStartIp(
+        startingIP(erroredSubnets[0].cidr_block),
+        subnetName() ?? ''
+      );
     }
   }
   if (fieldName === 'network_pod_cidr') {
     compareCidrs(false);
     if (erroredSubnets.length > 0) {
       if (erroredSubnets[0]?.overlaps) {
-        return `The Pod CIDR overlaps with ${subnetName()} CIDR 
-        '${erroredSubnets[0].cidr_block}'`;
+        return msgs.podOverlaps(subnetName() ?? '', erroredSubnets[0].cidr_block);
       }
-      return `The Pod CIDR includes the starting IP (${startingIP(
-        erroredSubnets[0].cidr_block
-      )}) of ${subnetName()}`;
+      return msgs.podIncludesStartIp(startingIP(erroredSubnets[0].cidr_block), subnetName() ?? '');
     }
   }
 
@@ -428,7 +450,13 @@ export const subnetCidrs = (
 };
 
 export const awsSubnetMask =
-  (fieldName: string | undefined) =>
+  (
+    fieldName: string | undefined,
+    msgs: Pick<
+      RosaWizardServiceCidrValidatorStrings,
+      'subnetMaskBetween' | 'subnetMaskBetweenOneAnd'
+    > = defaultRosaWizardValidatorStrings.serviceCidr
+  ) =>
   (value?: string): string | undefined => {
     if (!fieldName || cidr(value) !== undefined || !value) {
       return undefined;
@@ -443,12 +471,12 @@ export const awsSubnetMask =
     const maskBits = parseInt(parts[1], 10);
     if (!maskRange[0]) {
       if (maskBits > maskRange[1] || maskBits < 1) {
-        return `Subnet mask must be between /1 and /${maskRange[1]}.`;
+        return msgs.subnetMaskBetweenOneAnd(maskRange[1]);
       }
       return undefined;
     }
     if (!(maskRange[0] <= maskBits && maskBits <= maskRange[1])) {
-      return `Subnet mask must be between /${maskRange[0]} and /${maskRange[1]}.`;
+      return msgs.subnetMaskBetween(maskRange[0], maskRange[1]);
     }
     return undefined;
   };

--- a/src/components/Wizards/RosaWizard/validators.ts
+++ b/src/components/Wizards/RosaWizard/validators.ts
@@ -20,6 +20,17 @@ import {
 import { parseCIDRSubnetLength, stringToArray } from './helpers';
 import IPCIDR from 'ip-cidr';
 import { CIDRSubnet } from '../types';
+import {
+  defaultRosaWizardValidatorStrings,
+  type RosaWizardCaValidatorStrings,
+  type RosaWizardClusterNameValidatorStrings,
+  type RosaWizardKmsKeyValidatorStrings,
+  type RosaWizardNoProxyValidatorStrings,
+  type RosaWizardOperatorRolesPrefixValidatorStrings,
+  type RosaWizardReplicaValidatorStrings,
+  type RosaWizardSecurityGroupsValidatorStrings,
+  type RosaWizardUrlValidatorStrings,
+} from './rosaWizardStrings';
 
 const lowercaseAlphaNumericCharacters = 'abcdefghijklmnopqrstuvwxyz1234567890';
 
@@ -40,40 +51,38 @@ export const composeValidators =
     return undefined;
   };
 
-// TODO: remove any when i18next is implemented
-export function validateClusterName(value: string, _item: unknown, t?: any) {
-  t = t ? t : (value: any) => value;
+export function validateClusterName(
+  value: string,
+  _item?: unknown,
+  msgs: RosaWizardClusterNameValidatorStrings = defaultRosaWizardValidatorStrings.clusterName
+) {
   if (!value) return undefined;
-  if (value.length > 54) return `${t('This value can contain at most 54 characters')}`;
+  if (value.length > 54) return msgs.maxLength;
   for (const char of value) {
     if (!lowercaseAlphaNumericCharacters.includes(char) && char !== '-' && char !== '.')
-      return `${t("This value can only contain lowercase alphanumeric characters or '-' or '.'")}`;
+      return msgs.invalidChars;
   }
-  if (!lowercaseAlphaNumericCharacters.includes(value[0]))
-    return `${t('This value must start with an alphanumeric character')}`;
-  if (/^[0-9]/.test(value[0])) return `${t('This value must not start with a number')}`;
+  if (!lowercaseAlphaNumericCharacters.includes(value[0])) return msgs.mustStartAlphanumeric;
+  if (/^[0-9]/.test(value[0])) return msgs.mustNotStartNumber;
   if (!lowercaseAlphaNumericCharacters.includes(value[value.length - 1]))
-    return `${t('This value must end with an alphanumeric character')}`;
+    return msgs.mustEndAlphanumeric;
   return undefined;
 }
 
 export const validateCustomOperatorRolesPrefix = (
   value: string,
-  _item: unknown,
-  t?: any
+  _item?: unknown,
+  msgs: RosaWizardOperatorRolesPrefixValidatorStrings = defaultRosaWizardValidatorStrings.operatorRolesPrefix
 ): string | undefined => {
-  t = t ? t : (value: any) => value;
-  const label = 'Custom operator roles prefix';
+  const label = msgs.fieldLabel;
   if (!value) {
     return undefined;
   }
   if (!DNS_LABEL_REGEXP.test(value)) {
-    const validationErrorString = `${label} '${value}' isn't valid, must consist of lower-case alphanumeric characters or '-', start with an alphabetic character, and end with an alphanumeric character. For example, 'my-name', or 'abc-123'.`;
-    return t(validationErrorString);
+    return msgs.invalidFormat(label, value);
   }
   if (value.length > MAX_CUSTOM_OPERATOR_ROLES_PREFIX_LENGTH) {
-    const validationErrorString = `${label} may not exceed ${MAX_CUSTOM_OPERATOR_ROLES_PREFIX_LENGTH} characters.`;
-    return t(validationErrorString);
+    return msgs.tooLong(label, MAX_CUSTOM_OPERATOR_ROLES_PREFIX_LENGTH);
   }
   return undefined;
 };
@@ -81,15 +90,14 @@ export const validateCustomOperatorRolesPrefix = (
 export const validateAWSKMSKeyARN = (
   value: string,
   region: string,
-  t?: any
+  msgs: RosaWizardKmsKeyValidatorStrings = defaultRosaWizardValidatorStrings.kmsKeyArn
 ): string | undefined => {
-  t = t ? t : (value: any) => value;
   if (!value) {
-    return `${t('Field is required.')}`;
+    return msgs.required;
   }
 
   if (/\s/.test(value)) {
-    return `${t('Value must not contain whitespaces.')}`;
+    return msgs.noWhitespace;
   }
 
   if (
@@ -97,18 +105,21 @@ export const validateAWSKMSKeyARN = (
       ? !AWS_KMS_MULTI_REGION_SERVICE_ACCOUNT_REGEX.test(value)
       : !AWS_KMS_SERVICE_ACCOUNT_REGEX.test(value)
   ) {
-    return `${t('Key provided is not a valid ARN. It should be in the format "arn:aws:kms:<region>:<accountid>:key/<keyid>".')}`;
+    return msgs.invalidArn;
   }
 
   const kmsRegion = value.split('kms:')?.pop()?.split(':')[0];
   if (kmsRegion !== region) {
-    return `${t('Your KMS key must contain your selected region.')}`;
+    return msgs.wrongRegion;
   }
 
   return undefined;
 };
 
-export const checkNoProxyDomains = (value?: string) => {
+export const checkNoProxyDomains = (
+  value?: string,
+  msgs: RosaWizardNoProxyValidatorStrings = defaultRosaWizardValidatorStrings.noProxyDomains
+) => {
   const stringArray = stringToArray(value);
   if (stringArray && stringArray.length > 0) {
     const invalidDomains = stringArray.filter(
@@ -116,16 +127,16 @@ export const checkNoProxyDomains = (value?: string) => {
     );
     const plural = invalidDomains.length > 1;
     if (invalidDomains.length > 0) {
-      return `The domain${plural ? 's' : ''} '${invalidDomains.join(', ')}' ${
-        plural ? "aren't" : "isn't"
-      } valid, 
-      must contain at least two valid lower-case DNS labels separated by dots, for example 'domain.com' or 'sub.domain.com'.`;
+      return msgs.invalidDomains(invalidDomains.join(', '), plural);
     }
   }
   return undefined;
 };
 
-export const validateCA = (value: string): string | undefined => {
+export const validateCA = (
+  value: string,
+  msgs: RosaWizardCaValidatorStrings = defaultRosaWizardValidatorStrings.ca
+): string | undefined => {
   if (!value) {
     return undefined;
   }
@@ -133,17 +144,18 @@ export const validateCA = (value: string): string | undefined => {
     /-----BEGIN\s+(CERTIFICATE|TRUSTED CERTIFICATE|X509 CRL)-----[\s\S]+?-----END\s+(CERTIFICATE|TRUSTED CERTIFICATE|X509 CRL)-----/;
 
   if (value.length > MAX_CA_SIZE_BYTES) {
-    return 'File must be no larger than 4 MB';
+    return msgs.fileTooLarge;
   }
   if (!pemRegex.test(value)) {
-    return 'Must be a PEM encoded X.509 file (.pem, .crt, .ca, .cert) and no larger than 4 MB';
+    return msgs.invalidPem;
   }
   return undefined;
 };
 
 export const validateUrl = (
   value: string,
-  protocol: string | string[] = 'http'
+  protocol: string | string[] = 'http',
+  msgs: RosaWizardUrlValidatorStrings = defaultRosaWizardValidatorStrings.url
 ): string | undefined => {
   if (!value) {
     return undefined;
@@ -158,13 +170,13 @@ export const validateUrl = (
     // eslint-disable-next-line no-new
     new URL(value);
   } catch (error) {
-    return 'Invalid URL';
+    return msgs.invalid;
   } finally {
     const valueStart = value.substring(0, value.indexOf('://'));
     if (!protocolArr.includes(valueStart)) {
       const protocolStr = protocolArr.map((p) => `${p}://`).join(', ');
       // eslint-disable-next-line no-unsafe-finally
-      return `The URL should include the scheme prefix (${protocolStr})`;
+      return msgs.schemePrefix(protocolStr);
     }
   }
   return undefined;
@@ -473,15 +485,18 @@ export const validateNumericInput = (
   return undefined;
 };
 
-export const validatePositiveInteger = (value: number | undefined): string | undefined => {
+export const validatePositiveInteger = (
+  value: number | undefined,
+  msgs: RosaWizardReplicaValidatorStrings = defaultRosaWizardValidatorStrings.replicas
+): string | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
   if (!Number.isInteger(value)) {
-    return 'Input must be an integer.';
+    return msgs.notInteger;
   }
   if (value <= 0) {
-    return 'Input must be a positive number.';
+    return msgs.notPositive;
   }
   return undefined;
 };
@@ -489,21 +504,22 @@ export const validatePositiveInteger = (value: number | undefined): string | und
 export const validateMinReplicas = (
   value: number | undefined,
   item?: unknown,
-  machinePoolsNumber?: number
+  machinePoolsNumber?: number,
+  msgs: RosaWizardReplicaValidatorStrings = defaultRosaWizardValidatorStrings.replicas
 ): string | undefined => {
-  const positiveError = validatePositiveInteger(value);
+  const positiveError = validatePositiveInteger(value, msgs);
   if (positiveError) return positiveError;
   const typedItem = item as { cluster?: { max_replicas?: number } } | undefined;
   if (value !== undefined && value > 500) {
-    return 'Input cannot be more than 500.';
+    return msgs.maxNodes(500);
   }
   if (value !== undefined && typedItem?.cluster?.max_replicas !== undefined) {
     if (value > typedItem?.cluster?.max_replicas) {
-      return 'Min nodes cannot be greater than max nodes.';
+      return msgs.minGreaterThanMax;
     }
   }
   if (machinePoolsNumber && machinePoolsNumber < 2 && value !== undefined && value < 2) {
-    return 'Input cannot be less than 2 nodes.';
+    return msgs.computeMinTwo;
   }
   return undefined;
 };
@@ -511,9 +527,10 @@ export const validateMinReplicas = (
 export const validateMaxReplicas = (
   value: number | undefined,
   item?: unknown,
-  maxNodeBasedOnOpenshiftVersion?: number
+  maxNodeBasedOnOpenshiftVersion?: number,
+  msgs: RosaWizardReplicaValidatorStrings = defaultRosaWizardValidatorStrings.replicas
 ): string | undefined => {
-  const positiveError = validatePositiveInteger(value);
+  const positiveError = validatePositiveInteger(value, msgs);
   if (positiveError) return positiveError;
   const typedItem = item as { cluster?: { min_replicas?: number } } | undefined;
   if (
@@ -521,39 +538,48 @@ export const validateMaxReplicas = (
     maxNodeBasedOnOpenshiftVersion !== undefined &&
     value > maxNodeBasedOnOpenshiftVersion
   ) {
-    return `Input cannot be more than ${maxNodeBasedOnOpenshiftVersion}.`;
+    return msgs.maxNodes(maxNodeBasedOnOpenshiftVersion);
   }
   if (value !== undefined && typedItem?.cluster?.min_replicas !== undefined) {
     if (value < typedItem?.cluster?.min_replicas) {
-      return 'Max nodes must be greater than or equal to min nodes.';
+      return msgs.maxLessThanMin;
     }
   }
   return undefined;
 };
 
-export const validateComputeNodes = (value: number | undefined): string | undefined => {
-  return validatePositiveInteger(value);
+export const validateComputeNodes = (
+  value: number | undefined,
+  msgs: RosaWizardReplicaValidatorStrings = defaultRosaWizardValidatorStrings.replicas
+): string | undefined => {
+  return validatePositiveInteger(value, msgs);
 };
 
-export const validateRootDiskSize = (value: number | undefined): string | undefined => {
+export const validateRootDiskSize = (
+  value: number | undefined,
+  msgs = defaultRosaWizardValidatorStrings.rootDisk
+): string | undefined => {
   if (value === undefined || value === null) {
     return undefined;
   }
   if (!Number.isInteger(value)) {
-    return 'Root disk size must be an integer.';
+    return msgs.notInteger;
   }
   if (value < 75) {
-    return 'Root disk size must be at least 75 GiB.';
+    return msgs.tooSmall;
   }
   if (value > 16384) {
-    return 'Root disk size must not exceed 16384 GiB.';
+    return msgs.tooLarge;
   }
   return undefined;
 };
 
-export const validateSecurityGroups = (securityGroups: string[]) => {
+export const validateSecurityGroups = (
+  securityGroups: string[],
+  msgs: RosaWizardSecurityGroupsValidatorStrings = defaultRosaWizardValidatorStrings.securityGroups
+) => {
   const maxSecurityGroups = 10;
   return securityGroups?.length && securityGroups.length > maxSecurityGroups
-    ? `A maximum of ${maxSecurityGroups} security groups can be selected.`
+    ? msgs.maxExceeded(maxSecurityGroups)
     : undefined;
 };

--- a/src/components/Wizards/index.ts
+++ b/src/components/Wizards/index.ts
@@ -25,3 +25,20 @@ export type {
 /** @deprecated use `Role` instead. */
 export type { Role as Roles } from './types';
 export type { BasicSetupStepProps, WizardStepsData } from './RosaWizard/RosaWizard';
+export type {
+  RosaWizardStrings,
+  RosaWizardStringsInput,
+  DeepPartial,
+  RosaWizardValidatorStrings,
+} from './RosaWizard/rosaWizardStrings';
+export {
+  defaultRosaWizardStrings,
+  mergeRosaWizardStrings,
+  buildRosaWizardStringBundles,
+  defaultRosaWizardValidatorStrings,
+} from './RosaWizard/rosaWizardStrings';
+export {
+  RosaWizardStringsProvider,
+  useRosaWizardStrings,
+  useRosaWizardValidators,
+} from './RosaWizard/RosaWizardStringsContext';

--- a/src/components/Wizards/index.ts
+++ b/src/components/Wizards/index.ts
@@ -32,6 +32,7 @@ export type {
   RosaWizardValidatorStrings,
 } from './RosaWizard/rosaWizardStrings';
 export {
+  buildWizardStringsForRosa,
   defaultRosaWizardStrings,
   mergeRosaWizardStrings,
   buildRosaWizardStringBundles,


### PR DESCRIPTION
## Description
***AI written PR (with prompting from Kim)***

**Description**
Rosa cluster creation wizard copy is no longer tied to the old translation setup inside this library. All wizard wording (labels, help text, validation messages, and the shared wizard chrome like Next / Cancel) can be supplied or overridden from the app that embeds the wizard. English defaults stay in the repo so nothing breaks if an app passes no custom copy.

**Testing**
This is largely a refactor of how text is provided (props and context instead of the previous i18n path), so tests were updated to match the new wiring. A component test was added to confirm that custom strings passed into RosaWizard show up where users expect—both in the step navigation and in react-form-wizard UI (for example the Next button), so we know those props are applied end-to-end. Other Playwright CT mounts that render Rosa steps in isolation were aligned with the same string provider used in Storybook.

**How to implement (for consumers)**
Default English and the full shape of the strings live in two places you can use as references—or copy into your app and edit:

Rosa-specific copy (steps, fields, validation messages, optional formWizard overrides):
src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts

Shared wizard chrome (footer buttons, “Required”, typeahead strings, aria labels, etc.):
packages/react-form-wizard/src/contexts/StringContext.tsx (defaultStrings / WizardStrings)

After copying or hand-authoring overrides, pass them into RosaWizard with the strings prop:

Most Rosa UI uses the nested object under strings (same structure as the defaults file).
strings.formWizard is optional: it maps to react-form-wizard’s string bundle (what powers Next, Back, Cancel, etc.).
You do not need to pass every string. Omitted keys keep the library defaults. Examples:

Only change the Next button: pass strings={{ formWizard: { nextButtonText: '…' } }} (plus any other partials you want).
Only change a few step titles: pass strings={{ wizard: { stepLabels: { review: '…' } } }}.
Mix and match: partial Rosa strings + partial formWizard in one strings object.
Use mergeRosaWizardStrings / buildRosaWizardStringBundles from the Wizards barrel if you want to merge app locale objects with defaults before passing strings.


**Jira issue #** 
Fixes [FCN-65](https://redhat.atlassian.net/browse/FCN-65)


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
Go through the wizard and ensure the text is showing as expected


### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->

### After
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->



[FCN-65]: https://redhat.atlassian.net/browse/FCN-65?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ