### PR TITLE
FCN-265 Add Update Status dashboard widget component

### DIFF
--- a/src/components/dashboard/UpdateStatus/UpdateStatus.module.scss
+++ b/src/components/dashboard/UpdateStatus/UpdateStatus.module.scss
@@ -1,0 +1,37 @@
+.container {
+  padding: var(--pf-t--global--spacer--md);
+  height: 100%;
+  align-items: center;
+}
+
+.section {
+  padding: var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--md);
+  text-align: center;
+}
+
+.count {
+  font-size: var(--pf-t--global--font--size--2xl);
+  font-weight: 400;
+  line-height: 1;
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.label {
+  font-size: var(--pf-t--global--font--size--sm);
+  color: var(--pf-t--global--text--color--subtle);
+}
+
+.upToDateIcon {
+  font-size: var(--pf-t--global--font--size--xl);
+  color: var(--pf-t--global--icon--color--status--success--default);
+}
+
+.updateAvailableIcon {
+  font-size: var(--pf-t--global--font--size--xl);
+  color: var(--pf-t--global--icon--color--status--warning--default);
+}
+
+.updatingIcon {
+  font-size: var(--pf-t--global--font--size--xl);
+  color: var(--pf-t--global--icon--color--status--info--default);
+}

--- a/src/components/dashboard/UpdateStatus/UpdateStatus.spec.tsx
+++ b/src/components/dashboard/UpdateStatus/UpdateStatus.spec.tsx
@@ -43,7 +43,7 @@ test.describe('UpdateStatus', () => {
 
   test('should render a vertical divider', async ({ mount }) => {
     const component = await mount(<UpdateStatus data={defaultData} />);
-    await expect(component.locator('hr')).toBeVisible();
+    await expect(component.locator('hr')).toHaveCount(1);
   });
 
   test('should render two icons when no updating data', async ({ mount }) => {
@@ -53,7 +53,7 @@ test.describe('UpdateStatus', () => {
 
   test('should not show currently updating section when omitted', async ({ mount }) => {
     const component = await mount(<UpdateStatus data={defaultData} />);
-    await expect(component.getByTestId('currently-updating-count')).not.toBeVisible();
+    await expect(component.getByTestId('currently-updating-count')).toHaveCount(0);
   });
 
   test('should render currently updating section when provided', async ({ mount }) => {

--- a/src/components/dashboard/UpdateStatus/UpdateStatus.spec.tsx
+++ b/src/components/dashboard/UpdateStatus/UpdateStatus.spec.tsx
@@ -1,0 +1,105 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { UpdateStatus, UpdateStatusData } from './UpdateStatus';
+import { checkAccessibility } from '../../../test-helpers';
+
+const defaultData: UpdateStatusData = {
+  upToDate: 118,
+  updateAvailable: 32,
+};
+
+const dataWithUpdating: UpdateStatusData = {
+  upToDate: 105,
+  updateAvailable: 27,
+  currentlyUpdating: 18,
+};
+
+test.describe('UpdateStatus', () => {
+  test('should pass accessibility tests', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await checkAccessibility({ component });
+  });
+
+  test('should pass accessibility tests with currently updating', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={dataWithUpdating} />);
+    await checkAccessibility({ component });
+  });
+
+  test('should render the up-to-date count', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await expect(component.getByTestId('up-to-date-count')).toHaveText('118');
+  });
+
+  test('should render the update available count', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await expect(component.getByTestId('update-available-count')).toHaveText('32');
+  });
+
+  test('should render labels for both statuses', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await expect(component.getByText('clusters up-to-date')).toBeVisible();
+    await expect(component.getByText('clusters with update available')).toBeVisible();
+  });
+
+  test('should render a vertical divider', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await expect(component.locator('hr')).toBeVisible();
+  });
+
+  test('should render two icons when no updating data', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await expect(component.locator('svg')).toHaveCount(2);
+  });
+
+  test('should not show currently updating section when omitted', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={defaultData} />);
+    await expect(component.getByTestId('currently-updating-count')).not.toBeVisible();
+  });
+
+  test('should render currently updating section when provided', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={dataWithUpdating} />);
+    await expect(component.getByTestId('currently-updating-count')).toHaveText('18');
+    await expect(component.getByText('currently updating')).toBeVisible();
+  });
+
+  test('should render three icons when updating data is provided', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={dataWithUpdating} />);
+    await expect(component.locator('svg')).toHaveCount(3);
+  });
+
+  test('should render two dividers when updating data is provided', async ({ mount }) => {
+    const component = await mount(<UpdateStatus data={dataWithUpdating} />);
+    await expect(component.locator('hr')).toHaveCount(2);
+  });
+
+  test('should display zero for up-to-date when all need updates', async ({ mount }) => {
+    const data: UpdateStatusData = { upToDate: 0, updateAvailable: 45 };
+    const component = await mount(<UpdateStatus data={data} />);
+    await expect(component.getByTestId('up-to-date-count')).toHaveText('0');
+  });
+
+  test('should display zero for update available when all are current', async ({ mount }) => {
+    const data: UpdateStatusData = { upToDate: 150, updateAvailable: 0 };
+    const component = await mount(<UpdateStatus data={data} />);
+    await expect(component.getByTestId('update-available-count')).toHaveText('0');
+  });
+
+  test('should handle both counts being zero', async ({ mount }) => {
+    const data: UpdateStatusData = { upToDate: 0, updateAvailable: 0 };
+    const component = await mount(<UpdateStatus data={data} />);
+    await expect(component.getByTestId('up-to-date-count')).toHaveText('0');
+    await expect(component.getByTestId('update-available-count')).toHaveText('0');
+  });
+
+  test('should handle large counts', async ({ mount }) => {
+    const data: UpdateStatusData = {
+      upToDate: 9999,
+      updateAvailable: 5678,
+      currentlyUpdating: 1234,
+    };
+    const component = await mount(<UpdateStatus data={data} />);
+    await expect(component.getByTestId('up-to-date-count')).toHaveText('9999');
+    await expect(component.getByTestId('update-available-count')).toHaveText('5678');
+    await expect(component.getByTestId('currently-updating-count')).toHaveText('1234');
+  });
+});

