### PR TITLE
FCN-164: reset related fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@types/node": "^24.9.1",
         "@types/react": "^18.3.26",
         "@types/react-dom": "^18.2.7",
+        "@types/set-value": "^4.0.3",
         "@types/victory": "^33.1.5",
         "@typescript-eslint/eslint-plugin": "^6.0.0",
         "@typescript-eslint/parser": "^6.0.0",
@@ -5256,6 +5257,12 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true
+    },
+    "node_modules/@types/set-value": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/set-value/-/set-value-4.0.3.tgz",
+      "integrity": "sha512-tSuUcLl6kMzI+l0gG7FZ04xbIcynxNIYgWFj91LPAvRcn7W3L1EveXNdVjqFDgAZPjY1qCOsm8Sb1C70SxAPHw==",
       "dev": true
     },
     "node_modules/@types/stack-utils": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@types/node": "^24.9.1",
     "@types/react": "^18.3.26",
     "@types/react-dom": "^18.2.7",
+    "@types/set-value": "^4.0.3",
     "@types/victory": "^33.1.5",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
@@ -67,7 +67,7 @@ const minimalWizardsStepsData: { basicSetupStep: BasicSetupStepProps } = {
     awsBillingAccounts: mockResource([
       { label: 'Billing Account - Main (123456789012)', value: 'billing-main-123456789012' },
     ]),
-    regions: mockResource([
+    regions: mockFetchResource([
       { label: 'US East 1, US, Virginia', value: 'us-east-1' },
       { label: 'US West 1, US, Oregon', value: 'us-west-1' },
     ]),

--- a/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
@@ -72,7 +72,7 @@ const mockRegions = [
   { label: 'Asia Pacific (Tokyo)', value: 'ap-northeast-1' },
 ];
 
-const mockRoles: Role[] = [
+const mockRoles = [
   {
     installerRole: {
       label: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Installer-Role',
@@ -119,6 +119,15 @@ const mockMachineTypes = [
     label: 'm6a.xlarge',
     description: '4 vCPU 16 GiB RAM',
     value: 'm6a.xlarge',
+  },
+];
+
+const mockMachineTypesLimited = [
+  {
+    id: 'm5a.xlarge',
+    label: 'm5a.xlarge',
+    description: '4 vCPU 16 GiB RAM',
+    value: 'm5a.xlarge',
   },
 ];
 

--- a/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
@@ -727,7 +727,6 @@ function AsyncLoadingWrapper(props: React.ComponentProps<typeof RosaWizard>) {
 
   const machineTypesFetch = React.useCallback(async (region?: string) => {
     setMachineTypes((prev) => ({ ...prev, isFetching: true }));
-    console.log('REGION STORY', region);
     await new Promise((resolve) => setTimeout(resolve, 1000));
     if (region === 'us-east-1') {
       // fetching m6a and m5a

--- a/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.stories.tsx
@@ -1,7 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 import { RosaWizard } from './RosaWizard';
-import type { OpenShiftVersionsData, Resource, Role, ValidationResource } from '../types';
+import type {
+  MachineTypesDropdownType,
+  Region,
+  AWSInfrastructureAccounts,
+  OpenShiftVersionsData,
+  Resource,
+  Role,
+  ValidationResource,
+} from '../types';
 import type { BasicSetupStepProps } from './RosaWizard';
 
 // wraps static mock data in the Resource shape for stories
@@ -124,10 +132,10 @@ const mockMachineTypes = [
 
 const mockMachineTypesLimited = [
   {
-    id: 'm5a.xlarge',
-    label: 'm5a.xlarge',
+    id: 'm6a.xlarge',
+    label: 'm6a.xlarge',
     description: '4 vCPU 16 GiB RAM',
-    value: 'm5a.xlarge',
+    value: 'm6a.xlarge',
   },
 ];
 
@@ -218,7 +226,7 @@ const mockBasicSetupStep: BasicSetupStepProps = {
   versions: mockFetchResource(mockVersionsData),
   awsInfrastructureAccounts: mockResource(mockAwsInfrastructureAccounts),
   awsBillingAccounts: mockResource(mockAwsBillingAccounts),
-  regions: mockResource(mockRegions),
+  regions: mockFetchResource<Region[], [awsAccount: string]>(mockRegions),
   roles: mockFetchResource<Role[], [awsAccount: string]>(mockRoles),
   oidcConfig: mockResource(mockOicdConfig),
   machineTypes: mockResource(mockMachineTypes),
@@ -318,10 +326,6 @@ export const MinimalOptions: Story = {
             value: 'billing-main-123456789012',
           },
         ]),
-        regions: mockResource([
-          { label: 'US East 1, US, Virginia', value: 'us-east-1' },
-          { label: 'US West 1, US, Oregon', value: 'us-west-1' },
-        ]),
       },
     },
   },
@@ -351,7 +355,7 @@ export const EmptyOptions: Story = {
         }),
         awsInfrastructureAccounts: mockResource([]),
         awsBillingAccounts: mockResource([]),
-        regions: mockResource([]),
+        regions: mockFetchResource([]),
       },
     },
   },
@@ -637,10 +641,6 @@ export const ProductionSetup: Story = {
             value: 'billing-corp-987654321098',
           },
         ]),
-        regions: mockResource([
-          { label: 'US East 1, US, Virginia', value: 'us-east-1' },
-          { label: 'US West 1, US, Oregon', value: 'us-west-1' },
-        ]),
       },
     },
   },
