### PR TITLE
FCN-260: add Total Clusters dashboard widget

### DIFF
--- a/src/components/dashboard/TotalClusters/TotalClusters.module.scss
+++ b/src/components/dashboard/TotalClusters/TotalClusters.module.scss
@@ -1,0 +1,45 @@
+.container {
+  padding: 1rem;
+  height: 100%;
+}
+
+.totalSection {
+  padding-bottom: var(--pf-t--global--spacer--md);
+}
+
+.totalNumber {
+  font-size: 2.5rem;
+  font-weight: 300;
+  line-height: 1;
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.totalLabel {
+  font-size: 0.875rem;
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+.breakdown {
+  padding: var(--pf-t--global--spacer--md) 0;
+}
+
+.breakdownCount {
+  font-size: 1.5rem;
+  font-weight: 400;
+  line-height: 1;
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.breakdownLabel {
+  font-size: 0.875rem;
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.icon {
+  color: var(--pf-t--global--text--color--regular);
+  font-size: 1rem;
+}
+
+.viewLink {
+  padding-top: var(--pf-t--global--spacer--md);
+}

--- a/src/components/dashboard/TotalClusters/TotalClusters.module.scss
+++ b/src/components/dashboard/TotalClusters/TotalClusters.module.scss
@@ -1,5 +1,5 @@
 .container {
-  padding: 1rem;
+  padding: var(--pf-t--global--spacer--md);
   height: 100%;
 }
 
@@ -8,14 +8,14 @@
 }
 
 .totalNumber {
-  font-size: 2.5rem;
+  font-size: var(--pf-t--global--font--size--4xl);
   font-weight: 300;
   line-height: 1;
   color: var(--pf-t--global--text--color--regular);
 }
 
 .totalLabel {
-  font-size: 0.875rem;
+  font-size: var(--pf-t--global--font--size--sm);
   color: var(--pf-t--global--text--color--subtle);
 }
 
@@ -24,20 +24,20 @@
 }
 
 .breakdownCount {
-  font-size: 1.5rem;
+  font-size: var(--pf-t--global--font--size--2xl);
   font-weight: 400;
   line-height: 1;
   color: var(--pf-t--global--text--color--regular);
 }
 
 .breakdownLabel {
-  font-size: 0.875rem;
+  font-size: var(--pf-t--global--font--size--sm);
   color: var(--pf-t--global--text--color--regular);
 }
 
 .icon {
   color: var(--pf-t--global--text--color--regular);
-  font-size: 1rem;
+  font-size: var(--pf-t--global--font--size--md);
 }
 
 .viewLink {

--- a/src/components/dashboard/TotalClusters/TotalClusters.spec.tsx
+++ b/src/components/dashboard/TotalClusters/TotalClusters.spec.tsx
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { TotalClusters, TotalClustersProps } from './TotalClusters';
+import { checkAccessibility } from '../../../test-helpers';
+
+const defaultData: TotalClustersProps['data'] = {
+  total: 67,
+  breakdown: [
+    { label: 'ROSA', count: 42 },
+    { label: 'ARO', count: 15 },
+    { label: 'OSD', count: 10 },
+  ],
+};
+
+test.describe('TotalClusters', () => {
+  test('should pass accessibility tests', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+    await checkAccessibility({ component });
+  });
+
+  test('should display the total cluster count', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+    await expect(component.getByTestId('total-clusters')).toContainText('67');
+  });
+
+  test('should display the total label', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+    await expect(component.getByText('total managed clusters')).toBeVisible();
+  });
+
+  test('should display breakdown counts per cluster type', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+
+    await expect(component.getByTestId('count-ROSA')).toContainText('42');
+    await expect(component.getByTestId('count-ARO')).toContainText('15');
+    await expect(component.getByTestId('count-OSD')).toContainText('10');
+  });
+
+  test('should display breakdown labels', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+
+    await expect(component.getByText('ROSA')).toBeVisible();
+    await expect(component.getByText('ARO')).toBeVisible();
+    await expect(component.getByText('OSD')).toBeVisible();
+  });
+
+  test('should not render breakdown section when breakdown is not provided', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={{ total: 50 }} />);
+
+    await expect(component.getByTestId('total-clusters')).toContainText('50');
+    await expect(component.getByText('ROSA')).not.toBeVisible();
+  });
+
+  test('should not render breakdown section when breakdown is empty', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={{ total: 50, breakdown: [] }} />);
+
+    await expect(component.getByTestId('total-clusters')).toContainText('50');
+    await expect(component.getByText('total managed clusters')).toBeVisible();
+  });
+
+  test('should render with zero total', async ({ mount }) => {
+    const data: TotalClustersProps['data'] = {
+      total: 0,
+      breakdown: [
+        { label: 'ROSA', count: 0 },
+        { label: 'ARO', count: 0 },
+      ],
+    };
+    const component = await mount(<TotalClusters data={data} />);
+
+    await expect(component.getByTestId('total-clusters')).toContainText('0');
+    await expect(component.getByTestId('count-ROSA')).toContainText('0');
+    await expect(component.getByTestId('count-ARO')).toContainText('0');
+  });
+
+  test('should render with high counts', async ({ mount }) => {
+    const component = await mount(
+      <TotalClusters data={{ total: 9999, breakdown: [{ label: 'ROSA', count: 9999 }] }} />
+    );
+
+    await expect(component.getByTestId('total-clusters')).toContainText('9999');
+    await expect(component.getByTestId('count-ROSA')).toContainText('9999');
+  });
+
+  test('should not show "View all clusters" button when onViewMore is not provided', async ({
+    mount,
+  }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+    await expect(component.getByRole('button', { name: /View all clusters/i })).not.toBeVisible();
+  });
+
+  test('should show "View all clusters" button when onViewMore is provided', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} onViewMore={() => {}} />);
+
+    const viewButton = component.getByRole('button', { name: /View all clusters/i });
+    await expect(viewButton).toBeVisible();
+  });
+
+  test('should call onViewMore when button is clicked', async ({ mount }) => {
+    let viewMoreCalled = false;
+    const handleViewMore = () => {
+      viewMoreCalled = true;
+    };
+
+    const component = await mount(<TotalClusters data={defaultData} onViewMore={handleViewMore} />);
+
+    await component.getByRole('button', { name: /View all clusters/i }).click();
+    expect(viewMoreCalled).toBe(true);
+  });
+
+  test('should render icons for each breakdown item', async ({ mount }) => {
+    const component = await mount(<TotalClusters data={defaultData} />);
+
+    const icons = component.locator('svg');
+    expect(await icons.count()).toBeGreaterThanOrEqual(defaultData.breakdown!.length);
+  });
+
+  test('should handle single cluster type in breakdown', async ({ mount }) => {
+    const data: TotalClustersProps['data'] = {
+      total: 25,
+      breakdown: [{ label: 'ROSA', count: 25 }],
+    };
+    const component = await mount(<TotalClusters data={data} />);
+
+    await expect(component.getByTestId('total-clusters')).toContainText('25');
+    await expect(component.getByTestId('count-ROSA')).toContainText('25');
+    await expect(component.getByText('ARO')).not.toBeVisible();
+  });
+
+  test('should handle four or more cluster types in breakdown', async ({ mount }) => {
+    const data: TotalClustersProps['data'] = {
+      total: 100,
+      breakdown: [
+        { label: 'ROSA', count: 40 },
+        { label: 'ARO', count: 30 },
+        { label: 'OSD', count: 20 },
+        { label: 'Other', count: 10 },
+      ],
+    };
+    const component = await mount(<TotalClusters data={data} />);
+
+    await expect(component.getByTestId('count-ROSA')).toContainText('40');
+    await expect(component.getByTestId('count-ARO')).toContainText('30');
+    await expect(component.getByTestId('count-OSD')).toContainText('20');
+    await expect(component.getByTestId('count-Other')).toContainText('10');
+  });
+});

