### PR TITLE
fix(rosa): wrap long text in CopyInstruction

### DIFF
--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.css
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.css
@@ -1,0 +1,4 @@
+.copy-instruction pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.css
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.css
@@ -1,4 +1,4 @@
 .copy-instruction pre {
   white-space: pre-wrap;
-  word-break: break-word;
+  overflow-wrap: break-word;
 }

--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.tsx
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.tsx
@@ -1,5 +1,7 @@
 import { Content, ContentVariants, ClipboardCopy, clipboardCopyFunc } from '@patternfly/react-core';
 
+import './CopyInstruction.css';
+
 type CopyInstructionProps = {
   children: string;
   className?: string;
@@ -9,7 +11,7 @@ type CopyInstructionProps = {
 
 export const CopyInstruction: React.FunctionComponent<CopyInstructionProps> = (props) => {
   return (
-    <Content component={ContentVariants.pre}>
+    <Content component={ContentVariants.pre} className="copy-instruction">
       <ClipboardCopy
         variant={props.variant}
         isReadOnly

--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.tsx
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.tsx
@@ -11,7 +11,10 @@ type CopyInstructionProps = {
 
 export const CopyInstruction: React.FunctionComponent<CopyInstructionProps> = (props) => {
   return (
-    <Content component={ContentVariants.pre} className="copy-instruction">
+    <Content
+      component={ContentVariants.pre}
+      className={`copy-instruction${props.className ? ` ${props.className}` : ''}`}
+    >
       <ClipboardCopy
         variant={props.variant}
         isReadOnly


### PR DESCRIPTION
## Summary
- Fix text overflow in the OIDC config expandable hint popover
- The `rosa login --use-auth-code --url ...` command was extending beyond the popover boundary
- Added `white-space: pre-wrap` and `word-break: break-word` CSS to the CopyInstruction `<pre>` wrapper so long commands wrap within the container

## Test plan
- [ ] Open the ROSA wizard and navigate to the OIDC config step
- [ ] Click the hint to open the popover with the rosa login command
- [ ] Verify the expandable section text wraps within the popover boundary
- [ ] Verify the copy button still works correctly

Fixes [FCN-210](https://redhat.atlassian.net/browse/FCN-210)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FCN-210]: https://redhat.atlassian.net/browse/FCN-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