--- a/src/components/dashboard/UpdateStatus/UpdateStatus.stories.tsx
+++ b/src/components/dashboard/UpdateStatus/UpdateStatus.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { UpdateStatus } from './UpdateStatus';
+
+const meta: Meta<typeof UpdateStatus> = {
+  title: 'Components/Dashboard/UpdateStatus',
+  component: UpdateStatus,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof UpdateStatus>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      upToDate: 118,
+      updateAvailable: 32,
+    },
+  },
+};
+
+export const WithCurrentlyUpdating: Story = {
+  args: {
+    data: {
+      upToDate: 105,
+      updateAvailable: 27,
+      currentlyUpdating: 18,
+    },
+  },
+};
+
+export const AllUpToDate: Story = {
+  args: {
+    data: {
+      upToDate: 150,
+      updateAvailable: 0,
+    },
+  },
+};
+
+export const AllNeedUpdate: Story = {
+  args: {
+    data: {
+      upToDate: 0,
+      updateAvailable: 45,
+    },
+  },
+};
+
+export const HighCounts: Story = {
+  args: {
+    data: {
+      upToDate: 3842,
+      updateAvailable: 957,
+      currentlyUpdating: 201,
+    },
+  },
+};
+
+export const ZeroClusters: Story = {
+  args: {
+    data: {
+      upToDate: 0,
+      updateAvailable: 0,
+    },
+  },
+};