--- a/src/components/dashboard/TotalClusters/TotalClusters.stories.tsx
+++ b/src/components/dashboard/TotalClusters/TotalClusters.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { TotalClusters } from './TotalClusters';
+
+const meta: Meta<typeof TotalClusters> = {
+  title: 'Components/Dashboard/TotalClusters',
+  component: TotalClusters,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof TotalClusters>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      total: 67,
+      breakdown: [
+        { label: 'ROSA', count: 42 },
+        { label: 'ARO', count: 15 },
+        { label: 'OSD', count: 10 },
+      ],
+    },
+  },
+};
+
+export const WithViewMore: Story = {
+  args: {
+    data: {
+      total: 67,
+      breakdown: [
+        { label: 'ROSA', count: 42 },
+        { label: 'ARO', count: 15 },
+        { label: 'OSD', count: 10 },
+      ],
+    },
+    onViewMore: fn(),
+  },
+};
+
+export const TotalOnly: Story = {
+  args: {
+    data: {
+      total: 120,
+    },
+  },
+};
+
+export const SingleClusterType: Story = {
+  args: {
+    data: {
+      total: 25,
+      breakdown: [{ label: 'ROSA', count: 25 }],
+    },
+  },
+};
+
+export const ZeroClusters: Story = {
+  args: {
+    data: {
+      total: 0,
+      breakdown: [
+        { label: 'ROSA', count: 0 },
+        { label: 'ARO', count: 0 },
+        { label: 'OSD', count: 0 },
+      ],
+    },
+  },
+};
+
+export const HighCount: Story = {
+  args: {
+    data: {
+      total: 1247,
+      breakdown: [
+        { label: 'ROSA', count: 800 },
+        { label: 'ARO', count: 300 },
+        { label: 'OSD', count: 100 },
+        { label: 'Other', count: 47 },
+      ],
+    },
+    onViewMore: fn(),
+  },
+};
+
+export const EmptyBreakdown: Story = {
+  args: {
+    data: {
+      total: 50,
+      breakdown: [],
+    },
+  },
+};

