### PR TITLE
FCN-210: fixed bug with expandable command overflow

### DIFF
--- a/src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx
+++ b/src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx
@@ -8,7 +8,7 @@ export const OIDCConfigHint = () => {
   return (
     <>
       <Content component={ContentVariants.p}>{oidcHint.instructions}</Content>
-      <CopyInstruction variant={ClipboardCopyVariant.expansion}>
+      <CopyInstruction variant={ClipboardCopyVariant.expansion} className="pf-v6-u-text-wrap">
         rosa login --use-auth-code --url https://api.stage.openshift.com
         {/* TODO: This should be at least production */}
       </CopyInstruction>


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->
A small bug that was causing for rosa oidc command to overflow outside the popover hint container. Simple text wrap PF6 utility class fixes it (ai failed to do it)


**Jira issue #** 
https://redhat.atlassian.net/browse/FCN-210

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Navigate to roles and policies step.
2. Click on Create a new OIDC config id
3. Expand the command section

**Test Environment:**
- [ ] Tested locally
- [X] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->
<img width="2084" height="824" alt="image" src="https://github.com/user-attachments/assets/9b85cbf7-8500-41c2-b26c-edfaeef85d9e" />


### After
<!-- Screenshot or description of the new behavior -->
<img width="1500" height="806" alt="image" src="https://github.com/user-attachments/assets/a9ef5193-eb7a-479b-95e9-cd37f6ea267d" />



## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [ ] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