--- a/src/components/dashboard/UpdateStatus/UpdateStatus.tsx
+++ b/src/components/dashboard/UpdateStatus/UpdateStatus.tsx
@@ -1,0 +1,88 @@
+import { Divider, Flex, FlexItem } from '@patternfly/react-core';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import InProgressIcon from '@patternfly/react-icons/dist/esm/icons/in-progress-icon';
+import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
+import React from 'react';
+import styles from './UpdateStatus.module.scss';
+
+export type UpdateStatusData = {
+  /** number of clusters running the latest version */
+  upToDate: number;
+  /** number of clusters with an update available */
+  updateAvailable: number;
+  /** number of clusters currently updating (omit if not applicable) */
+  currentlyUpdating?: number;
+};
+
+export type UpdateStatusProps = {
+  /** update status counts */
+  data: UpdateStatusData;
+};
+
+export const UpdateStatus: React.FC<UpdateStatusProps> = ({ data }) => {
+  const { upToDate, updateAvailable, currentlyUpdating } = data;
+  const showUpdating = currentlyUpdating !== undefined;
+
+  return (
+    <Flex className={styles.container}>
+      <FlexItem flex={{ default: 'flex_1' }}>
+        <Flex
+          direction={{ default: 'column' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+          spaceItems={{ default: 'spaceItemsSm' }}
+          className={styles.section}
+        >
+          <FlexItem>
+            <CheckCircleIcon className={styles.upToDateIcon} aria-hidden="true" />
+          </FlexItem>
+          <FlexItem className={styles.count} data-testid="up-to-date-count">
+            {upToDate}
+          </FlexItem>
+          <FlexItem className={styles.label}>clusters up-to-date</FlexItem>
+        </Flex>
+      </FlexItem>
+
+      <Divider orientation={{ default: 'vertical' }} />
+
+      <FlexItem flex={{ default: 'flex_1' }}>
+        <Flex
+          direction={{ default: 'column' }}
+          alignItems={{ default: 'alignItemsCenter' }}
+          spaceItems={{ default: 'spaceItemsSm' }}
+          className={styles.section}
+        >
+          <FlexItem>
+            <SyncAltIcon className={styles.updateAvailableIcon} aria-hidden="true" />
+          </FlexItem>
+          <FlexItem className={styles.count} data-testid="update-available-count">
+            {updateAvailable}
+          </FlexItem>
+          <FlexItem className={styles.label}>clusters with update available</FlexItem>
+        </Flex>
+      </FlexItem>
+
+      {showUpdating && (
+        <>
+          <Divider orientation={{ default: 'vertical' }} />
+
+          <FlexItem flex={{ default: 'flex_1' }}>
+            <Flex
+              direction={{ default: 'column' }}
+              alignItems={{ default: 'alignItemsCenter' }}
+              spaceItems={{ default: 'spaceItemsSm' }}
+              className={styles.section}
+            >
+              <FlexItem>
+                <InProgressIcon className={styles.updatingIcon} aria-hidden="true" />
+              </FlexItem>
+              <FlexItem className={styles.count} data-testid="currently-updating-count">
+                {currentlyUpdating}
+              </FlexItem>
+              <FlexItem className={styles.label}>currently updating</FlexItem>
+            </Flex>
+          </FlexItem>
+        </>
+      )}
+    </Flex>
+  );
+};

--- a/src/components/dashboard/UpdateStatus/index.ts
+++ b/src/components/dashboard/UpdateStatus/index.ts
@@ -1,0 +1,2 @@
+export { UpdateStatus } from './UpdateStatus';
+export type { UpdateStatusData, UpdateStatusProps } from './UpdateStatus';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,3 +16,4 @@ export * from './dashboard/Subscriptions';
 export * from './dashboard/LoadingPanel';
 export * from './dashboard/TotalClusters';
 export * from './dashboard/Telemetry';
+export * from './dashboard/UpdateStatus';


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

Adds the Update Status dashboard widget for the OCM dashboard. This is a two-count split card (same layout pattern as Telemetry) showing clusters up-to-date vs clusters with update available. An optional third section ("currently updating") renders when the data is provided, expanding to three columns.

Uses PF's <Divider> for vertical separators, icon-specific status color tokens, and aria-hidden on decorative icons.

**Jira issue #** 
https://redhat.atlassian.net/browse/FCN-265

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Run npm run storybook
2. Navigate to Components > Dashboard > UpdateStatus
3. Check all 6 stories: Default, WithCurrentlyUpdating, AllUpToDate, AllNeedUpdate, HighCounts, ZeroClusters

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->
Default
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/f4cee0a3-0247-4a54-be4f-63bb8722a10b" />

Currently updating
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/bfd46bcb-6721-459d-83aa-5cabdfea16eb" />



## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->
Part of the FCN-259 dashboard widget build epic. Same two-count split layout as FCN-264 (Telemetry) with an optional third column for "currently updating" clusters. Margot confirmed the third state should only appear if the data exists.

All styling uses PF v6 design tokens — no hardcoded colors or font sizes.
### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- 

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->