--- a/src/components/dashboard/TotalClusters/TotalClusters.tsx
+++ b/src/components/dashboard/TotalClusters/TotalClusters.tsx
@@ -1,5 +1,6 @@
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import ClusterIcon from '@patternfly/react-icons/dist/esm/icons/cluster-icon';
+import React from 'react';
 import styles from './TotalClusters.module.scss';
 
 export type ClusterBreakdown = {

--- a/src/components/dashboard/TotalClusters/TotalClusters.tsx
+++ b/src/components/dashboard/TotalClusters/TotalClusters.tsx
@@ -1,0 +1,84 @@
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import ClusterIcon from '@patternfly/react-icons/dist/esm/icons/cluster-icon';
+import styles from './TotalClusters.module.scss';
+
+export type ClusterBreakdown = {
+  /** cluster type label (e.g. "ROSA", "ARO", "OSD") */
+  label: string;
+  /** number of clusters of this type */
+  count: number;
+};
+
+export type TotalClustersData = {
+  /** total number of managed clusters */
+  total: number;
+  /** optional per-type breakdown */
+  breakdown?: ClusterBreakdown[];
+};
+
+export type TotalClustersProps = {
+  /** cluster data to display */
+  data: TotalClustersData;
+  /** callback when "View all clusters" is clicked */
+  onViewMore?: () => void;
+};
+
+export const TotalClusters: React.FC<TotalClustersProps> = ({ data, onViewMore }) => {
+  const { total, breakdown } = data;
+
+  return (
+    <Flex direction={{ default: 'column' }} className={styles.container}>
+      <Flex
+        direction={{ default: 'column' }}
+        spaceItems={{ default: 'spaceItemsXs' }}
+        className={styles.totalSection}
+      >
+        <FlexItem className={styles.totalNumber} data-testid="total-clusters">
+          {total}
+        </FlexItem>
+        <FlexItem className={styles.totalLabel}>total managed clusters</FlexItem>
+      </Flex>
+
+      {breakdown && breakdown.length > 0 && (
+        <Flex
+          justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          spaceItems={{ default: 'spaceItemsMd' }}
+          className={styles.breakdown}
+        >
+          {breakdown.map((item) => (
+            <Flex
+              key={item.label}
+              direction={{ default: 'column' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsXs' }}
+              flex={{ default: 'flex_1' }}
+            >
+              <FlexItem className={styles.breakdownCount} data-testid={`count-${item.label}`}>
+                {item.count}
+              </FlexItem>
+              <FlexItem>
+                <Flex
+                  alignItems={{ default: 'alignItemsCenter' }}
+                  spaceItems={{ default: 'spaceItemsXs' }}
+                >
+                  <ClusterIcon className={styles.icon} />
+                  <span className={styles.breakdownLabel}>{item.label}</span>
+                </Flex>
+              </FlexItem>
+            </Flex>
+          ))}
+        </Flex>
+      )}
+
+      {onViewMore && (
+        <Flex justifyContent={{ default: 'justifyContentFlexEnd' }} className={styles.viewLink}>
+          <FlexItem>
+            <Button variant="link" onClick={onViewMore}>
+              View all clusters
+            </Button>
+          </FlexItem>
+        </Flex>
+      )}
+    </Flex>
+  );
+};

--- a/src/components/dashboard/TotalClusters/index.ts
+++ b/src/components/dashboard/TotalClusters/index.ts
@@ -1,0 +1,2 @@
+export { TotalClusters } from './TotalClusters';
+export type { TotalClustersProps, TotalClustersData, ClusterBreakdown } from './TotalClusters';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -14,3 +14,4 @@ export * from './dashboard/UpgradeRisks';
 export * from './dashboard/ClusterRecommendations';
 export * from './dashboard/Subscriptions';
 export * from './dashboard/LoadingPanel';
+export * from './dashboard/TotalClusters';


### PR DESCRIPTION
## Description

Adds a new `TotalClusters` dashboard widget component for the new OCM dashboard. This is the first of the widget builds under the FCN-259 epic.

The component shows a prominent total managed cluster count with an optional per-type breakdown (ROSA, ARO, OSD, etc.) and an optional "View all clusters" action link. Both breakdown and action link are optional props, so consumers can render either a simple count card (matching the latest Figma mockup) or a richer version with breakdown.

**Jira issue #** [FCN-260](https://issues.redhat.com/browse/FCN-260)

**Backport of** N/A


## Type of Change

- [x] New feature/enhancement (non-breaking change which adds functionality)


## Testing

### Manual Testing

**Test Steps:**
1. Run Storybook (`npm run storybook`)
2. Navigate to Components > Dashboard > TotalClusters
3. Verify all 7 story variants render correctly: Default, WithViewMore, TotalOnly, SingleClusterType, ZeroClusters, HighCount, EmptyBreakdown

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [x] Playwright Tests: 15/15 component tests pass (`npx playwright test src/components/dashboard/TotalClusters/`)

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

### Before
N/A -- new component

### After
**Default (with breakdown):**
Total count of 67, with per-type breakdown (ROSA: 42, ARO: 15, OSD: 10)
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/ba4192f4-d9b7-4eaa-bfe8-ee614c76917a" />


**TotalOnly (matches new Figma mockup):**
Simple count of 120, no breakdown, no action link
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/447051ea-65fa-4587-bdc6-669783514023" />



## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [x] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

- Breakdown and onViewMore are optional props. The latest Figma mockup shows a simple count card without them, but Margot confirmed keeping breakdown as optional since ACM uses it.
- This follows the same folder structure and patterns as existing dashboard widgets (StorageCard, CVECard, UpgradeRisks).


## Reviewer Guidelines

### Focus Areas
- Component API design: are the prop types flexible enough for dashboard integration?
- SCSS: using PatternFly design tokens only, no raw values

### Questions for Reviewers
- Any concerns with the `ClusterBreakdown` type being an array of `{label, count}` rather than a fixed set of cluster types?


[FCN-260]: https://redhat.atlassian.net/browse/FCN-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