@@ -682,6 +682,108 @@ export const SubmitError: Story = {
     onCancel: () => {
       console.log('Wizard cancelled');
       alert('Wizard cancelled');
+    },
+    wizardsStepsData: {
+      basicSetupStep: mockBasicSetupStep,
+    },
+  },
+};
+
+/**
+ * Demonstrates async loading behaviour:
+ * - AWS infrastructure accounts start loading, then populate after 2 s.
+ * - When the user picks an account, the regions dropdown enters a loading
+ *   state for 1.5 s before populating with mock regions.
+ */
+function AsyncLoadingWrapper(props: React.ComponentProps<typeof RosaWizard>) {
+  const [awsAccounts, setAwsAccounts] = React.useState<Resource<AWSInfrastructureAccounts[]>>({
+    data: [],
+    error: null,
+    isFetching: true,
+  });
+
+  const [regions, setRegions] = React.useState<Resource<Region[]>>({
+    data: [],
+    error: null,
+    isFetching: false,
+  });
+
+  const [machineTypes, setMachineTypes] = React.useState<Resource<MachineTypesDropdownType[]>>({
+    data: mockMachineTypes,
+    error: null,
+    isFetching: false,
+  });
+
+  React.useEffect(() => {
+    const timer = setTimeout(() => {
+      setAwsAccounts({
+        data: mockAwsInfrastructureAccounts,
+        error: null,
+        isFetching: false,
+      });
+    }, 2000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const machineTypesFetch = React.useCallback(async (region?: string) => {
+    setMachineTypes((prev) => ({ ...prev, isFetching: true }));
+    console.log('REGION STORY', region);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    if (region === 'us-east-1') {
+      // fetching m6a and m5a
+      setMachineTypes({ data: mockMachineTypes, error: null, isFetching: false });
+    } else {
+      // fetching only m6a
+      setMachineTypes({ data: mockMachineTypesLimited, error: null, isFetching: false });
+    }
+  }, []);
+
+  const regionsFetch = React.useCallback(async (awsAccount?: string) => {
+    const mockedRegions = [
+      { label: 'US East (N. Virginia)', value: 'us-east-1' },
+      { label: 'US West (Oregon)', value: 'us-west-2' },
+      { label: 'EU (London)', value: 'eu-west-2' },
+      { label: 'EU (Paris)', value: 'eu-west-3' },
+      { label: 'Asia Pacific (Singapore)', value: 'ap-southeast-1' },
+      { label: 'Asia Pacific (Sydney)', value: 'ap-southeast-2' },
+      { label: 'Canada (Central)', value: 'ca-central-1' },
+    ];
+    const mockedRegionsLimited = [
+      { label: 'US East (N. Virginia) - Limited', value: 'us-east-1' },
+      { label: 'US West (Oregon) - Limited', value: 'us-west-2' },
+      { label: 'EU (Frankfurt)', value: 'eu-west-4' },
+      { label: 'EU (Rome)', value: 'eu-west-5' },
+    ];
+    setRegions((prev) => ({ ...prev, isFetching: true }));
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    if (awsAccount === 'aws-dev-345678901234') {
+      setRegions({ data: mockedRegionsLimited, error: null, isFetching: false });
+    } else {
+      setRegions({ data: mockedRegions, error: null, isFetching: false });
+    }
+  }, []);
+
+  const basicSetupStep: BasicSetupStepProps = {
+    ...props.wizardsStepsData.basicSetupStep,
+    awsInfrastructureAccounts: awsAccounts,
+    regions: { ...regions, fetch: regionsFetch },
+    machineTypes: { ...machineTypes, fetch: machineTypesFetch },
+  };
+
+  return <RosaWizard {...props} wizardsStepsData={{ ...props.wizardsStepsData, basicSetupStep }} />;
+}
+
+export const AsyncLoading: Story = {
+  render: (args) => <AsyncLoadingWrapper {...args} />,
+  args: {
+    title: 'Create ROSA Cluster - Async Loading',
+    onSubmit: async (data: unknown) => {
+      console.log('Wizard submitted with data:', data);
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+      alert('Cluster creation initiated successfully!');
+    },
+    onCancel: () => {
+      console.log('Wizard cancelled');
     },
     wizardsStepsData: {
       basicSetupStep: mockBasicSetupStep,

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -16,7 +16,6 @@ import React, { ReactNode } from 'react';
 import { ClusterWideProxySubstep } from './Steps/AdditionalSetupStep/ClusterWideProxySubstep/ClusterWideProxySubstep';
 import { ReviewStepData } from './Steps/ReviewStepData';
 import {
-  MachineTypesDropdownType,
   OIDCConfig,
   OpenShiftVersionsData,
   Role,
@@ -27,6 +26,7 @@ import {
   ValidationResource,
   VPC,
   WizardNavigationContext,
+  MachineTypesDropdownType,
 } from '../types';
 import { MachinePoolsSubstep } from './Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep';
 import { YamlDrawerEditor } from './Steps/YamlCodeEditor';
@@ -153,6 +153,12 @@ const RosaWizardBody = (props: RosaWizardProps) => {
       compute_root_volume: 300,
     },
   };
+  const opVersions = {
+    data: buildVersionOptions(basicSetupStep.versions.data),
+    fetch: () => basicSetupStep.versions.fetch(),
+    error: null,
+    isFetching: basicSetupStep.versions.isFetching
+  }
 
   return (
     <>
@@ -186,9 +192,8 @@ const RosaWizardBody = (props: RosaWizardProps) => {
               <Step label={sl.details} id="basic-setup-step-details" key="basic-setup-details">
                 <DetailsSubStep
                   clusterNameValidation={basicSetupStep.clusterNameValidation}
-                  openShiftVersions={buildVersionOptions(basicSetupStep.versions.data)}
-                  versionsIsPending={basicSetupStep.versions.isFetching}
-                  refreshVersionsCallback={() => void basicSetupStep.versions.fetch()}
+                  openShiftVersions={opVersions}
+                  machineTypes={basicSetupStep.machineTypes}
                   roles={basicSetupStep.roles}
                   awsInfrastructureAccounts={basicSetupStep.awsInfrastructureAccounts}
                   awsBillingAccounts={basicSetupStep.awsBillingAccounts}

--- a/src/components/Wizards/RosaWizard/RosaWizard.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.tsx
@@ -27,6 +27,7 @@ import {
   VPC,
   WizardNavigationContext,
   MachineTypesDropdownType,
+  Region,
 } from '../types';
 import { MachinePoolsSubstep } from './Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep';
 import { YamlDrawerEditor } from './Steps/YamlCodeEditor';
@@ -42,7 +43,9 @@ export type BasicSetupStepProps = {
   versions: Resource<OpenShiftVersionsData, []> & { fetch: () => Promise<void> };
   awsInfrastructureAccounts: Resource<SelectDropdownType[]>;
   awsBillingAccounts: Resource<SelectDropdownType[]>;
-  regions: Resource<SelectDropdownType[]>;
+  regions: Resource<Region[], [awsAccount: string]> & {
+    fetch: (awsAccount: string) => Promise<void>;
+  };
   roles: Resource<Role[], [awsAccount: string]> & {
     fetch: (awsAccount: string) => Promise<void>;
   };
@@ -157,8 +160,8 @@ const RosaWizardBody = (props: RosaWizardProps) => {
     data: buildVersionOptions(basicSetupStep.versions.data),
     fetch: () => basicSetupStep.versions.fetch(),
     error: null,
-    isFetching: basicSetupStep.versions.isFetching
-  }
+    isFetching: basicSetupStep.versions.isFetching,
+  };
 
   return (
     <>

--- a/src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx
@@ -80,7 +80,7 @@ const wizardStepsData: WizardStepsData = {
     versions: mockFetchResource(versionsData),
     awsInfrastructureAccounts: mockResource([{ label: 'aws-account-1', value: 'aws-account-1' }]),
     awsBillingAccounts: mockResource([{ label: 'billing-account-1', value: 'billing-account-1' }]),
-    regions: mockResource([{ label: 'US East 1', value: 'us-east-1' }]),
+    regions: mockFetchResource([{ label: 'US East 1', value: 'us-east-1' }]),
     roles: mockFetchResource<Role[], [awsAccount: string]>(roles),
     oidcConfig: mockResource(oidcConfigs),
     machineTypes: mockResource([

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.spec.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.spec.tsx
@@ -1,0 +1,202 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import { checkAccessibility } from '../../../../../../test-helpers';
+import { DetailsSubStepStory } from './DetailsSubStep.story';
+import { mockRegions, mockSingleBillingAccount } from './DetailsSubStep.story';
+
+test.describe('DetailsSubStep', () => {
+  test('should pass accessibility tests', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+    await checkAccessibility({ component });
+  });
+
+  test('should render the Details section title', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(component.getByText('Details', { exact: true })).toBeVisible();
+  });
+
+  test('should render the Cluster name input', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(component.getByText('Cluster name', { exact: true })).toBeVisible();
+    await expect(component.getByRole('textbox', { name: 'Cluster name' })).toBeVisible();
+  });
+
+  test('should render the OpenShift version select', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(component.getByText('OpenShift version', { exact: true })).toBeVisible();
+  });
+
+  test('should render the Associated AWS infrastructure account select', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(
+      component.getByText('Associated AWS infrastructure account', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('should render the Associated AWS billing account select', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(
+      component.getByText('Associated AWS billing account', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('should render the Region select', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(component.getByText('Region', { exact: true })).toBeVisible();
+  });
+
+  test('should render the Associate a new AWS account button', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(component.getByText('Associate a new AWS account')).toBeVisible();
+  });
+
+  test('should show OpenShift version options in dropdown', async ({ mount, page }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const versionCombobox = component.locator('#cluster-cluster_version [role="combobox"]');
+    await versionCombobox.click();
+
+    await expect(page.getByText('OpenShift 4.12.0', { exact: true })).toBeVisible();
+    await expect(page.getByText('OpenShift 4.11.5', { exact: true })).toBeVisible();
+  });
+
+  test('should show AWS infrastructure account options in dropdown', async ({ mount, page }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const awsCombobox = component.locator('#cluster-associated_aws_id [role="combobox"]');
+    await awsCombobox.click();
+
+    await expect(
+      page.getByText('AWS Account - Production (123456789012)', { exact: true })
+    ).toBeVisible();
+    await expect(
+      page.getByText('AWS Account - Staging (234567890123)', { exact: true })
+    ).toBeVisible();
+  });
+
+  test('should show region options in dropdown', async ({ mount, page }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const regionCombobox = component.locator('#cluster-region [role="combobox"]');
+    await regionCombobox.click();
+
+    for (const region of mockRegions) {
+      await expect(page.getByText(region.label, { exact: true })).toBeVisible();
+    }
+  });
+
+  test('should show disabled state for AWS infrastructure account when loading', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <DetailsSubStepStory awsInfrastructureAccounts={{ data: [], isFetching: true, error: null }} />
+    );
+
+    const awsSelect = component.locator('#cluster-associated_aws_id');
+    await expect(awsSelect).toBeVisible();
+    await expect(awsSelect.locator('.pf-m-disabled')).toBeVisible();
+  });
+
+  test('should show disabled state for AWS billing account when loading', async ({ mount }) => {
+    const component = await mount(
+      <DetailsSubStepStory awsBillingAccounts={{ data: [], isFetching: true, error: null }} />
+    );
+
+    const billingSelect = component.locator('#cluster-billing_account_id');
+    await expect(billingSelect).toBeVisible();
+    await expect(billingSelect.locator('.pf-m-disabled')).toBeVisible();
+  });
+
+  test('should show disabled state for Region select when loading', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory regions={{ data: [], isFetching: true, error: null }} />);
+
+    const regionSelect = component.locator('#cluster-region');
+    await expect(regionSelect).toBeVisible();
+    await expect(regionSelect.locator('.pf-m-disabled')).toBeVisible();
+  });
+
+  test('should auto-select billing account when only one is available', async ({ mount }) => {
+    const component = await mount(
+      <DetailsSubStepStory
+        awsBillingAccounts={{ data: mockSingleBillingAccount, isFetching: false, error: null }}
+      />
+    );
+
+    const billingCombobox = component.locator('#cluster-billing_account_id [role="combobox"]');
+    await expect(billingCombobox).toHaveValue(mockSingleBillingAccount[0].label);
+  });
+
+  test('should not auto-select billing account when multiple are available', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const billingCombobox = component.locator('#cluster-billing_account_id [role="combobox"]');
+    await expect(billingCombobox).toHaveValue('');
+  });
+
+  test('should render with empty OpenShift versions', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory openShiftVersions={{ data: [], isFetching: false, error: null }} />);
+
+    await expect(component.getByText('OpenShift version', { exact: true })).toBeVisible();
+  });
+
+  test('should render with empty regions', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory regions={{ data: [], isFetching: false, error: null }} />);
+
+    await expect(component.getByText('Region', { exact: true })).toBeVisible();
+  });
+
+  test('should render the Connect ROSA to a new AWS billing account link', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    await expect(component.getByText('Connect ROSA to a new AWS billing account')).toBeVisible();
+  });
+
+  test('should allow typing a cluster name', async ({ mount }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const nameInput = component.getByRole('textbox', { name: 'Cluster name' });
+    await nameInput.fill('my-test-cluster');
+
+    await expect(nameInput).toHaveValue('my-test-cluster');
+  });
+
+  test('should select an OpenShift version', async ({ mount, page }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const versionCombobox = component.locator('#cluster-cluster_version [role="combobox"]');
+    await versionCombobox.click();
+    await page.getByText('OpenShift 4.12.0', { exact: true }).click();
+
+    await expect(versionCombobox).toHaveValue('OpenShift 4.12.0');
+  });
+
+  test('should select a region', async ({ mount, page }) => {
+    const component = await mount(<DetailsSubStepStory />);
+
+    const regionCombobox = component.locator('#cluster-region [role="combobox"]');
+    await regionCombobox.click();
+    await page.getByText('US East (N. Virginia)', { exact: true }).click();
+
+    await expect(regionCombobox).toHaveValue('US East (N. Virginia)');
+  });
+
+  test('should render pre-filled cluster data', async ({ mount }) => {
+    const component = await mount(
+      <DetailsSubStepStory
+        clusterOverrides={{
+          name: 'existing-cluster',
+          billing_account_id: 'billing-main-123456789012',
+        }}
+      />
+    );
+
+    const nameInput = component.getByRole('textbox', { name: 'Cluster name' });
+    await expect(nameInput).toHaveValue('existing-cluster');
+  });
+});

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.spec.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.spec.tsx
@@ -95,7 +95,9 @@ test.describe('DetailsSubStep', () => {
     mount,
   }) => {
     const component = await mount(
-      <DetailsSubStepStory awsInfrastructureAccounts={{ data: [], isFetching: true, error: null }} />
+      <DetailsSubStepStory
+        awsInfrastructureAccounts={{ data: [], isFetching: true, error: null }}
+      />
     );
 
     const awsSelect = component.locator('#cluster-associated_aws_id');
@@ -114,7 +116,11 @@ test.describe('DetailsSubStep', () => {
   });
 
   test('should show disabled state for Region select when loading', async ({ mount }) => {
-    const component = await mount(<DetailsSubStepStory regions={{ data: [], isFetching: true, error: null }} />);
+    const component = await mount(
+      <DetailsSubStepStory
+        regions={{ data: [], isFetching: true, error: null, fetch: async () => {} }}
+      />
+    );
 
     const regionSelect = component.locator('#cluster-region');
     await expect(regionSelect).toBeVisible();
@@ -140,13 +146,19 @@ test.describe('DetailsSubStep', () => {
   });
 
   test('should render with empty OpenShift versions', async ({ mount }) => {
-    const component = await mount(<DetailsSubStepStory openShiftVersions={{ data: [], isFetching: false, error: null }} />);
+    const component = await mount(
+      <DetailsSubStepStory openShiftVersions={{ data: [], isFetching: false, error: null }} />
+    );
 
     await expect(component.getByText('OpenShift version', { exact: true })).toBeVisible();
   });
 
   test('should render with empty regions', async ({ mount }) => {
-    const component = await mount(<DetailsSubStepStory regions={{ data: [], isFetching: false, error: null }} />);
+    const component = await mount(
+      <DetailsSubStepStory
+        regions={{ data: [], isFetching: false, error: null, fetch: async () => {} }}
+      />
+    );
 
     await expect(component.getByText('Region', { exact: true })).toBeVisible();
   });

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.story.tsx
@@ -1,0 +1,166 @@
+import React, { useState, useCallback } from 'react';
+import { DetailsSubStep } from './DetailsSubStep';
+import { TranslationProvider } from '../../../../../../context/TranslationContext';
+import { ItemContext } from '@patternfly-labs/react-form-wizard/contexts/ItemContext';
+import { DataContext } from '@patternfly-labs/react-form-wizard/contexts/DataContext';
+import {
+  DisplayModeContext,
+  DisplayMode,
+} from '@patternfly-labs/react-form-wizard/contexts/DisplayModeContext';
+import { ShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ShowValidationProvider';
+import { ValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ValidationProvider';
+import { StepShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/StepShowValidationProvider';
+import { SelectDropdownType, Resource, Role } from '../../../../types';
+
+export const mockOpenShiftVersions: SelectDropdownType[] = [
+  { label: 'OpenShift 4.12.0', value: '4.12.0' },
+  { label: 'OpenShift 4.11.5', value: '4.11.5' },
+];
+
+export const mockAwsInfrastructureAccounts: SelectDropdownType[] = [
+  { label: 'AWS Account - Production (123456789012)', value: 'aws-prod-123456789012' },
+  { label: 'AWS Account - Staging (234567890123)', value: 'aws-staging-234567890123' },
+];
+
+export const mockAwsBillingAccounts: SelectDropdownType[] = [
+  { label: 'Billing Account - Main (123456789012)', value: 'billing-main-123456789012' },
+  { label: 'Billing Account - Secondary (234567890123)', value: 'billing-secondary-234567890123' },
+];
+
+export const mockSingleBillingAccount: SelectDropdownType[] = [
+  { label: 'Billing Account - Main (123456789012)', value: 'billing-main-123456789012' },
+];
+
+export const mockRegions: SelectDropdownType[] = [
+  { label: 'US East (N. Virginia)', value: 'us-east-1' },
+  { label: 'US East (Ohio)', value: 'us-east-2' },
+  { label: 'US West (Oregon)', value: 'us-west-2' },
+];
+
+export const mockMachineTypes: SelectDropdownType[] = [
+  { label: 'm5.xlarge', value: 'm5.xlarge' },
+  { label: 'm5.2xlarge', value: 'm5.2xlarge' },
+];
+
+export const mockRoles: Role[] = [
+  {
+    installerRole: { label: 'Installer Role', value: 'arn:aws:iam::role/installer' },
+    supportRole: [{ label: 'Support Role', value: 'arn:aws:iam::role/support' }],
+    workerRole: [{ label: 'Worker Role', value: 'arn:aws:iam::role/worker' }],
+  },
+];
+
+export const createMockClusterData = (overrides: Record<string, unknown> = {}) => ({
+  cluster: {
+    name: '',
+    cluster_version: '',
+    associated_aws_id: '',
+    billing_account_id: '',
+    region: '',
+    machine_type: '',
+    ...overrides,
+  },
+});
+
+const mockResource = <TData,>(data: TData): Resource<TData> => ({
+  data,
+  error: null,
+  isFetching: false,
+  fetch: async () => {},
+});
+
+export interface DetailsSubStepStoryProps {
+  openShiftVersions?: Resource<SelectDropdownType[]>;
+  awsInfrastructureAccounts?: Resource<SelectDropdownType[]>;
+  awsBillingAccounts?: Resource<SelectDropdownType[]>;
+  regions?: Resource<SelectDropdownType[]>;
+  machineTypes?: Resource<SelectDropdownType[]>;
+  roles?: Resource<Role[], [awsAccount: string]> & {
+    fetch: (awsAccount: string) => Promise<void>;
+  };
+  clusterOverrides?: Record<string, unknown>;
+}
+
+export const DetailsSubStepStory: React.FC<DetailsSubStepStoryProps> = ({
+  openShiftVersions,
+  awsInfrastructureAccounts,
+  awsBillingAccounts,
+  regions,
+  machineTypes,
+  roles,
+  clusterOverrides = {},
+}) => {
+  const [data, setData] = useState(() => createMockClusterData(clusterOverrides));
+
+  const update = useCallback(() => {
+    setData((currentData) => ({ ...currentData }));
+  }, []);
+
+  const awsInfraProps = {
+    data: awsInfrastructureAccounts?.data ?? mockAwsInfrastructureAccounts,
+    isFetching: awsInfrastructureAccounts?.isFetching ?? false,
+    fetch: awsInfrastructureAccounts?.fetch ?? (async () => {}),
+    error: null
+  };
+
+  const awsBillingProps = {
+    data: awsBillingAccounts?.data ?? mockAwsBillingAccounts,
+    isFetching: awsBillingAccounts?.isFetching ?? false,
+    fetch: awsBillingAccounts?.fetch ?? (async () => {}),
+    error: null
+  };
+
+  const regionsProps = {
+    data: regions?.data ?? mockRegions,
+    isFetching: regions?.isFetching ?? false,
+    fetch: regions?.fetch ?? (async () => {}),
+    error: null
+  };
+
+  const machineTypesProps = {
+    data: machineTypes?.data ?? mockMachineTypes,
+    isFetching: machineTypes?.isFetching ?? false,
+    fetch: machineTypes?.fetch ?? (async () => {}),
+    error: null
+  };
+
+  const openShiftVersionsProps = {
+    data: openShiftVersions?.data ?? mockOpenShiftVersions,
+    isFetching: openShiftVersions?.isFetching ?? false,
+    fetch: openShiftVersions?.fetch ?? (async () => {}),
+    error: null
+  };
+
+  const rolesProps = {
+    data: roles?.data ?? mockRoles,
+    isFetching: roles?.isFetching ?? false,
+    fetch: roles?.fetch ?? (async (_awsAccount: string) => {}),
+    error: null
+  };
+
+  return (
+    <TranslationProvider>
+      <DataContext.Provider value={{ update }}>
+        <DisplayModeContext.Provider value={DisplayMode.Step}>
+          <ItemContext.Provider value={data}>
+            <StepShowValidationProvider>
+              <ShowValidationProvider>
+                <ValidationProvider>
+                  <DetailsSubStep
+                    clusterNameValidation={{error: null, isFetching: false}}
+                    roles={rolesProps}
+                    openShiftVersions={openShiftVersionsProps}
+                    awsInfrastructureAccounts={awsInfraProps}
+                    awsBillingAccounts={awsBillingProps}
+                    regions={regionsProps}
+                    machineTypes={machineTypesProps}
+                  />
+                </ValidationProvider>
+              </ShowValidationProvider>
+            </StepShowValidationProvider>
+          </ItemContext.Provider>
+        </DisplayModeContext.Provider>
+      </DataContext.Provider>
+    </TranslationProvider>
+  );
+};

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.story.tsx
@@ -10,7 +10,15 @@ import {
 import { ShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ShowValidationProvider';
 import { ValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ValidationProvider';
 import { StepShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/StepShowValidationProvider';
-import { SelectDropdownType, Resource, Role } from '../../../../types';
+import {
+  SelectDropdownType,
+  Resource,
+  Role,
+  MachineTypesDropdownType,
+  Region,
+  AWSInfrastructureAccounts,
+  OpenShiftVersions,
+} from '../../../../types';
 
 export const mockOpenShiftVersions: SelectDropdownType[] = [
   { label: 'OpenShift 4.12.0', value: '4.12.0' },
@@ -37,9 +45,9 @@ export const mockRegions: SelectDropdownType[] = [
   { label: 'US West (Oregon)', value: 'us-west-2' },
 ];
 
-export const mockMachineTypes: SelectDropdownType[] = [
-  { label: 'm5.xlarge', value: 'm5.xlarge' },
-  { label: 'm5.2xlarge', value: 'm5.2xlarge' },
+export const mockMachineTypes: MachineTypesDropdownType[] = [
+  { id: '1', label: 'm5.xlarge', value: 'm5.xlarge', description: 'm5.xlarge' },
+  { id: '2', label: 'm5.2xlarge', value: 'm5.2xlarge', description: 'm5.2xlarge' },
 ];
 
 export const mockRoles: Role[] = [
@@ -62,19 +70,14 @@ export const createMockClusterData = (overrides: Record<string, unknown> = {}) =
   },
 });
 
-const mockResource = <TData,>(data: TData): Resource<TData> => ({
-  data,
-  error: null,
-  isFetching: false,
-  fetch: async () => {},
-});
-
 export interface DetailsSubStepStoryProps {
-  openShiftVersions?: Resource<SelectDropdownType[]>;
-  awsInfrastructureAccounts?: Resource<SelectDropdownType[]>;
+  openShiftVersions?: Resource<OpenShiftVersions[]>;
+  awsInfrastructureAccounts?: Resource<AWSInfrastructureAccounts[]>;
   awsBillingAccounts?: Resource<SelectDropdownType[]>;
-  regions?: Resource<SelectDropdownType[]>;
-  machineTypes?: Resource<SelectDropdownType[]>;
+  regions?: Resource<Region[], [awsAccount: string]> & {
+    fetch: (awsAccount?: string) => Promise<void>;
+  };
+  machineTypes?: Resource<MachineTypesDropdownType[]>;
   roles?: Resource<Role[], [awsAccount: string]> & {
     fetch: (awsAccount: string) => Promise<void>;
   };
@@ -100,42 +103,42 @@ export const DetailsSubStepStory: React.FC<DetailsSubStepStoryProps> = ({
     data: awsInfrastructureAccounts?.data ?? mockAwsInfrastructureAccounts,
     isFetching: awsInfrastructureAccounts?.isFetching ?? false,
     fetch: awsInfrastructureAccounts?.fetch ?? (async () => {}),
-    error: null
+    error: null,
   };
 
   const awsBillingProps = {
     data: awsBillingAccounts?.data ?? mockAwsBillingAccounts,
     isFetching: awsBillingAccounts?.isFetching ?? false,
     fetch: awsBillingAccounts?.fetch ?? (async () => {}),
-    error: null
+    error: null,
   };
 
   const regionsProps = {
     data: regions?.data ?? mockRegions,
     isFetching: regions?.isFetching ?? false,
     fetch: regions?.fetch ?? (async () => {}),
-    error: null
+    error: null,
   };
 
   const machineTypesProps = {
     data: machineTypes?.data ?? mockMachineTypes,
     isFetching: machineTypes?.isFetching ?? false,
     fetch: machineTypes?.fetch ?? (async () => {}),
-    error: null
+    error: null,
   };
 
   const openShiftVersionsProps = {
     data: openShiftVersions?.data ?? mockOpenShiftVersions,
     isFetching: openShiftVersions?.isFetching ?? false,
     fetch: openShiftVersions?.fetch ?? (async () => {}),
-    error: null
+    error: null,
   };
 
   const rolesProps = {
     data: roles?.data ?? mockRoles,
     isFetching: roles?.isFetching ?? false,
     fetch: roles?.fetch ?? (async (_awsAccount: string) => {}),
-    error: null
+    error: null,
   };
 
   return (
@@ -147,7 +150,7 @@ export const DetailsSubStepStory: React.FC<DetailsSubStepStoryProps> = ({
               <ShowValidationProvider>
                 <ValidationProvider>
                   <DetailsSubStep
-                    clusterNameValidation={{error: null, isFetching: false}}
+                    clusterNameValidation={{ error: null, isFetching: false }}
                     roles={rolesProps}
                     openShiftVersions={openShiftVersionsProps}
                     awsInfrastructureAccounts={awsInfraProps}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.story.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { DetailsSubStep } from './DetailsSubStep';
-import { TranslationProvider } from '../../../../../../context/TranslationContext';
+import { RosaWizardStringsProvider } from '../../../RosaWizardStringsContext';
 import { ItemContext } from '@patternfly-labs/react-form-wizard/contexts/ItemContext';
 import { DataContext } from '@patternfly-labs/react-form-wizard/contexts/DataContext';
 import {
@@ -142,7 +142,7 @@ export const DetailsSubStepStory: React.FC<DetailsSubStepStoryProps> = ({
   };
 
   return (
-    <TranslationProvider>
+    <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
         <DisplayModeContext.Provider value={DisplayMode.Step}>
           <ItemContext.Provider value={data}>
@@ -164,6 +164,6 @@ export const DetailsSubStepStory: React.FC<DetailsSubStepStoryProps> = ({
           </ItemContext.Provider>
         </DisplayModeContext.Provider>
       </DataContext.Provider>
-    </TranslationProvider>
+    </RosaWizardStringsProvider>
   );
 };

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -2,24 +2,37 @@ import { Section, WizSelect, WizTextInput, useItem } from '@patternfly-labs/reac
 import { Button, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import React from 'react';
 import { StepDrawer } from '../../../common/StepDrawer';
-import { Resource, Role, SelectDropdownType, ValidationResource } from '../../../../types';
+import {   
+  Resource,
+  Role,
+  SelectDropdownType,
+  ValidationResource,
+  Region,
+  MachineTypesDropdownType,
+  OpenShiftVersions
+} from '../../../../types';
 import { validateClusterName } from '../../../validators';
 import ExternalLink from '../../../common/ExternalLink';
 import { updateOnAWSAccountChange } from '../../../hooks/updateOnAWSAccountChange';
 import links from '../../../externalLinks';
 import { useRosaWizardStrings } from '../../../RosaWizardStringsContext';
 import { useResetFieldOnOptionsChange } from '../../../hooks/useResetFieldOnOptionsChange';
+import { showSecurityGroupsSection } from '../../../helpers';
 
 type DetailsSubStepProps = {
   clusterNameValidation: ValidationResource;
-  openShiftVersions: Resource<SelectDropdownType[]>;
+  openShiftVersions: Resource<OpenShiftVersions[]>;
   roles: Resource<Role[], [awsAccount: string]> & {
     fetch: (awsAccount: string) => Promise<void>;
   };
   awsInfrastructureAccounts: Resource<SelectDropdownType[]>;
   awsBillingAccounts: Resource<SelectDropdownType[]>;
-  regions: Resource<SelectDropdownType[]>;
-  machineTypes: Resource<SelectDropdownType[]>;
+  regions: Resource<Region[], [awsAccount: string]> & {
+    fetch: (awsAccount: string) => Promise<void>;
+  };
+  machineTypes: Resource<MachineTypesDropdownType[], [region: string]> & {
+    fetch?: (region: string) => Promise<void>;
+  };
 };
 
 export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
@@ -29,7 +42,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
   awsBillingAccounts,
   regions,
   machineTypes,
-  roles
+  roles,
 }) => {
   const d = useRosaWizardStrings().details;
   const { cluster } = useItem();
@@ -55,41 +68,6 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
         onWizardExpand={onWizardExpand}
       >
         <Stack hasGutter>
-          <StackItem>
-            <Grid>
-              <GridItem span={4}>
-                <WizTextInput
-                  validation={(name: string, item: unknown) =>
-                    validateClusterName(name, item) || clusterNameValidation.error || undefined
-                  }
-                  path="cluster.name"
-                  label={d.clusterNameLabel}
-                  validateOnBlur
-                  placeholder={d.clusterNamePlaceholder}
-                  required
-                  labelHelp={d.clusterNameHelp}
-                />
-              </GridItem>
-            </Grid>
-          </StackItem>
-
-          <StackItem>
-            <Grid>
-              <GridItem span={4}>
-                <WizSelect
-                  isFill
-                  path="cluster.cluster_version"
-                  label={d.openShiftVersionLabel}
-                  placeholder={d.openShiftVersionPlaceholder}
-                  options={openShiftVersions.data}
-                  disabled={openShiftVersions.isFetching}
-                  refreshCallback={openShiftVersions.fetch}
-                  required
-                />
-              </GridItem>
-            </Grid>
-          </StackItem>
-
           <StackItem>
             <Grid hasGutter>
               <GridItem span={4}>
@@ -156,6 +134,45 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
           <StackItem>
             <Grid>
               <GridItem span={4}>
+                <WizTextInput
+                  validation={(name: string, item: unknown) =>
+                    validateClusterName(name, item) || clusterNameValidation.error || undefined
+                  }
+                  path="cluster.name"
+                  label={d.clusterNameLabel}
+                  validateOnBlur
+                  placeholder={d.clusterNamePlaceholder}
+                  required
+                  labelHelp={d.clusterNameHelp}
+                />
+              </GridItem>
+            </Grid>
+          </StackItem>
+
+          <StackItem>
+            <Grid>
+              <GridItem span={4}>
+                <WizSelect
+                  isFill
+                  path="cluster.cluster_version"
+                  label={d.openShiftVersionLabel}
+                  placeholder={d.openShiftVersionPlaceholder}
+                  options={openShiftVersions.data}
+                  disabled={openShiftVersions.isFetching}
+                  refreshCallback={openShiftVersions.fetch}
+                  required
+                  onValueChange={(_value, item) => {
+                    if (!showSecurityGroupsSection(_value as string)) {
+                      item.cluster.security_groups_worker = undefined;
+                    }
+                  }}
+                />
+              </GridItem>
+            </Grid>
+          </StackItem>
+          <StackItem>
+            <Grid>
+              <GridItem span={4}>
                 <WizSelect
                   isFill
                   path="cluster.region"
@@ -173,7 +190,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                     ) {
                       item.cluster.machine_pools_subnets = [];
                     }
-                    if(machineTypes.fetch) void machineTypes.fetch();
+                    if (_value && machineTypes.fetch) void machineTypes.fetch(_value as string);
                   }}
                   required
                 />

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -66,7 +66,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
       return;
     }
     const optionValues = awsBillingAccounts.data.map(({ value }) => value);
-    if (optionValues.length === 1) {
+    if (optionValues.length === 1 && cluster.billing_account_id !== optionValues[0]) {
       cluster.billing_account_id = optionValues[0];
       update();
       return;

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -1,41 +1,51 @@
-import { Section, WizSelect, WizTextInput } from '@patternfly-labs/react-form-wizard';
+import { Section, WizSelect, WizTextInput, useItem } from '@patternfly-labs/react-form-wizard';
 import { Button, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import React from 'react';
 import { StepDrawer } from '../../../common/StepDrawer';
 import { Resource, Role, SelectDropdownType, ValidationResource } from '../../../../types';
 import { validateClusterName } from '../../../validators';
 import ExternalLink from '../../../common/ExternalLink';
+import { updateOnAWSAccountChange } from '../../../hooks/updateOnAWSAccountChange';
 import links from '../../../externalLinks';
 import { useRosaWizardStrings } from '../../../RosaWizardStringsContext';
+import { useResetFieldOnOptionsChange } from '../../../hooks/useResetFieldOnOptionsChange';
 
 type DetailsSubStepProps = {
   clusterNameValidation: ValidationResource;
-  openShiftVersions: SelectDropdownType[];
-  versionsIsPending: boolean;
-  refreshVersionsCallback?: () => void;
+  openShiftVersions: Resource<SelectDropdownType[]>;
   roles: Resource<Role[], [awsAccount: string]> & {
     fetch: (awsAccount: string) => Promise<void>;
   };
   awsInfrastructureAccounts: Resource<SelectDropdownType[]>;
   awsBillingAccounts: Resource<SelectDropdownType[]>;
   regions: Resource<SelectDropdownType[]>;
+  machineTypes: Resource<SelectDropdownType[]>;
 };
 
 export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
   clusterNameValidation,
   openShiftVersions,
-  versionsIsPending,
-  refreshVersionsCallback,
-  roles,
   awsInfrastructureAccounts,
   awsBillingAccounts,
   regions,
+  machineTypes,
+  roles
 }) => {
   const d = useRosaWizardStrings().details;
+  const { cluster } = useItem();
 
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState<boolean>(false);
   const drawerRef = React.useRef<HTMLSpanElement>(null);
   const onWizardExpand = () => drawerRef.current && drawerRef.current.focus();
+
+  useResetFieldOnOptionsChange('cluster.region', regions.data);
+  useResetFieldOnOptionsChange('cluster.machine_type', machineTypes.data, 'machinepools-sub-step');
+
+  React.useEffect(() => {
+    if (awsBillingAccounts.data.length === 1 && !cluster.billing_account_id) {
+      cluster.billing_account_id = awsBillingAccounts.data[0].value;
+    }
+  }, [awsBillingAccounts, cluster]);
 
   return (
     <Section label={d.sectionLabel}>
@@ -71,9 +81,9 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                   path="cluster.cluster_version"
                   label={d.openShiftVersionLabel}
                   placeholder={d.openShiftVersionPlaceholder}
-                  options={openShiftVersions}
-                  disabled={versionsIsPending}
-                  refreshCallback={refreshVersionsCallback}
+                  options={openShiftVersions.data}
+                  disabled={openShiftVersions.isFetching}
+                  refreshCallback={openShiftVersions.fetch}
                   required
                 />
               </GridItem>
@@ -91,21 +101,18 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                   labelHelp={d.awsInfraHelp}
                   options={awsInfrastructureAccounts.data}
                   disabled={awsInfrastructureAccounts.isFetching}
-                  onValueChange={(_newAccountId, item) => {
-                    item.cluster.installer_role_arn = undefined;
-                    item.cluster.worker_role_arn = undefined;
-                    item.cluster.support_role_arn = undefined;
-
-                    if (_newAccountId) {
-                      void roles.fetch(_newAccountId as string);
-                    }
-                  }}
                   required
                   refreshCallback={
                     awsInfrastructureAccounts.fetch
                       ? () => void awsInfrastructureAccounts.fetch?.()
                       : undefined
                   }
+                  onValueChange={(_value, item) => {
+                    void updateOnAWSAccountChange(_value, item, regions.fetch);
+                    if (_value) {
+                      void roles.fetch(_value as string);
+                    }
+                  }}
                 />
               </GridItem>
             </Grid>
@@ -125,12 +132,12 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
               <GridItem span={4}>
                 <WizSelect
                   isFill
+                  disabled={awsBillingAccounts.isFetching}
                   path="cluster.billing_account_id"
                   label={d.billingLabel}
                   placeholder={d.billingPlaceholder}
                   labelHelp={d.billingHelp}
                   options={awsBillingAccounts.data}
-                  disabled={awsBillingAccounts.isFetching}
                   required
                   refreshCallback={
                     awsBillingAccounts.fetch ? () => void awsBillingAccounts.fetch?.() : undefined
@@ -157,6 +164,17 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                   labelHelp={d.regionHelp}
                   options={regions.data}
                   disabled={regions.isFetching}
+                  onValueChange={(_value, item) => {
+                    item.cluster.selected_vpc = undefined;
+                    item.cluster.cluster_privacy_public_subnet_id = undefined;
+                    if (
+                      item.cluster.machine_pools_subnets &&
+                      item.cluster.machine_pools_subnets.length > 0
+                    ) {
+                      item.cluster.machine_pools_subnets = [];
+                    }
+                    if(machineTypes.fetch) void machineTypes.fetch();
+                  }}
                   required
                 />
               </GridItem>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -2,14 +2,14 @@ import { Section, WizSelect, WizTextInput, useItem } from '@patternfly-labs/reac
 import { Button, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import React from 'react';
 import { StepDrawer } from '../../../common/StepDrawer';
-import {   
+import {
   Resource,
   Role,
   SelectDropdownType,
   ValidationResource,
   Region,
   MachineTypesDropdownType,
-  OpenShiftVersions
+  OpenShiftVersions,
 } from '../../../../types';
 import { validateClusterName } from '../../../validators';
 import ExternalLink from '../../../common/ExternalLink';

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -1,4 +1,10 @@
-import { Section, WizSelect, WizTextInput, useItem } from '@patternfly-labs/react-form-wizard';
+import {
+  Section,
+  WizSelect,
+  WizTextInput,
+  useData,
+  useItem,
+} from '@patternfly-labs/react-form-wizard';
 import { Button, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import React from 'react';
 import { StepDrawer } from '../../../common/StepDrawer';
@@ -46,6 +52,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
 }) => {
   const d = useRosaWizardStrings().details;
   const { cluster } = useItem();
+  const { update } = useData();
 
   const [isDrawerExpanded, setIsDrawerExpanded] = React.useState<boolean>(false);
   const drawerRef = React.useRef<HTMLSpanElement>(null);
@@ -61,12 +68,14 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
     const optionValues = awsBillingAccounts.data.map(({ value }) => value);
     if (optionValues.length === 1) {
       cluster.billing_account_id = optionValues[0];
+      update();
       return;
     }
     if (cluster.billing_account_id && !optionValues.includes(cluster.billing_account_id)) {
       cluster.billing_account_id = undefined;
+      update();
     }
-  }, [awsBillingAccounts.data, awsBillingAccounts.isFetching, cluster]);
+  }, [awsBillingAccounts.data, awsBillingAccounts.isFetching, cluster, update]);
 
   return (
     <Section label={d.sectionLabel}>
@@ -170,7 +179,7 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
                   refreshCallback={openShiftVersions.fetch}
                   required
                   onValueChange={(_value, item) => {
-                    if (!showSecurityGroupsSection(_value as string)) {
+                    if (_value && !showSecurityGroupsSection(_value as string)) {
                       item.cluster.security_groups_worker = undefined;
                     }
                   }}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/DetailsSubStep/DetailsSubStep.tsx
@@ -55,10 +55,18 @@ export const DetailsSubStep: React.FunctionComponent<DetailsSubStepProps> = ({
   useResetFieldOnOptionsChange('cluster.machine_type', machineTypes.data, 'machinepools-sub-step');
 
   React.useEffect(() => {
-    if (awsBillingAccounts.data.length === 1 && !cluster.billing_account_id) {
-      cluster.billing_account_id = awsBillingAccounts.data[0].value;
+    if (awsBillingAccounts.isFetching) {
+      return;
     }
-  }, [awsBillingAccounts, cluster]);
+    const optionValues = awsBillingAccounts.data.map(({ value }) => value);
+    if (optionValues.length === 1) {
+      cluster.billing_account_id = optionValues[0];
+      return;
+    }
+    if (cluster.billing_account_id && !optionValues.includes(cluster.billing_account_id)) {
+      cluster.billing_account_id = undefined;
+    }
+  }, [awsBillingAccounts.data, awsBillingAccounts.isFetching, cluster]);
 
   return (
     <Section label={d.sectionLabel}>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.spec.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.spec.tsx
@@ -98,6 +98,30 @@ test.describe('MachinePoolsSubstep', () => {
       component.getByText(/The following settings apply to all machine pools/)
     ).toBeVisible();
   });
+
+  test('should show disabled state for Compute node instance type when machine types are loading', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <MachinePoolsSubstepStory machineTypes={{ data: [], isFetching: true, error: null }} />
+    );
+
+    const machineTypeSelect = component.locator('#cluster-machine_type');
+    await expect(machineTypeSelect).toBeVisible();
+    await expect(machineTypeSelect.locator('.pf-m-disabled')).toBeVisible();
+  });
+
+  test('should not show disabled state for Compute node instance type when not loading', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <MachinePoolsSubstepStory machineTypes={{ data: [], isFetching: false, error: null }} />
+    );
+
+    const machineTypeSelect = component.locator('#cluster-machine_type');
+    await expect(machineTypeSelect).toBeVisible();
+    await expect(machineTypeSelect.locator('.pf-m-disabled')).not.toBeVisible();
+  });
 });
 
 test.describe('SecurityGroupsSection', () => {

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.spec.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.spec.tsx
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import { checkAccessibility } from '../../../../../../test-helpers';
 import { MachinePoolsSubstepStory } from './MachinePoolsSubstep.story';
+import { ShowValidationContext } from '@patternfly-labs/react-form-wizard/contexts/ShowValidationProvider';
 import type { Resource, MachineTypesDropdownType, VPC } from '../../../../types';
 
 const mockResource = <TData,>(data: TData): Resource<TData> => ({
@@ -269,5 +270,124 @@ test.describe('SecurityGroupsSection', () => {
     await page.getByText('my-production-vpc', { exact: true }).click();
 
     await expect(component.locator('.pf-v6-c-label').getByText('default')).not.toBeVisible();
+  });
+});
+
+const ADVANCED_TOGGLE_TEXT = 'Advanced machine pool configuration (optional)';
+
+const mountWithValidation = (
+  mount: Parameters<Parameters<typeof test>[2]>[0]['mount'],
+  clusterOverrides: Record<string, unknown> = {}
+) =>
+  mount(
+    <ShowValidationContext.Provider value={true}>
+      <MachinePoolsSubstepStory clusterOverrides={clusterOverrides} />
+    </ShowValidationContext.Provider>
+  );
+
+test.describe('Root disk size validation', () => {
+  test('should render root disk size input inside advanced section', async ({ mount }) => {
+    const component = await mountWithValidation(mount);
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText('Root disk size', { exact: true })).toBeVisible();
+  });
+
+  test('should not show validation error for a valid value', async ({ mount }) => {
+    const component = await mountWithValidation(mount, { compute_root_volume: 100 });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText(/Root disk size must be/)).not.toBeVisible();
+    await expect(component.getByText(/must not exceed/)).not.toBeVisible();
+  });
+
+  test('should not show validation error for minimum boundary value (75)', async ({ mount }) => {
+    const component = await mountWithValidation(mount, { compute_root_volume: 75 });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText(/Root disk size must be/)).not.toBeVisible();
+    await expect(component.getByText(/must not exceed/)).not.toBeVisible();
+  });
+
+  test('should not show validation error for maximum boundary value (16384) on OpenShift >= 4.14', async ({
+    mount,
+  }) => {
+    const component = await mountWithValidation(mount, {
+      compute_root_volume: 16384,
+      cluster_version: '4.16.0',
+    });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText(/Root disk size must be/)).not.toBeVisible();
+    await expect(component.getByText(/must not exceed/)).not.toBeVisible();
+  });
+
+  test('should show error when root disk size is below minimum', async ({ mount }) => {
+    const component = await mountWithValidation(mount, { compute_root_volume: 50 });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText('Root disk size must be at least 75 GiB.')).toBeVisible();
+  });
+
+  test('should show error when root disk size is not an integer', async ({ mount }) => {
+    const component = await mountWithValidation(mount, { compute_root_volume: 75.5 });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText('Root disk size must be an integer.')).toBeVisible();
+  });
+
+  test('should show error when root disk size exceeds maximum for OpenShift >= 4.14', async ({
+    mount,
+  }) => {
+    const component = await mountWithValidation(mount, {
+      compute_root_volume: 20000,
+      cluster_version: '4.16.0',
+    });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText('Root disk size must not exceed 16384 GiB.')).toBeVisible();
+  });
+
+  test('should show error when root disk size exceeds maximum for OpenShift < 4.14', async ({
+    mount,
+  }) => {
+    const component = await mountWithValidation(mount, {
+      compute_root_volume: 2000,
+      cluster_version: '4.12.0',
+    });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText('Root disk size must not exceed 1024 GiB')).toBeVisible();
+  });
+
+  test('should not show validation error for maximum boundary value (1024) on OpenShift < 4.14', async ({
+    mount,
+  }) => {
+    const component = await mountWithValidation(mount, {
+      compute_root_volume: 1024,
+      cluster_version: '4.12.0',
+    });
+
+    const advancedToggle = component.getByText(ADVANCED_TOGGLE_TEXT);
+    await advancedToggle.click();
+
+    await expect(component.getByText(/Root disk size must be/)).not.toBeVisible();
+    await expect(component.getByText(/must not exceed/)).not.toBeVisible();
   });
 });

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
@@ -72,6 +72,7 @@ export const mockVpcList: Resource<VPC[]> = {
   ],
   error: null,
   isFetching: false,
+  fetch: async () => {},
 };
 
 export const mockMachineTypesData: Resource<MachineTypesDropdownType[]> = {
@@ -100,6 +101,7 @@ export const createMockClusterData = (overrides: Record<string, unknown> = {}) =
     selected_vpc: '',
     cluster_privacy: 'external',
     cluster_privacy_public_subnet_id: '',
+    cluster_version: '4.16.0',
     machine_type: '',
     autoscaling: false,
     min_replicas: 2,

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
@@ -17,8 +17,8 @@ const mockResource = <TData,>(data: TData): Resource<TData> => ({
   isFetching: false,
   fetch: async () => {},
 });
+import { StepShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/StepShowValidationProvider';
 
-// Mock security groups
 export const mockSecurityGroups: SecurityGroup[] = [
   { id: 'sg-0a1b2c3d4e5f00001', name: 'default' },
   { id: 'sg-0a1b2c3d4e5f00002', name: 'k8s-traffic-rules' },
@@ -27,7 +27,6 @@ export const mockSecurityGroups: SecurityGroup[] = [
   { id: 'sg-0a1b2c3d4e5f00005', name: '' },
 ];
 
-// Mock VPC data with subnets
 export const mockSubnets: Subnet[] = [
   {
     subnet_id: 'subnet-private-1',
@@ -51,7 +50,8 @@ export const mockSubnets: Subnet[] = [
   },
 ];
 
-export const mockVpcList: VPC[] = [
+export const mockVpcList: Resource<VPC[]> = {
+  data: [
   {
     id: 'vpc-123',
     name: 'my-production-vpc',
@@ -75,9 +75,12 @@ export const mockVpcList: VPC[] = [
     ],
     aws_security_groups: [],
   },
-];
+],
+error: null,
+isFetching: false};
 
-export const mockMachineTypes: MachineTypesDropdownType[] = [
+export const mockMachineTypesData: Resource<MachineTypesDropdownType[]> = {
+  data: [
   { id: 'm5.xlarge', label: 'm5.xlarge', description: '4 vCPU, 16 GiB Memory', value: 'm5.xlarge' },
   {
     id: 'm5.2xlarge',
@@ -86,9 +89,10 @@ export const mockMachineTypes: MachineTypesDropdownType[] = [
     value: 'm5.2xlarge',
   },
   { id: 'r5.large', label: 'r5.large', description: '2 vCPU, 16 GiB Memory', value: 'r5.large' },
-];
+],
+error: null,
+isFetching: false};
 
-// Default cluster data factory
 export const createMockClusterData = (overrides: Record<string, unknown> = {}) => ({
   cluster: {
     region: 'us-east-1',
@@ -106,36 +110,36 @@ export const createMockClusterData = (overrides: Record<string, unknown> = {}) =
   },
 });
 
-// Props interface for the wrapped component
 export interface MachinePoolsSubstepStoryProps {
   vpcList?: Resource<VPC[]>;
   machineTypes?: Resource<MachineTypesDropdownType[]>;
   clusterOverrides?: Record<string, unknown>;
 }
 
-// Wrapped component that can be mounted in tests
 export const MachinePoolsSubstepStory: React.FC<MachinePoolsSubstepStoryProps> = ({
-  vpcList = mockResource(mockVpcList),
-  machineTypes = mockResource(mockMachineTypes),
+  vpcList = mockVpcList,
+  machineTypes = mockMachineTypesData,
   clusterOverrides = {},
 }) => {
   const [data, setData] = useState(() => createMockClusterData(clusterOverrides));
 
   const update = useCallback(() => {
-    // Force re-render by creating a new object reference
     setData((currentData) => ({ ...currentData }));
   }, []);
+
 
   return (
     <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
         <DisplayModeContext.Provider value={DisplayMode.Step}>
           <ItemContext.Provider value={data}>
-            <ShowValidationProvider>
-              <ValidationProvider>
-                <MachinePoolsSubstep vpcList={vpcList} machineTypes={machineTypes} />
-              </ValidationProvider>
-            </ShowValidationProvider>
+            <StepShowValidationProvider>
+              <ShowValidationProvider>
+                <ValidationProvider>
+                  <MachinePoolsSubstep vpcList={vpcList} machineTypes={mockMachineTypesData} />
+                </ValidationProvider>
+              </ShowValidationProvider>
+            </StepShowValidationProvider>
           </ItemContext.Provider>
         </DisplayModeContext.Provider>
       </DataContext.Provider>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.story.tsx
@@ -11,12 +11,6 @@ import { ShowValidationProvider } from '@patternfly-labs/react-form-wizard/conte
 import { ValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/ValidationProvider';
 import { VPC, Subnet, SecurityGroup, MachineTypesDropdownType, Resource } from '../../../../types';
 
-const mockResource = <TData,>(data: TData): Resource<TData> => ({
-  data,
-  error: null,
-  isFetching: false,
-  fetch: async () => {},
-});
 import { StepShowValidationProvider } from '@patternfly-labs/react-form-wizard/contexts/StepShowValidationProvider';
 
 export const mockSecurityGroups: SecurityGroup[] = [
@@ -52,46 +46,53 @@ export const mockSubnets: Subnet[] = [
 
 export const mockVpcList: Resource<VPC[]> = {
   data: [
-  {
-    id: 'vpc-123',
-    name: 'my-production-vpc',
-    aws_subnets: mockSubnets,
-    aws_security_groups: mockSecurityGroups,
-  },
-  {
-    id: 'vpc-456',
-    name: 'my-staging-vpc',
-    aws_subnets: [
-      {
-        subnet_id: 'subnet-staging-private',
-        name: 'staging-private-subnet',
-        availability_zone: 'us-west-2a',
-      },
-      {
-        subnet_id: 'subnet-staging-public',
-        name: 'staging-public-subnet',
-        availability_zone: 'us-west-2a',
-      },
-    ],
-    aws_security_groups: [],
-  },
-],
-error: null,
-isFetching: false};
+    {
+      id: 'vpc-123',
+      name: 'my-production-vpc',
+      aws_subnets: mockSubnets,
+      aws_security_groups: mockSecurityGroups,
+    },
+    {
+      id: 'vpc-456',
+      name: 'my-staging-vpc',
+      aws_subnets: [
+        {
+          subnet_id: 'subnet-staging-private',
+          name: 'staging-private-subnet',
+          availability_zone: 'us-west-2a',
+        },
+        {
+          subnet_id: 'subnet-staging-public',
+          name: 'staging-public-subnet',
+          availability_zone: 'us-west-2a',
+        },
+      ],
+      aws_security_groups: [],
+    },
+  ],
+  error: null,
+  isFetching: false,
+};
 
 export const mockMachineTypesData: Resource<MachineTypesDropdownType[]> = {
   data: [
-  { id: 'm5.xlarge', label: 'm5.xlarge', description: '4 vCPU, 16 GiB Memory', value: 'm5.xlarge' },
-  {
-    id: 'm5.2xlarge',
-    label: 'm5.2xlarge',
-    description: '8 vCPU, 32 GiB Memory',
-    value: 'm5.2xlarge',
-  },
-  { id: 'r5.large', label: 'r5.large', description: '2 vCPU, 16 GiB Memory', value: 'r5.large' },
-],
-error: null,
-isFetching: false};
+    {
+      id: 'm5.xlarge',
+      label: 'm5.xlarge',
+      description: '4 vCPU, 16 GiB Memory',
+      value: 'm5.xlarge',
+    },
+    {
+      id: 'm5.2xlarge',
+      label: 'm5.2xlarge',
+      description: '8 vCPU, 32 GiB Memory',
+      value: 'm5.2xlarge',
+    },
+    { id: 'r5.large', label: 'r5.large', description: '2 vCPU, 16 GiB Memory', value: 'r5.large' },
+  ],
+  error: null,
+  isFetching: false,
+};
 
 export const createMockClusterData = (overrides: Record<string, unknown> = {}) => ({
   cluster: {
@@ -127,7 +128,6 @@ export const MachinePoolsSubstepStory: React.FC<MachinePoolsSubstepStoryProps> =
     setData((currentData) => ({ ...currentData }));
   }, []);
 
-
   return (
     <RosaWizardStringsProvider>
       <DataContext.Provider value={{ update }}>
@@ -136,7 +136,7 @@ export const MachinePoolsSubstepStory: React.FC<MachinePoolsSubstepStoryProps> =
             <StepShowValidationProvider>
               <ShowValidationProvider>
                 <ValidationProvider>
-                  <MachinePoolsSubstep vpcList={vpcList} machineTypes={mockMachineTypesData} />
+                  <MachinePoolsSubstep vpcList={vpcList} machineTypes={machineTypes} />
                 </ValidationProvider>
               </ShowValidationProvider>
             </StepShowValidationProvider>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -65,7 +65,6 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
     <>
       <Section label={mp.sectionLabel} id="machine-pools-section" key="machine-pools-key">
         <Content component={ContentVariants.p}>{mp.intro}</Content>
-
         <Grid>
           <GridItem span={5}>
             <WizSelect

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -15,7 +15,8 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { subnetsFilter } from '../../../helpers';
+import { useTranslation } from '../../../../../../context/TranslationContext';
+import { subnetsFilter, canSelectImds, getWorkerNodeVolumeSizeMaxGiB } from '../../../helpers';
 import {
   MachineTypesDropdownType,
   Resource,
@@ -33,7 +34,9 @@ import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWiza
 
 type MachinePoolsSubstepProps = {
   vpcList: Resource<VPC[]>;
-  machineTypes: Resource<MachineTypesDropdownType[]>;
+  machineTypes: Resource<MachineTypesDropdownType[], [region: string]> & {
+    fetch?: (region: string) => Promise<void>;
+  };
 };
 
 export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
@@ -41,25 +44,22 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
   const v = useRosaWizardValidators();
   const { cluster } = useItem<RosaWizardFormData>();
   const currentRegion = cluster?.region;
+  const maxRootDiskSize = getWorkerNodeVolumeSizeMaxGiB(cluster.cluster_version);
 
+  // Resets cluster_privacy_public_subnet_id when user selects private and refetch regions with the selected region
   React.useEffect(() => {
-    if (props.machineTypes.fetch) {
-      void props.machineTypes.fetch();
+    if (cluster?.cluster_privacy === 'internal') {
+      cluster.cluster_privacy_public_subnet_id = '';
     }
-  }, [currentRegion, props.machineTypes]);
+    if (props.machineTypes.fetch) void props.machineTypes.fetch(currentRegion);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const vpcRef = cluster?.selected_vpc;
   const selectedVPC =
     typeof vpcRef === 'string' ? props.vpcList.data.find((vpc: VPC) => vpc.id === vpcRef) : vpcRef;
 
   const { privateSubnets } = subnetsFilter(selectedVPC);
-
-  React.useEffect(() => {
-    if (cluster?.cluster_privacy === 'internal') {
-      cluster.cluster_privacy_public_subnet_id = '';
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <>
@@ -146,6 +146,7 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
       <ExpandableSection toggleText={mp.advancedToggle}>
         <Indented>
           <WizRadioGroup
+            disabled={!canSelectImds(cluster.cluster_version)}
             labelHelpTitle={mp.imdsHelpTitle}
             labelHelp={
               <>
@@ -178,12 +179,13 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
             label={mp.rootDiskLabel}
             labelHelp={mp.rootDiskHelp}
             min={75}
-            max={16384}
-            validation={(value) => validateRootDiskSize(value, v.rootDisk)}
+            max={maxRootDiskSize}
+            validation={(_value: number) => validateRootDiskSize(_value, v.rootDisk, maxRootDiskSize)}
           />
         </Indented>
       </ExpandableSection>
       <SecurityGroupsSection
+        clusterVersion={cluster.cluster_version}
         selectedVPC={selectedVPC}
         refreshVPCs={props.vpcList.fetch ? () => void props.vpcList.fetch?.() : undefined}
       />

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -43,7 +43,8 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
   const v = useRosaWizardValidators();
   const { cluster } = useItem<RosaWizardFormData>();
   const currentRegion = cluster?.region;
-  const maxRootDiskSize = getWorkerNodeVolumeSizeMaxGiB(cluster.cluster_version);
+  const clusterVersion = cluster.cluster_version ?? '';
+  const maxRootDiskSize = getWorkerNodeVolumeSizeMaxGiB(clusterVersion);
 
   // Resets cluster_privacy_public_subnet_id when user selects private and refetch regions with the selected region
   React.useEffect(() => {
@@ -145,7 +146,7 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
       <ExpandableSection toggleText={mp.advancedToggle}>
         <Indented>
           <WizRadioGroup
-            disabled={!canSelectImds(cluster.cluster_version)}
+            disabled={!canSelectImds(clusterVersion)}
             labelHelpTitle={mp.imdsHelpTitle}
             labelHelp={
               <>
@@ -186,7 +187,7 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
         </Indented>
       </ExpandableSection>
       <SecurityGroupsSection
-        clusterVersion={cluster.cluster_version}
+        clusterVersion={clusterVersion}
         selectedVPC={selectedVPC}
         refreshVPCs={props.vpcList.fetch ? () => void props.vpcList.fetch?.() : undefined}
       />

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -51,7 +51,7 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
     if (cluster?.cluster_privacy === 'internal') {
       cluster.cluster_privacy_public_subnet_id = '';
     }
-    if (props.machineTypes.fetch) void props.machineTypes.fetch(currentRegion);
+    if (props.machineTypes.fetch && currentRegion) void props.machineTypes.fetch(currentRegion);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -46,11 +46,8 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
   const clusterVersion = cluster.cluster_version ?? '';
   const maxRootDiskSize = getWorkerNodeVolumeSizeMaxGiB(clusterVersion);
 
-  // Resets cluster_privacy_public_subnet_id when user selects private and refetch regions with the selected region
+  // Refetch machine types with the selected region
   React.useEffect(() => {
-    if (cluster?.cluster_privacy === 'internal') {
-      cluster.cluster_privacy_public_subnet_id = '';
-    }
     if (props.machineTypes.fetch && currentRegion) void props.machineTypes.fetch(currentRegion);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -40,6 +40,13 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
   const mp = useRosaWizardStrings().machinePools;
   const v = useRosaWizardValidators();
   const { cluster } = useItem<RosaWizardFormData>();
+  const currentRegion = cluster?.region;
+
+  React.useEffect(() => {
+    if (props.machineTypes.fetch) {
+      void props.machineTypes.fetch();
+    }
+  }, [currentRegion, props.machineTypes]);
 
   const vpcRef = cluster?.selected_vpc;
   const selectedVPC =
@@ -112,6 +119,8 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
           <GridItem span={5}>
             <WizSelect
               label={mp.instanceTypeLabel}
+              validateOnBlur={true}
+              disabled={props.machineTypes.isFetching}
               path="cluster.machine_type"
               required
               labelHelp={
@@ -123,7 +132,6 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
                 </>
               }
               options={props.machineTypes.data}
-              disabled={props.machineTypes.isFetching}
             />
           </GridItem>
         </Grid>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.tsx
@@ -15,7 +15,6 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { useTranslation } from '../../../../../../context/TranslationContext';
 import { subnetsFilter, canSelectImds, getWorkerNodeVolumeSizeMaxGiB } from '../../../helpers';
 import {
   MachineTypesDropdownType,
@@ -180,7 +179,9 @@ export const MachinePoolsSubstep = (props: MachinePoolsSubstepProps) => {
             labelHelp={mp.rootDiskHelp}
             min={75}
             max={maxRootDiskSize}
-            validation={(_value: number) => validateRootDiskSize(_value, v.rootDisk, maxRootDiskSize)}
+            validation={(_value: number) =>
+              validateRootDiskSize(_value, v.rootDisk, maxRootDiskSize)
+            }
           />
         </Indented>
       </ExpandableSection>

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupSection.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupSection.tsx
@@ -5,14 +5,17 @@ import { useValue } from '@patternfly-labs/react-form-wizard/inputs/Input';
 import EditSecurityGroups from './EditSecurityGroups';
 import SecurityGroupsEmptyAlert from './SecurityGroupsEmptyAlert';
 import SecurityGroupsNoEditAlert from './SecurityGroupsNoEditAlert';
+import { showSecurityGroupsSection } from '../../../../helpers';
 import { CloudVpc } from '../../../../../types';
 import { useRosaWizardStrings } from '../../../../RosaWizardStringsContext';
 
 export const SecurityGroupsSection = ({
   selectedVPC,
+  clusterVersion,
   refreshVPCs,
 }: {
   selectedVPC: CloudVpc | undefined;
+  clusterVersion: string;
   refreshVPCs?: () => void;
 }) => {
   const { machinePools } = useRosaWizardStrings();
@@ -22,6 +25,7 @@ export const SecurityGroupsSection = ({
   );
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const incompatibleClusterVersion = !showSecurityGroupsSection(clusterVersion);
 
   const prevVpcId = useRef(selectedVPC?.id);
   useEffect(() => {
@@ -36,6 +40,7 @@ export const SecurityGroupsSection = ({
   }
 
   const showEmptyAlert = (selectedVPC?.aws_security_groups || []).length === 0;
+  const incompatibleClusterVersionMessage = `To use securityGroups, your cluster must be version 4.14.x or newer.`;
 
   return (
     <ExpandableSection
@@ -44,8 +49,9 @@ export const SecurityGroupsSection = ({
       isIndented
       onToggle={() => setIsExpanded(!isExpanded)}
     >
+      {incompatibleClusterVersion && <div>{incompatibleClusterVersionMessage}</div>}
       {showEmptyAlert && <SecurityGroupsEmptyAlert refreshVPCCallback={refreshVPCs} />}
-      {!showEmptyAlert && (
+      {!incompatibleClusterVersion && !showEmptyAlert && (
         <>
           <EditSecurityGroups
             selectedVPC={selectedVPC}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupSection.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/SecurityGroupSection/SecurityGroupSection.tsx
@@ -18,7 +18,7 @@ export const SecurityGroupsSection = ({
   clusterVersion: string;
   refreshVPCs?: () => void;
 }) => {
-  const { machinePools } = useRosaWizardStrings();
+  const { machinePools, securityGroups } = useRosaWizardStrings();
   const [selectedGroupIds, setSelectedGroupIds] = useValue(
     { path: 'cluster.security_groups_worker' },
     []
@@ -40,7 +40,7 @@ export const SecurityGroupsSection = ({
   }
 
   const showEmptyAlert = (selectedVPC?.aws_security_groups || []).length === 0;
-  const incompatibleClusterVersionMessage = `To use securityGroups, your cluster must be version 4.14.x or newer.`;
+  const incompatibleClusterVersionMessage = securityGroups.incompatibleVersion;
 
   return (
     <ExpandableSection

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.tsx
@@ -114,6 +114,11 @@ export const NetworkingAndSubnetsSubStep = (props: NetworkingAndSubnetsSubStepPr
           id="public-private-subnet-radio-group"
           path="cluster.cluster_privacy"
           helperText={n.privacyHelper}
+          onValueChange={() => {
+            if (cluster.cluster_privacy && cluster.cluster_privacy_public_subnet_id) {
+              cluster.cluster_privacy_public_subnet_id = undefined;
+            }
+          }}
         >
           <Radio
             id="public"

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
@@ -158,7 +158,7 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
                 placeholder={rp.supportPlaceholder}
                 labelHelp={rp.supportHelp}
                 options={supportRoles}
-                disabled={roles.isFetching}
+                disabled={true}
                 required
               />
             </GridItem>
@@ -170,7 +170,7 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
                 placeholder={rp.workerPlaceholder}
                 labelHelp={rp.workerHelp}
                 options={workerRoles}
-                disabled={roles.isFetching}
+                disabled={true}
                 required
               />
             </GridItem>

--- a/src/components/Wizards/RosaWizard/helpers.ts
+++ b/src/components/Wizards/RosaWizard/helpers.ts
@@ -103,6 +103,43 @@ const truncateTextWithEllipsis = (text: string, maxLength?: number) => {
   return text;
 };
 
+/**
+ * Split version string to an array.
+ *
+ * @param version cluster version raw ID (i.e. "4.13.5")
+ * @returns An array with destructuralized version [major, minor, patch, ...]
+ */
+const splitVersion = (version: string): number[] => {
+  let versionArray = [];
+  try {
+    versionArray = version.split('.').map((num) => parseInt(num, 10));
+    versionArray[1] = versionArray[1] ?? 0;
+    versionArray[2] = versionArray[2] ?? 0;
+  } catch (error) {
+    return [];
+  }
+  return versionArray;
+};
+
+const canSelectImds = (clusterVersionRawId: string): boolean => {
+  const [major, minor] = splitVersion(clusterVersionRawId);
+  return major > 4 || (major === 4 && minor >= 11);
+};
+
+/**
+ * Returns ROSA/AWS max worker node volume size, varies per cluster version.
+ * In GiB.
+ */
+const getWorkerNodeVolumeSizeMaxGiB = (clusterVersionRawId: string): number => {
+  const [major, minor] = splitVersion(clusterVersionRawId);
+  return (major > 4 || (major === 4 && minor >= 14) ? 16 : 1) * 1024;
+};
+
+const showSecurityGroupsSection = (clusterVersionRawId: string): boolean => {
+  const [major, minor] = splitVersion(clusterVersionRawId);
+  return major > 4 || (major === 4 && minor >= 14);
+};
+
 export {
   createOperatorRolesPrefix,
   stringToArray,
@@ -111,4 +148,8 @@ export {
   constructSelectedSubnets,
   subnetsFilter,
   truncateTextWithEllipsis,
+  splitVersion,
+  canSelectImds,
+  getWorkerNodeVolumeSizeMaxGiB,
+  showSecurityGroupsSection,
 };

--- a/src/components/Wizards/RosaWizard/hooks/updateOnAWSAccountChange.ts
+++ b/src/components/Wizards/RosaWizard/hooks/updateOnAWSAccountChange.ts
@@ -1,0 +1,14 @@
+export const updateOnAWSAccountChange = async (
+  value: any,
+  item: any,
+  refetch?: (param?: string) => Promise<void>
+) => {
+  item.cluster.installer_role_arn = undefined;
+  item.cluster.worker_role_arn = undefined;
+  item.cluster.support_role_arn = undefined;
+  item.cluster.cluster_privacy = 'external';
+  item.cluster.cluster_privacy_public_subnet_id = undefined;
+  item.cluster.selected_vpc = undefined;
+  item.cluster.machine_pools_subnets = undefined;
+  if(refetch) await refetch(value as string);
+};

--- a/src/components/Wizards/RosaWizard/hooks/updateOnAWSAccountChange.ts
+++ b/src/components/Wizards/RosaWizard/hooks/updateOnAWSAccountChange.ts
@@ -1,7 +1,7 @@
 export const updateOnAWSAccountChange = async (
   value: any,
   item: any,
-  refetch?: (param?: string) => Promise<void>
+  refetch?: (param: string) => Promise<void>
 ) => {
   item.cluster.installer_role_arn = undefined;
   item.cluster.worker_role_arn = undefined;
@@ -10,5 +10,5 @@ export const updateOnAWSAccountChange = async (
   item.cluster.cluster_privacy_public_subnet_id = undefined;
   item.cluster.selected_vpc = undefined;
   item.cluster.machine_pools_subnets = undefined;
-  if(refetch) await refetch(value as string);
+  if (refetch) await refetch(value as string);
 };

--- a/src/components/Wizards/RosaWizard/hooks/useResetFieldOnOptionsChange.ts
+++ b/src/components/Wizards/RosaWizard/hooks/useResetFieldOnOptionsChange.ts
@@ -1,0 +1,30 @@
+import get from 'get-value';
+import set from 'set-value';
+import React from 'react';
+import { useItem } from '../../../../../packages/react-form-wizard/src/contexts/ItemContext';
+import { useData } from '../../../../../packages/react-form-wizard/src/contexts/DataContext';
+import { useSetStepShowValidation } from '../../../../../packages/react-form-wizard/src/contexts/StepShowValidationProvider';
+
+type OptionWithValue = { value: string };
+
+export function useResetFieldOnOptionsChange(
+  path: string,
+  options: OptionWithValue[],
+  stepId?: string
+) {
+  const item = useItem();
+  const { update } = useData();
+  const setStepShowValidation = useSetStepShowValidation();
+
+  React.useEffect(() => {
+    const currentValue = get(item, path);
+    if (currentValue && options.length > 0) {
+      const isStillValid = options.some((o) => o.value === currentValue);
+      if (!isStillValid) {
+        set(item, path, undefined, { preservePaths: false });
+        if (stepId) setStepShowValidation(stepId, true);
+        update();
+      }
+    }
+  }, [options, item, path, setStepShowValidation, stepId, update]);
+}

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
@@ -267,6 +267,7 @@ export const defaultRosaWizardStrings: RosaWizardStrings = {
     selectAriaLabelledBy: 'Select AWS security groups',
     noEditViewMoreInfo: 'View more information',
     noEditAwsConsoleLink: 'AWS security groups console',
+    incompatibleVersion: 'To use securityGroups, your cluster must be version 4.14.x or newer.',
   },
   clusterWideProxy: {
     sectionLabel: 'Cluster-wide proxy',

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.defaults.ts
@@ -403,7 +403,8 @@ export const defaultRosaWizardValidatorStrings: RosaWizardValidatorStrings = {
   rootDisk: {
     notInteger: 'Root disk size must be an integer.',
     tooSmall: 'Root disk size must be at least 75 GiB.',
-    tooLarge: 'Root disk size must not exceed 16384 GiB.',
+    tooLargeOldOpenshift: 'Root disk size must not exceed 1024 GiB',
+    tooLargeNewOpenshift: 'Root disk size must not exceed 16384 GiB.',
   },
   replicas: {
     notInteger: 'Input must be an integer.',

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
@@ -55,7 +55,8 @@ export type RosaWizardCaValidatorStrings = {
 export type RosaWizardRootDiskValidatorStrings = {
   notInteger: string;
   tooSmall: string;
-  tooLarge: string;
+  tooLargeNewOpenshift: string;
+  tooLargeOldOpenshift: string;
 };
 
 export type RosaWizardReplicaValidatorStrings = {

--- a/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardStrings.types.ts
@@ -349,6 +349,7 @@ export type RosaWizardStrings = {
     selectAriaLabelledBy: string;
     noEditViewMoreInfo: string;
     noEditAwsConsoleLink: string;
+    incompatibleVersion: string;
   };
   clusterWideProxy: {
     sectionLabel: string;

--- a/src/components/Wizards/RosaWizard/rosaWizardTestMocks.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardTestMocks.ts
@@ -99,7 +99,7 @@ export const rosaWizardMockStepsData: WizardStepsData = {
     awsBillingAccounts: mockResource([
       { label: 'Billing Account - Main (123456789012)', value: 'billing-main-123456789012' },
     ]),
-    regions: mockResource([
+    regions: mockFetchResource([
       { label: 'US East (N. Virginia)', value: 'us-east-1' },
       { label: 'US West (Oregon)', value: 'us-west-2' },
     ]),

--- a/src/components/Wizards/RosaWizard/validators.ts
+++ b/src/components/Wizards/RosaWizard/validators.ts
@@ -585,7 +585,8 @@ export const validateComputeNodes = (
 
 export const validateRootDiskSize = (
   value: number | undefined,
-  msgs = defaultRosaWizardValidatorStrings.rootDisk
+  msgs = defaultRosaWizardValidatorStrings.rootDisk,
+  maxRootDiskSize: number
 ): string | undefined => {
   if (value === undefined || value === null) {
     return undefined;
@@ -596,7 +597,7 @@ export const validateRootDiskSize = (
   if (value < 75) {
     return msgs.tooSmall;
   }
-  if (value > 16384) {
+  if (value > maxRootDiskSize) {
     return msgs.tooLarge;
   }
   return undefined;

--- a/src/components/Wizards/RosaWizard/validators.ts
+++ b/src/components/Wizards/RosaWizard/validators.ts
@@ -597,8 +597,11 @@ export const validateRootDiskSize = (
   if (value < 75) {
     return msgs.tooSmall;
   }
-  if (value > maxRootDiskSize) {
-    return msgs.tooLarge;
+  if (value > maxRootDiskSize && maxRootDiskSize === 1024) {
+    return msgs.tooLargeOldOpenshift;
+  }
+  if (value > maxRootDiskSize && maxRootDiskSize === 16384) {
+    return msgs.tooLargeNewOpenshift;
   }
   return undefined;
 };

--- a/src/examples/rosaWizardIntegration.example.tsx
+++ b/src/examples/rosaWizardIntegration.example.tsx
@@ -74,7 +74,7 @@ const wizardStepsData: WizardStepsData = {
     versions: mockFetchResource(versionsData),
     awsInfrastructureAccounts: mockResource([{ label: 'aws-account-1', value: 'aws-account-1' }]),
     awsBillingAccounts: mockResource([{ label: 'billing-account-1', value: 'billing-account-1' }]),
-    regions: mockResource([{ label: 'US East 1', value: 'us-east-1' }]),
+    regions: mockFetchResource([{ label: 'US East 1', value: 'us-east-1' }]),
     roles: mockFetchResource<Role[], [awsAccount: string]>(roles),
     oidcConfig: mockResource(oidcConfigs),
     machineTypes: mockResource([


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
The PR addresses certain fields being reset, updated based on changes and selections in other fields.
Especially next fields are being changed/updated/refetched.

1. When user selects AWS infrastructure account, regions field is being refetched. When user selects region and changes aws infrastructure account we refetch regions. If previously selected region no longer exists we clear the field and make users select region again. If region exists we keep it intact.
2. With AWS billing account, if there is only one value in the dropdown, we preselect it. Otherwise users have to select.
3. When user selects region, we fetch machine types. If user navigates up to Machine pools screen, selects machine type and returns to change region we refetch machine types. If previously selected machine type no longer available we clear the field and force user to select machine type again, otherwise we keep it.
4. With the change of aws infrastructure account or/and region we clear VPC field, machine pools subnet field and on the networking screen selection of public/private subnet to default.
5. Disabling/Enabling IMDS fields based on Openshift versions selected.
6. Additional security groups based on VPC selection.


**Jira issue #** 
https://redhat.atlassian.net/browse/FCN-164

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Select AWS infrastructure account (use Production one), regions are fetched (disabled field) then select Oregon in the region dropdown. Change aws infra account to development one. Observe change in label of the region (mocking with the same value to show that we keep it.) then select production aws infra account again and change region to Sydney. Change aws infra account to development. Observe that regions are cleared (Sydney does not exist for dev one)
2. Select aws prod account and select region North Virginia, navigate to machine pools step and select m5a.xlarge machine type, VPC and machine pools subnet. Navigate back to details step and change region to London. Navigate back to machine pools step and observe that we clear the fields. But if m6a.xlarge was selected it should stay selected regardless of the region while VPC and machine pool subnet should be cleared. Same behaviour is with Networking step clearing public private subnet.

**Test Environment:**
- [ ] Tested locally
- [X] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [X] Unit tests added/updated
- [X] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->

### After
<!-- Screenshot or description of the new behavior -->


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

