### PR TITLE
fix(CopyInstruction): wrap long text

### DIFF
--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.css
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.css
@@ -1,0 +1,4 @@
+.copy-instruction {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}

--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.spec.tsx
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.spec.tsx
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import { checkAccessibility } from '../../../../test-helpers';
+import { CopyInstruction } from './CopyInstruction';
+
+test.describe('CopyInstruction', () => {
+  test('should pass accessibility tests', async ({ mount }) => {
+    const component = await mount(<CopyInstruction>rosa login --use-auth-code</CopyInstruction>);
+    await checkAccessibility({ component });
+  });
+
+  test('should render the command text in a copyable input', async ({ mount }) => {
+    const component = await mount(<CopyInstruction>rosa create oidc-config</CopyInstruction>);
+
+    const input = component.getByRole('textbox', { name: 'Copyable input' });
+    await expect(input).toBeVisible();
+    await expect(input).toHaveValue('rosa create oidc-config');
+  });
+
+  test('should render a copy button', async ({ mount }) => {
+    const component = await mount(<CopyInstruction>rosa login</CopyInstruction>);
+
+    await expect(component.getByRole('button', { name: 'Copy to clipboard' })).toBeVisible();
+  });
+
+  test('should apply copy-instruction class to wrapper', async ({ mount, page }) => {
+    await mount(<CopyInstruction>rosa login</CopyInstruction>);
+
+    const wrapper = page.locator('pre.copy-instruction');
+    await expect(wrapper).toBeAttached();
+  });
+
+  test('should merge custom className with copy-instruction class', async ({ mount, page }) => {
+    await mount(<CopyInstruction className="custom-class">rosa login</CopyInstruction>);
+
+    const wrapper = page.locator('pre.copy-instruction.custom-class');
+    await expect(wrapper).toBeAttached();
+  });
+
+  test('should have text wrapping styles for long commands', async ({ mount, page }) => {
+    const longCommand = 'rosa login --use-auth-code --url https://api.stage.openshift.com';
+    const component = await mount(<CopyInstruction>{longCommand}</CopyInstruction>);
+
+    const input = component.getByRole('textbox', { name: 'Copyable input' });
+    await expect(input).toHaveValue(longCommand);
+
+    // Verify the pre wrapper has wrapping styles
+    const preWrapper = page.locator('pre.copy-instruction');
+    await expect(preWrapper).toHaveCSS('white-space', 'pre-wrap');
+    await expect(preWrapper).toHaveCSS('overflow-wrap', 'break-word');
+  });
+});

--- a/src/components/Wizards/RosaWizard/common/CopyInstruction.tsx
+++ b/src/components/Wizards/RosaWizard/common/CopyInstruction.tsx
@@ -1,4 +1,5 @@
 import { Content, ContentVariants, ClipboardCopy, clipboardCopyFunc } from '@patternfly/react-core';
+import './CopyInstruction.css';
 
 type CopyInstructionProps = {
   children: string;
@@ -7,19 +8,27 @@ type CopyInstructionProps = {
   variant?: 'inline' | 'expansion' | 'inline-compact';
 };
 
-export const CopyInstruction: React.FunctionComponent<CopyInstructionProps> = (props) => {
+export const CopyInstruction: React.FunctionComponent<CopyInstructionProps> = ({
+  children,
+  className,
+  textAriaLabel,
+  variant,
+  ...rest
+}) => {
+  const contentClassName = ['copy-instruction', className].filter(Boolean).join(' ');
+
   return (
-    <Content component={ContentVariants.pre}>
+    <Content component={ContentVariants.pre} className={contentClassName}>
       <ClipboardCopy
-        variant={props.variant}
+        variant={variant}
         isReadOnly
-        textAriaLabel={props.textAriaLabel}
+        textAriaLabel={textAriaLabel}
         onCopy={(event, text) => {
           clipboardCopyFunc(event, text);
         }}
-        {...props}
+        {...rest}
       >
-        {props.children}
+        {children}
       </ClipboardCopy>
     </Content>
   );


### PR DESCRIPTION
## Summary

- **FCN-210**: Fix long command text overflowing the popover boundary in the OIDC config expandable section
- Add `CopyInstruction.css` with `white-space: pre-wrap` and `overflow-wrap: break-word` to the `<pre>` wrapper so long commands wrap within the container
- Properly destructure props and combine the `className` prop with the `copy-instruction` class (addresses CodeRabbit feedback from previous PR #94)
- Uses modern `overflow-wrap: break-word` instead of the deprecated `word-break: break-word`
- Add Playwright component tests for CopyInstruction

## Test plan

- [x] All 260 existing component tests pass
- [x] 6 new CopyInstruction tests pass (accessibility, rendering, className merging, CSS wrapping)
- [x] Lint and type-check pass
- [ ] Visual verification of the OIDC config popover with long command text