### PR TITLE
FCN-261 Add Clusters with Issues dashboard widget component

### DIFF
--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
@@ -10,28 +10,18 @@
   color: var(--pf-t--global--text--color--regular);
 }
 
-.tableWrapper {
-  padding-top: var(--pf-t--global--spacer--sm);
+.countSection {
+  padding-bottom: var(--pf-t--global--spacer--sm);
+  border-bottom: var(--pf-t--global--border--width--divider--default) solid
+    var(--pf-t--global--border--color--default);
 }
 
-.clusterLink {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  font: inherit;
-  color: var(--pf-t--global--text--color--link--default);
-  text-decoration: none;
+.tableWrapper {
+  padding-top: 0;
+}
 
-  &:hover {
-    text-decoration: underline;
-  }
-
-  &:focus-visible {
-    outline: 2px solid currentcolor;
-    outline-offset: 2px;
-    text-decoration: underline;
-  }
+.pagination {
+  margin-top: auto;
 }
 
 .emptyState {

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
@@ -1,0 +1,35 @@
+.container {
+  padding: var(--pf-t--global--spacer--md);
+  height: 100%;
+}
+
+.count {
+  font-size: var(--pf-t--global--font--size--2xl);
+  font-weight: 400;
+  line-height: 1;
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.tableWrapper {
+  padding-top: var(--pf-t--global--spacer--sm);
+}
+
+.clusterLink {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--pf-t--global--text--color--link--default);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.emptyState {
+  padding: var(--pf-t--global--spacer--xl) 0;
+  color: var(--pf-t--global--text--color--subtle);
+  font-size: var(--pf-t--global--font--size--sm);
+}

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
@@ -28,7 +28,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid currentColor;
+    outline: 2px solid currentcolor;
     outline-offset: 2px;
     text-decoration: underline;
   }

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.module.scss
@@ -26,6 +26,12 @@
   &:hover {
     text-decoration: underline;
   }
+
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+    text-decoration: underline;
+  }
 }
 
 .emptyState {

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec-helpers.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec-helpers.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
 import { ClustersWithIssues, ClustersWithIssuesProps } from './ClustersWithIssues';
 
-// playwright CT can't serialize functions that return data across process
-// boundaries, so this wrapper defines rowActions in the browser context
-export const ClustersWithIssuesWithActions: React.FC<{
+// playwright CT can't serialize functions across process boundaries,
+// so this wrapper defines callbacks in the browser context
+export const ClustersWithIssuesWithConsoleLink: React.FC<{
   data: ClustersWithIssuesProps['data'];
-}> = ({ data }) => (
-  <ClustersWithIssues data={data} rowActions={() => [{ title: 'Open console' }]} />
-);
+}> = ({ data }) => <ClustersWithIssues data={data} onOpenConsole={() => {}} />;

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec-helpers.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec-helpers.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ClustersWithIssues, ClustersWithIssuesProps } from './ClustersWithIssues';
+
+// playwright CT can't serialize functions that return data across process
+// boundaries, so this wrapper defines rowActions in the browser context
+export const ClustersWithIssuesWithActions: React.FC<{
+  data: ClustersWithIssuesProps['data'];
+}> = ({ data }) => (
+  <ClustersWithIssues data={data} rowActions={() => [{ title: 'Open console' }]} />
+);

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
@@ -1,16 +1,16 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import React from 'react';
 import { ClustersWithIssues, ClustersWithIssuesProps } from './ClustersWithIssues';
-import { ClustersWithIssuesWithActions } from './ClustersWithIssues.spec-helpers';
+import { ClustersWithIssuesWithConsoleLink } from './ClustersWithIssues.spec-helpers';
 import { checkAccessibility } from '../../../test-helpers';
 
 const defaultData: ClustersWithIssuesProps['data'] = {
   totalUnhealthy: 4,
   clusters: [
-    { id: 'c1', name: 'cluster1', issues: 1 },
-    { id: 'c2', name: 'cluster2', issues: 12 },
-    { id: 'c3', name: 'cluster3', issues: 7 },
-    { id: 'c4', name: 'cluster4', issues: 5 },
+    { id: 'c1', name: 'cluster1', issues: 1, consoleUrl: 'https://console.example.com/c1' },
+    { id: 'c2', name: 'cluster2', issues: 12, consoleUrl: 'https://console.example.com/c2' },
+    { id: 'c3', name: 'cluster3', issues: 7, consoleUrl: 'https://console.example.com/c3' },
+    { id: 'c4', name: 'cluster4', issues: 5, consoleUrl: 'https://console.example.com/c4' },
   ],
 };
 
@@ -128,20 +128,6 @@ test.describe('ClustersWithIssues', () => {
     await expect(component.locator('.pf-v6-c-pagination')).toHaveCount(0);
   });
 
-  test('should render kebab actions when rowActions is provided', async ({ mount }) => {
-    const component = await mount(<ClustersWithIssuesWithActions data={defaultData} />);
-
-    const kebabs = component.locator('[aria-label="Kebab toggle"]');
-    expect(await kebabs.count()).toBe(defaultData.clusters.length);
-  });
-
-  test('should not render kebab column when rowActions is not provided', async ({ mount }) => {
-    const component = await mount(<ClustersWithIssues data={defaultData} />);
-
-    const kebabs = component.locator('[aria-label="Kebab toggle"]');
-    expect(await kebabs.count()).toBe(0);
-  });
-
   test('should handle single cluster', async ({ mount }) => {
     const data: ClustersWithIssuesProps['data'] = {
       totalUnhealthy: 1,
@@ -163,6 +149,55 @@ test.describe('ClustersWithIssues', () => {
 
     await expect(component.getByTestId('unhealthy-count')).toContainText('999');
     await expect(component.getByTestId('issues-c1')).toContainText('500');
+  });
+});
+
+test.describe('ClustersWithIssues — open console link', () => {
+  test('should render "Open console" links when onOpenConsole is provided', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssuesWithConsoleLink data={defaultData} />);
+
+    await expect(component.getByTestId('open-console-c1')).toBeVisible();
+    await expect(component.getByTestId('open-console-c1').getByText('Open console')).toBeVisible();
+  });
+
+  test('should render external link icon in each console link', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssuesWithConsoleLink data={defaultData} />);
+
+    const consoleCell = component.getByTestId('open-console-c1');
+    await expect(consoleCell.locator('svg')).toBeVisible();
+  });
+
+  test('should not render console column when onOpenConsole is not provided', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+
+    await expect(component.getByTestId('open-console-c1')).toHaveCount(0);
+  });
+
+  test('should render console links for all visible rows', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssuesWithConsoleLink data={defaultData} />);
+
+    for (const cluster of defaultData.clusters) {
+      await expect(component.getByTestId(`open-console-${cluster.id}`)).toBeVisible();
+    }
+  });
+});
+
+test.describe('ClustersWithIssues — title tooltip', () => {
+  test('should render the tooltip icon by default', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    await expect(component.getByTestId('title-tooltip-icon')).toBeVisible();
+  });
+
+  test('should hide the tooltip icon when titleTooltip is empty', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} titleTooltip="" />);
+    await expect(component.getByTestId('title-tooltip-icon')).toHaveCount(0);
+  });
+
+  test('should have an accessible label on the tooltip icon', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    await expect(
+      component.locator('[aria-label="More info about clusters with issues"]')
+    ).toBeVisible();
   });
 });
 
@@ -204,7 +239,7 @@ test.describe('ClustersWithIssues — pagination', () => {
     expect(await rows.count()).toBe(2);
   });
 
-  test('should not show pagination for fewer items than perPage', async ({ mount }) => {
+  test('should show all items on one page when fewer items than perPage', async ({ mount }) => {
     const smallData: ClustersWithIssuesProps['data'] = {
       totalUnhealthy: 3,
       clusters: [

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
@@ -14,6 +14,15 @@ const defaultData: ClustersWithIssuesProps['data'] = {
   ],
 };
 
+const paginatedData: ClustersWithIssuesProps['data'] = {
+  totalUnhealthy: 12,
+  clusters: Array.from({ length: 12 }, (_, i) => ({
+    id: `c${i + 1}`,
+    name: `cluster-${i + 1}`,
+    issues: 12 - i,
+  })),
+};
+
 test.describe('ClustersWithIssues', () => {
   test('should pass accessibility tests', async ({ mount }) => {
     const component = await mount(<ClustersWithIssues data={defaultData} />);
@@ -46,6 +55,17 @@ test.describe('ClustersWithIssues', () => {
     await expect(component.getByTestId('issues-c2')).toContainText('12');
     await expect(component.getByTestId('issues-c3')).toContainText('7');
     await expect(component.getByTestId('issues-c4')).toContainText('5');
+  });
+
+  test('should render the card title', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    await expect(component.getByRole('heading', { name: 'Clusters with issues' })).toBeVisible();
+  });
+
+  test('should render a divider after the cluster count', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    const countSection = component.getByTestId('unhealthy-count').locator('..');
+    await expect(countSection).toBeVisible();
   });
 
   test('should render table headers', async ({ mount }) => {
@@ -100,6 +120,14 @@ test.describe('ClustersWithIssues', () => {
     await expect(component.getByText('No clusters with issues')).toBeVisible();
   });
 
+  test('should not show pagination when no clusters', async ({ mount }) => {
+    const component = await mount(
+      <ClustersWithIssues data={{ totalUnhealthy: 0, clusters: [] }} />
+    );
+
+    await expect(component.locator('.pf-v6-c-pagination')).toHaveCount(0);
+  });
+
   test('should render kebab actions when rowActions is provided', async ({ mount }) => {
     const component = await mount(<ClustersWithIssuesWithActions data={defaultData} />);
 
@@ -135,5 +163,60 @@ test.describe('ClustersWithIssues', () => {
 
     await expect(component.getByTestId('unhealthy-count')).toContainText('999');
     await expect(component.getByTestId('issues-c1')).toContainText('500');
+  });
+});
+
+test.describe('ClustersWithIssues — pagination', () => {
+  test('should show only first page of clusters by default', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={paginatedData} perPage={5} />);
+
+    const rows = component.locator('tbody tr');
+    expect(await rows.count()).toBe(5);
+    await expect(component.getByText('cluster-1')).toBeVisible();
+    await expect(component.getByText('cluster-5')).toBeVisible();
+    await expect(component.getByText('cluster-6')).not.toBeVisible();
+  });
+
+  test('should show pagination controls', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={paginatedData} perPage={5} />);
+
+    await expect(component.locator('.pf-v6-c-pagination')).toBeVisible();
+  });
+
+  test('should navigate to next page', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={paginatedData} perPage={5} />);
+
+    await component.getByLabel('Go to next page').click();
+
+    await expect(component.getByText('cluster-6', { exact: true })).toBeVisible();
+    await expect(component.getByText('cluster-10', { exact: true })).toBeVisible();
+    await expect(component.getByText('cluster-1', { exact: true })).not.toBeVisible();
+  });
+
+  test('should navigate to last page', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={paginatedData} perPage={5} />);
+
+    await component.getByLabel('Go to last page').click();
+
+    await expect(component.getByText('cluster-11')).toBeVisible();
+    await expect(component.getByText('cluster-12')).toBeVisible();
+    const rows = component.locator('tbody tr');
+    expect(await rows.count()).toBe(2);
+  });
+
+  test('should not show pagination for fewer items than perPage', async ({ mount }) => {
+    const smallData: ClustersWithIssuesProps['data'] = {
+      totalUnhealthy: 3,
+      clusters: [
+        { id: 'c1', name: 'a', issues: 1 },
+        { id: 'c2', name: 'b', issues: 2 },
+        { id: 'c3', name: 'c', issues: 3 },
+      ],
+    };
+    const component = await mount(<ClustersWithIssues data={smallData} perPage={5} />);
+
+    const rows = component.locator('tbody tr');
+    expect(await rows.count()).toBe(3);
+    await expect(component.locator('.pf-v6-c-pagination')).toBeVisible();
   });
 });

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/experimental-ct-react';
 import React from 'react';
 import { ClustersWithIssues, ClustersWithIssuesProps } from './ClustersWithIssues';
+import { ClustersWithIssuesWithActions } from './ClustersWithIssues.spec-helpers';
 import { checkAccessibility } from '../../../test-helpers';
 
 const defaultData: ClustersWithIssuesProps['data'] = {
@@ -26,8 +27,7 @@ test.describe('ClustersWithIssues', () => {
 
   test('should display the danger icon', async ({ mount }) => {
     const component = await mount(<ClustersWithIssues data={defaultData} />);
-    const icon = component.locator('svg');
-    expect(await icon.count()).toBeGreaterThanOrEqual(1);
+    await expect(component.getByTestId('unhealthy-icon')).toBeVisible();
   });
 
   test('should render cluster names in the table', async ({ mount }) => {
@@ -42,10 +42,10 @@ test.describe('ClustersWithIssues', () => {
   test('should render issue counts in the table', async ({ mount }) => {
     const component = await mount(<ClustersWithIssues data={defaultData} />);
 
-    await expect(component.getByRole('cell', { name: '1' })).toBeVisible();
-    await expect(component.getByRole('cell', { name: '12' })).toBeVisible();
-    await expect(component.getByRole('cell', { name: '7' })).toBeVisible();
-    await expect(component.getByRole('cell', { name: '5' })).toBeVisible();
+    await expect(component.getByTestId('issues-c1')).toContainText('1');
+    await expect(component.getByTestId('issues-c2')).toContainText('12');
+    await expect(component.getByTestId('issues-c3')).toContainText('7');
+    await expect(component.getByTestId('issues-c4')).toContainText('5');
   });
 
   test('should render table headers', async ({ mount }) => {
@@ -101,18 +101,16 @@ test.describe('ClustersWithIssues', () => {
   });
 
   test('should render kebab actions when rowActions is provided', async ({ mount }) => {
-    const component = await mount(
-      <ClustersWithIssues data={defaultData} rowActions={() => [{ title: 'Open console' }]} />
-    );
+    const component = await mount(<ClustersWithIssuesWithActions data={defaultData} />);
 
-    const kebabs = component.getByRole('button', { name: 'Kebab toggle' });
+    const kebabs = component.locator('[aria-label="Kebab toggle"]');
     expect(await kebabs.count()).toBe(defaultData.clusters.length);
   });
 
   test('should not render kebab column when rowActions is not provided', async ({ mount }) => {
     const component = await mount(<ClustersWithIssues data={defaultData} />);
 
-    const kebabs = component.getByRole('button', { name: 'Kebab toggle' });
+    const kebabs = component.locator('[aria-label="Kebab toggle"]');
     expect(await kebabs.count()).toBe(0);
   });
 
@@ -125,7 +123,7 @@ test.describe('ClustersWithIssues', () => {
 
     await expect(component.getByTestId('unhealthy-count')).toContainText('1');
     await expect(component.getByText('prod-east')).toBeVisible();
-    await expect(component.getByRole('cell', { name: '3' })).toBeVisible();
+    await expect(component.getByTestId('issues-c1')).toContainText('3');
   });
 
   test('should handle high issue counts', async ({ mount }) => {
@@ -136,6 +134,6 @@ test.describe('ClustersWithIssues', () => {
     const component = await mount(<ClustersWithIssues data={data} />);
 
     await expect(component.getByTestId('unhealthy-count')).toContainText('999');
-    await expect(component.getByRole('cell', { name: '500' })).toBeVisible();
+    await expect(component.getByTestId('issues-c1')).toContainText('500');
   });
 });

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.spec.tsx
@@ -1,0 +1,141 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { ClustersWithIssues, ClustersWithIssuesProps } from './ClustersWithIssues';
+import { checkAccessibility } from '../../../test-helpers';
+
+const defaultData: ClustersWithIssuesProps['data'] = {
+  totalUnhealthy: 4,
+  clusters: [
+    { id: 'c1', name: 'cluster1', issues: 1 },
+    { id: 'c2', name: 'cluster2', issues: 12 },
+    { id: 'c3', name: 'cluster3', issues: 7 },
+    { id: 'c4', name: 'cluster4', issues: 5 },
+  ],
+};
+
+test.describe('ClustersWithIssues', () => {
+  test('should pass accessibility tests', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    await checkAccessibility({ component });
+  });
+
+  test('should display the total unhealthy count', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    await expect(component.getByTestId('unhealthy-count')).toContainText('4');
+  });
+
+  test('should display the danger icon', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+    const icon = component.locator('svg');
+    expect(await icon.count()).toBeGreaterThanOrEqual(1);
+  });
+
+  test('should render cluster names in the table', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+
+    await expect(component.getByText('cluster1')).toBeVisible();
+    await expect(component.getByText('cluster2')).toBeVisible();
+    await expect(component.getByText('cluster3')).toBeVisible();
+    await expect(component.getByText('cluster4')).toBeVisible();
+  });
+
+  test('should render issue counts in the table', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+
+    await expect(component.getByRole('cell', { name: '1' })).toBeVisible();
+    await expect(component.getByRole('cell', { name: '12' })).toBeVisible();
+    await expect(component.getByRole('cell', { name: '7' })).toBeVisible();
+    await expect(component.getByRole('cell', { name: '5' })).toBeVisible();
+  });
+
+  test('should render table headers', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+
+    await expect(component.getByRole('columnheader', { name: 'Cluster name' })).toBeVisible();
+    await expect(component.getByRole('columnheader', { name: 'Issues' })).toBeVisible();
+  });
+
+  test('should render cluster names as links when onClusterClick is provided', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <ClustersWithIssues data={defaultData} onClusterClick={() => {}} />
+    );
+
+    await expect(component.getByTestId('cluster-link-c1')).toBeVisible();
+    await expect(component.getByTestId('cluster-link-c2')).toBeVisible();
+  });
+
+  test('should call onClusterClick when a cluster name is clicked', async ({ mount }) => {
+    let clickedCluster: { id: string; name: string } | null = null;
+    const handleClick = (cluster: { id: string; name: string }) => {
+      clickedCluster = cluster;
+    };
+
+    const component = await mount(
+      <ClustersWithIssues data={defaultData} onClusterClick={handleClick} />
+    );
+
+    await component.getByTestId('cluster-link-c1').click();
+    expect(clickedCluster).not.toBeNull();
+    expect(clickedCluster!.id).toBe('c1');
+    expect(clickedCluster!.name).toBe('cluster1');
+  });
+
+  test('should render cluster names as plain text when onClusterClick is not provided', async ({
+    mount,
+  }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+
+    await expect(component.getByText('cluster1')).toBeVisible();
+    await expect(component.locator('a')).toHaveCount(0);
+  });
+
+  test('should show empty state when no clusters', async ({ mount }) => {
+    const component = await mount(
+      <ClustersWithIssues data={{ totalUnhealthy: 0, clusters: [] }} />
+    );
+
+    await expect(component.getByTestId('unhealthy-count')).toContainText('0');
+    await expect(component.getByText('No clusters with issues')).toBeVisible();
+  });
+
+  test('should render kebab actions when rowActions is provided', async ({ mount }) => {
+    const component = await mount(
+      <ClustersWithIssues data={defaultData} rowActions={() => [{ title: 'Open console' }]} />
+    );
+
+    const kebabs = component.getByRole('button', { name: 'Kebab toggle' });
+    expect(await kebabs.count()).toBe(defaultData.clusters.length);
+  });
+
+  test('should not render kebab column when rowActions is not provided', async ({ mount }) => {
+    const component = await mount(<ClustersWithIssues data={defaultData} />);
+
+    const kebabs = component.getByRole('button', { name: 'Kebab toggle' });
+    expect(await kebabs.count()).toBe(0);
+  });
+
+  test('should handle single cluster', async ({ mount }) => {
+    const data: ClustersWithIssuesProps['data'] = {
+      totalUnhealthy: 1,
+      clusters: [{ id: 'c1', name: 'prod-east', issues: 3 }],
+    };
+    const component = await mount(<ClustersWithIssues data={data} />);
+
+    await expect(component.getByTestId('unhealthy-count')).toContainText('1');
+    await expect(component.getByText('prod-east')).toBeVisible();
+    await expect(component.getByRole('cell', { name: '3' })).toBeVisible();
+  });
+
+  test('should handle high issue counts', async ({ mount }) => {
+    const data: ClustersWithIssuesProps['data'] = {
+      totalUnhealthy: 999,
+      clusters: [{ id: 'c1', name: 'big-cluster', issues: 500 }],
+    };
+    const component = await mount(<ClustersWithIssues data={data} />);
+
+    await expect(component.getByTestId('unhealthy-count')).toContainText('999');
+    await expect(component.getByRole('cell', { name: '500' })).toBeVisible();
+  });
+});

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.stories.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from 'storybook/test';
-import { ClustersWithIssues } from './ClustersWithIssues';
+import { ClustersWithIssues, ClusterIssue } from './ClustersWithIssues';
 
 const meta: Meta<typeof ClustersWithIssues> = {
   title: 'Components/Dashboard/ClustersWithIssues',
@@ -14,12 +14,22 @@ const meta: Meta<typeof ClustersWithIssues> = {
 export default meta;
 type Story = StoryObj<typeof ClustersWithIssues>;
 
-const sampleClusters = [
+const sampleClusters: ClusterIssue[] = [
   { id: 'c1', name: 'cluster1', issues: 1 },
   { id: 'c2', name: 'cluster2', issues: 12 },
   { id: 'c3', name: 'cluster3', issues: 7 },
   { id: 'c4', name: 'cluster4', issues: 5 },
 ];
+
+function generateClusters(count: number): ClusterIssue[] {
+  const regions = ['us-east', 'us-west', 'eu-west', 'eu-central', 'ap-south', 'ap-northeast'];
+  const envs = ['prod', 'staging', 'dev', 'test', 'perf'];
+  return Array.from({ length: count }, (_, i) => ({
+    id: `c${i + 1}`,
+    name: `${envs[i % envs.length]}-${regions[i % regions.length]}-${i + 1}`,
+    issues: Math.max(1, Math.floor(50 / (i + 1))),
+  }));
+}
 
 export const Default: Story = {
   args: {
@@ -65,6 +75,17 @@ export const SingleCluster: Story = {
     data: {
       totalUnhealthy: 1,
       clusters: [{ id: 'c1', name: 'prod-east-1', issues: 3 }],
+    },
+    onClusterClick: fn(),
+    rowActions: () => [{ title: 'Open console', onClick: fn() }],
+  },
+};
+
+export const ManyClustersPaginated: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 442,
+      clusters: generateClusters(30),
     },
     onClusterClick: fn(),
     rowActions: () => [{ title: 'Open console', onClick: fn() }],

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.stories.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { ClustersWithIssues } from './ClustersWithIssues';
+
+const meta: Meta<typeof ClustersWithIssues> = {
+  title: 'Components/Dashboard/ClustersWithIssues',
+  component: ClustersWithIssues,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ClustersWithIssues>;
+
+const sampleClusters = [
+  { id: 'c1', name: 'cluster1', issues: 1 },
+  { id: 'c2', name: 'cluster2', issues: 12 },
+  { id: 'c3', name: 'cluster3', issues: 7 },
+  { id: 'c4', name: 'cluster4', issues: 5 },
+];
+
+export const Default: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 4,
+      clusters: sampleClusters,
+    },
+  },
+};
+
+export const WithClusterClick: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 4,
+      clusters: sampleClusters,
+    },
+    onClusterClick: fn(),
+  },
+};
+
+export const WithRowActions: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 4,
+      clusters: sampleClusters,
+    },
+    onClusterClick: fn(),
+    rowActions: () => [{ title: 'Open console', onClick: fn() }],
+  },
+};
+
+export const NoClusters: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 0,
+      clusters: [],
+    },
+  },
+};
+
+export const SingleCluster: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 1,
+      clusters: [{ id: 'c1', name: 'prod-east-1', issues: 3 }],
+    },
+    onClusterClick: fn(),
+    rowActions: () => [{ title: 'Open console', onClick: fn() }],
+  },
+};
+
+export const HighIssueCounts: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 50,
+      clusters: [
+        { id: 'c1', name: 'staging-us-east', issues: 42 },
+        { id: 'c2', name: 'prod-eu-west', issues: 31 },
+        { id: 'c3', name: 'dev-ap-south', issues: 18 },
+        { id: 'c4', name: 'test-us-central', issues: 9 },
+        { id: 'c5', name: 'perf-eu-north', issues: 5 },
+      ],
+    },
+    onClusterClick: fn(),
+  },
+};

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.stories.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.stories.tsx
@@ -15,10 +15,10 @@ export default meta;
 type Story = StoryObj<typeof ClustersWithIssues>;
 
 const sampleClusters: ClusterIssue[] = [
-  { id: 'c1', name: 'cluster1', issues: 1 },
-  { id: 'c2', name: 'cluster2', issues: 12 },
-  { id: 'c3', name: 'cluster3', issues: 7 },
-  { id: 'c4', name: 'cluster4', issues: 5 },
+  { id: 'c1', name: 'cluster1', issues: 1, consoleUrl: 'https://console.example.com/c1' },
+  { id: 'c2', name: 'cluster2', issues: 12, consoleUrl: 'https://console.example.com/c2' },
+  { id: 'c3', name: 'cluster3', issues: 7, consoleUrl: 'https://console.example.com/c3' },
+  { id: 'c4', name: 'cluster4', issues: 5, consoleUrl: 'https://console.example.com/c4' },
 ];
 
 function generateClusters(count: number): ClusterIssue[] {
@@ -28,6 +28,7 @@ function generateClusters(count: number): ClusterIssue[] {
     id: `c${i + 1}`,
     name: `${envs[i % envs.length]}-${regions[i % regions.length]}-${i + 1}`,
     issues: Math.max(1, Math.floor(50 / (i + 1))),
+    consoleUrl: `https://console.example.com/c${i + 1}`,
   }));
 }
 
@@ -50,14 +51,14 @@ export const WithClusterClick: Story = {
   },
 };
 
-export const WithRowActions: Story = {
+export const WithOpenConsole: Story = {
   args: {
     data: {
       totalUnhealthy: 4,
       clusters: sampleClusters,
     },
     onClusterClick: fn(),
-    rowActions: () => [{ title: 'Open console', onClick: fn() }],
+    onOpenConsole: fn(),
   },
 };
 
@@ -74,10 +75,12 @@ export const SingleCluster: Story = {
   args: {
     data: {
       totalUnhealthy: 1,
-      clusters: [{ id: 'c1', name: 'prod-east-1', issues: 3 }],
+      clusters: [
+        { id: 'c1', name: 'prod-east-1', issues: 3, consoleUrl: 'https://console.example.com/c1' },
+      ],
     },
     onClusterClick: fn(),
-    rowActions: () => [{ title: 'Open console', onClick: fn() }],
+    onOpenConsole: fn(),
   },
 };
 
@@ -88,7 +91,7 @@ export const ManyClustersPaginated: Story = {
       clusters: generateClusters(30),
     },
     onClusterClick: fn(),
-    rowActions: () => [{ title: 'Open console', onClick: fn() }],
+    onOpenConsole: fn(),
   },
 };
 
@@ -105,5 +108,26 @@ export const HighIssueCounts: Story = {
       ],
     },
     onClusterClick: fn(),
+  },
+};
+
+export const CustomTooltip: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 4,
+      clusters: sampleClusters,
+    },
+    titleTooltip: 'Custom tooltip explaining issues criteria.',
+    onOpenConsole: fn(),
+  },
+};
+
+export const NoTooltip: Story = {
+  args: {
+    data: {
+      totalUnhealthy: 4,
+      clusters: sampleClusters,
+    },
+    titleTooltip: '',
   },
 };

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
@@ -1,8 +1,10 @@
-import { Flex, FlexItem, Icon, Bullseye } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Icon, Bullseye, Pagination, Title } from '@patternfly/react-core';
 import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './ClustersWithIssues.module.scss';
+
+const DEFAULT_PER_PAGE = 5;
 
 export type ClusterIssue = {
   /** unique cluster identifier */
@@ -27,23 +29,54 @@ export type ClustersWithIssuesProps = {
   onClusterClick?: (cluster: ClusterIssue) => void;
   /** builds the kebab actions per row; if omitted the kebab column is hidden */
   rowActions?: (cluster: ClusterIssue) => IAction[];
+  /** rows per page — defaults to 5 */
+  perPage?: number;
 };
 
 export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
   data,
   onClusterClick,
   rowActions,
+  perPage: initialPerPage = DEFAULT_PER_PAGE,
 }) => {
   const { totalUnhealthy, clusters } = data;
   const hasActions = typeof rowActions === 'function';
 
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(initialPerPage);
+
+  const startIdx = (page - 1) * perPage;
+  const visibleClusters = clusters.slice(startIdx, startIdx + perPage);
+
+  const handleSetPage = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPage: number
+  ) => {
+    setPage(newPage);
+  };
+
+  const handlePerPageSelect = (
+    _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
+    newPerPage: number,
+    newPage: number
+  ) => {
+    setPerPage(newPerPage);
+    setPage(newPage);
+  };
+
   return (
     <Flex direction={{ default: 'column' }} className={styles.container}>
       <FlexItem>
+        <Title headingLevel="h3" size="md">
+          Clusters with issues
+        </Title>
+      </FlexItem>
+
+      <FlexItem className={styles.countSection}>
         <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
           <FlexItem>
             <Icon status="danger" data-testid="unhealthy-icon">
-              <ExclamationCircleIcon />
+              <ExclamationCircleIcon aria-hidden="true" />
             </Icon>
           </FlexItem>
           <FlexItem className={styles.count} data-testid="unhealthy-count">
@@ -53,45 +86,58 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
       </FlexItem>
 
       {clusters.length > 0 ? (
-        <FlexItem className={styles.tableWrapper}>
-          <Table aria-label="Clusters with issues" variant="compact">
-            <Thead>
-              <Tr>
-                <Th>Cluster name</Th>
-                <Th>Issues</Th>
-                {hasActions && <Th screenReaderText="Actions" />}
-              </Tr>
-            </Thead>
-            <Tbody>
-              {clusters.map((cluster) => (
-                <Tr key={cluster.id}>
-                  <Td dataLabel="Cluster name">
-                    {onClusterClick ? (
-                      <button
-                        type="button"
-                        className={styles.clusterLink}
-                        data-testid={`cluster-link-${cluster.id}`}
-                        onClick={() => onClusterClick(cluster)}
-                      >
-                        {cluster.name}
-                      </button>
-                    ) : (
-                      cluster.name
-                    )}
-                  </Td>
-                  <Td dataLabel="Issues" data-testid={`issues-${cluster.id}`}>
-                    {cluster.issues}
-                  </Td>
-                  {hasActions && (
-                    <Td isActionCell>
-                      <ActionsColumn items={rowActions(cluster)} />
-                    </Td>
-                  )}
+        <>
+          <FlexItem className={styles.tableWrapper}>
+            <Table aria-label="Clusters with issues" variant="compact">
+              <Thead>
+                <Tr>
+                  <Th>Cluster name</Th>
+                  <Th>Issues</Th>
+                  {hasActions && <Th screenReaderText="Actions" />}
                 </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </FlexItem>
+              </Thead>
+              <Tbody>
+                {visibleClusters.map((cluster) => (
+                  <Tr key={cluster.id}>
+                    <Td dataLabel="Cluster name">
+                      {onClusterClick ? (
+                        <Button
+                          variant="link"
+                          isInline
+                          data-testid={`cluster-link-${cluster.id}`}
+                          onClick={() => onClusterClick(cluster)}
+                        >
+                          {cluster.name}
+                        </Button>
+                      ) : (
+                        cluster.name
+                      )}
+                    </Td>
+                    <Td dataLabel="Issues" data-testid={`issues-${cluster.id}`}>
+                      {cluster.issues}
+                    </Td>
+                    {hasActions && (
+                      <Td isActionCell>
+                        <ActionsColumn items={rowActions(cluster)} />
+                      </Td>
+                    )}
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </FlexItem>
+
+          <FlexItem className={styles.pagination}>
+            <Pagination
+              itemCount={clusters.length}
+              perPage={perPage}
+              page={page}
+              onSetPage={handleSetPage}
+              onPerPageSelect={handlePerPageSelect}
+              variant="bottom"
+            />
+          </FlexItem>
+        </>
       ) : (
         <FlexItem>
           <Bullseye className={styles.emptyState}>No clusters with issues</Bullseye>

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
@@ -1,10 +1,24 @@
-import { Button, Flex, FlexItem, Icon, Bullseye, Pagination, Title } from '@patternfly/react-core';
-import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Icon,
+  Bullseye,
+  Pagination,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import React, { useState } from 'react';
 import styles from './ClustersWithIssues.module.scss';
 
 const DEFAULT_PER_PAGE = 5;
+
+const DEFAULT_TOOLTIP =
+  'Clusters with critical alerts, failing operators, or resource usage above 95%.';
 
 export type ClusterIssue = {
   /** unique cluster identifier */
@@ -13,6 +27,8 @@ export type ClusterIssue = {
   name: string;
   /** number of detected issues */
   issues: number;
+  /** external console URL for this cluster */
+  consoleUrl?: string;
 };
 
 export type ClustersWithIssuesData = {
@@ -27,8 +43,10 @@ export type ClustersWithIssuesProps = {
   data: ClustersWithIssuesData;
   /** fired when a cluster name link is clicked */
   onClusterClick?: (cluster: ClusterIssue) => void;
-  /** builds the kebab actions per row; if omitted the kebab column is hidden */
-  rowActions?: (cluster: ClusterIssue) => IAction[];
+  /** fired when the "Open console" link is clicked for a row */
+  onOpenConsole?: (cluster: ClusterIssue) => void;
+  /** tooltip content for the info icon next to the title */
+  titleTooltip?: string;
   /** rows per page — defaults to 5 */
   perPage?: number;
 };
@@ -36,11 +54,11 @@ export type ClustersWithIssuesProps = {
 export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
   data,
   onClusterClick,
-  rowActions,
+  onOpenConsole,
+  titleTooltip = DEFAULT_TOOLTIP,
   perPage: initialPerPage = DEFAULT_PER_PAGE,
 }) => {
   const { totalUnhealthy, clusters } = data;
-  const hasActions = typeof rowActions === 'function';
 
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(Math.max(1, initialPerPage));
@@ -71,9 +89,27 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
   return (
     <Flex direction={{ default: 'column' }} className={styles.container}>
       <FlexItem>
-        <Title headingLevel="h3" size="md">
-          Clusters with issues
-        </Title>
+        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <Title headingLevel="h3" size="md">
+              Clusters with issues
+            </Title>
+          </FlexItem>
+          {titleTooltip && (
+            <FlexItem>
+              <Tooltip content={titleTooltip}>
+                <Button
+                  variant="plain"
+                  isInline
+                  aria-label="More info about clusters with issues"
+                  data-testid="title-tooltip-icon"
+                >
+                  <OutlinedQuestionCircleIcon aria-hidden="true" />
+                </Button>
+              </Tooltip>
+            </FlexItem>
+          )}
+        </Flex>
       </FlexItem>
 
       <FlexItem className={styles.countSection}>
@@ -97,7 +133,7 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
                 <Tr>
                   <Th>Cluster name</Th>
                   <Th>Issues</Th>
-                  {hasActions && <Th screenReaderText="Actions" />}
+                  {onOpenConsole && <Th screenReaderText="Console" />}
                 </Tr>
               </Thead>
               <Tbody>
@@ -120,9 +156,17 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
                     <Td dataLabel="Issues" data-testid={`issues-${cluster.id}`}>
                       {cluster.issues}
                     </Td>
-                    {hasActions && (
-                      <Td isActionCell>
-                        <ActionsColumn items={rowActions(cluster)} />
+                    {onOpenConsole && (
+                      <Td dataLabel="Console" data-testid={`open-console-${cluster.id}`}>
+                        <Button
+                          variant="link"
+                          isInline
+                          icon={<ExternalLinkAltIcon />}
+                          iconPosition="end"
+                          onClick={() => onOpenConsole(cluster)}
+                        >
+                          Open console
+                        </Button>
                       </Td>
                     )}
                   </Tr>

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
@@ -42,7 +42,7 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
       <FlexItem>
         <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
           <FlexItem>
-            <Icon status="danger">
+            <Icon status="danger" data-testid="unhealthy-icon">
               <ExclamationCircleIcon />
             </Icon>
           </FlexItem>
@@ -79,7 +79,9 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
                       cluster.name
                     )}
                   </Td>
-                  <Td dataLabel="Issues">{cluster.issues}</Td>
+                  <Td dataLabel="Issues" data-testid={`issues-${cluster.id}`}>
+                    {cluster.issues}
+                  </Td>
                   {hasActions && (
                     <Td isActionCell>
                       <ActionsColumn items={rowActions(cluster)} />

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
@@ -43,9 +43,13 @@ export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
   const hasActions = typeof rowActions === 'function';
 
   const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(initialPerPage);
+  const [perPage, setPerPage] = useState(Math.max(1, initialPerPage));
 
-  const startIdx = (page - 1) * perPage;
+  const lastPage = Math.max(1, Math.ceil(clusters.length / perPage));
+  const clampedPage = Math.min(page, lastPage);
+  if (clampedPage !== page) setPage(clampedPage);
+
+  const startIdx = (clampedPage - 1) * perPage;
   const visibleClusters = clusters.slice(startIdx, startIdx + perPage);
 
   const handleSetPage = (

--- a/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
+++ b/src/components/dashboard/ClustersWithIssues/ClustersWithIssues.tsx
@@ -1,0 +1,100 @@
+import { Flex, FlexItem, Icon, Bullseye } from '@patternfly/react-core';
+import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import React from 'react';
+import styles from './ClustersWithIssues.module.scss';
+
+export type ClusterIssue = {
+  /** unique cluster identifier */
+  id: string;
+  /** display name of the cluster */
+  name: string;
+  /** number of detected issues */
+  issues: number;
+};
+
+export type ClustersWithIssuesData = {
+  /** total number of unhealthy clusters */
+  totalUnhealthy: number;
+  /** list of clusters with their issue counts */
+  clusters: ClusterIssue[];
+};
+
+export type ClustersWithIssuesProps = {
+  /** cluster issues data */
+  data: ClustersWithIssuesData;
+  /** fired when a cluster name link is clicked */
+  onClusterClick?: (cluster: ClusterIssue) => void;
+  /** builds the kebab actions per row; if omitted the kebab column is hidden */
+  rowActions?: (cluster: ClusterIssue) => IAction[];
+};
+
+export const ClustersWithIssues: React.FC<ClustersWithIssuesProps> = ({
+  data,
+  onClusterClick,
+  rowActions,
+}) => {
+  const { totalUnhealthy, clusters } = data;
+  const hasActions = typeof rowActions === 'function';
+
+  return (
+    <Flex direction={{ default: 'column' }} className={styles.container}>
+      <FlexItem>
+        <Flex alignItems={{ default: 'alignItemsCenter' }} spaceItems={{ default: 'spaceItemsSm' }}>
+          <FlexItem>
+            <Icon status="danger">
+              <ExclamationCircleIcon />
+            </Icon>
+          </FlexItem>
+          <FlexItem className={styles.count} data-testid="unhealthy-count">
+            {totalUnhealthy}
+          </FlexItem>
+        </Flex>
+      </FlexItem>
+
+      {clusters.length > 0 ? (
+        <FlexItem className={styles.tableWrapper}>
+          <Table aria-label="Clusters with issues" variant="compact">
+            <Thead>
+              <Tr>
+                <Th>Cluster name</Th>
+                <Th>Issues</Th>
+                {hasActions && <Th screenReaderText="Actions" />}
+              </Tr>
+            </Thead>
+            <Tbody>
+              {clusters.map((cluster) => (
+                <Tr key={cluster.id}>
+                  <Td dataLabel="Cluster name">
+                    {onClusterClick ? (
+                      <button
+                        type="button"
+                        className={styles.clusterLink}
+                        data-testid={`cluster-link-${cluster.id}`}
+                        onClick={() => onClusterClick(cluster)}
+                      >
+                        {cluster.name}
+                      </button>
+                    ) : (
+                      cluster.name
+                    )}
+                  </Td>
+                  <Td dataLabel="Issues">{cluster.issues}</Td>
+                  {hasActions && (
+                    <Td isActionCell>
+                      <ActionsColumn items={rowActions(cluster)} />
+                    </Td>
+                  )}
+                </Tr>
+              ))}
+            </Tbody>
+          </Table>
+        </FlexItem>
+      ) : (
+        <FlexItem>
+          <Bullseye className={styles.emptyState}>No clusters with issues</Bullseye>
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};

--- a/src/components/dashboard/ClustersWithIssues/index.ts
+++ b/src/components/dashboard/ClustersWithIssues/index.ts
@@ -1,0 +1,6 @@
+export { ClustersWithIssues } from './ClustersWithIssues';
+export type {
+  ClustersWithIssuesProps,
+  ClustersWithIssuesData,
+  ClusterIssue,
+} from './ClustersWithIssues';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,3 +20,4 @@ export * from './dashboard/UpdateStatus';
 export * from './dashboard/ExpiredTrials';
 export * from './dashboard/ResourceUtilization';
 export * from './dashboard/AdvisorRecommendations';
+export * from './dashboard/ClustersWithIssues';


### PR DESCRIPTION
## Description

New shared `ClustersWithIssues` dashboard widget component for the OCM dashboard. Shows total unhealthy cluster count with danger icon, a tooltip explaining what "issues" means, and a compact table of clusters with their issue counts. Each row has an optional "Open console" link with an external-link icon instead of a kebab menu.

Supports optional cluster name click callback, optional console link callback, customizable tooltip text, and empty state.

Mockups

**Jira issue #** FCN-261

**Backport of** #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):

## Testing

### Manual Testing

**Test Steps:**

1. Run Storybook (`npm run storybook`)
2. Navigate to Components → Dashboard → ClustersWithIssues
3. Verify all story variants render correctly (Default, WithClusterClick, WithOpenConsole, NoClusters, SingleCluster, ManyClustersPaginated, HighIssueCounts, CustomTooltip, NoTooltip)

**Test Environment:**

- Tested locally
- Tested in Storybook

### Automated Testing

**E2E Run:**

- Cypress Tests: N/A
- Playwright Tests: Component tests pass (27/27)

**Unit Tests:**

- [x] Unit tests added/updated
- [x] All unit tests pass

**Integration Tests:**

- Integration tests added/updated
- All integration tests pass

## Screenshots/Recordings

### Default — plain table with 4 clusters, count badge, tooltip icon
Default story showing title with question-circle tooltip, count with danger icon, and plain cluster names.
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/d370e54f-a386-4d80-8a0c-ea798dacacf5" />


### With Open Console - external link per row
Each row shows an "Open console" link with the external-link icon instead of a kebab menu.
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/585647ed-b3bf-4ec3-a982-c2f4f1aba0e7" />


### Empty state
Shows "No clusters with issues" when the cluster list is empty.
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/02ad4873-dfba-405f-b3e3-1fb8493b3828" />


### Clusters with issues tooltip
<img width="1459" height="802" alt="image" src="https://github.com/user-attachments/assets/ca4b7d46-bba5-4dff-a700-a84219af0a7b" />


## Checklist

### Code Quality

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation

- [x] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility

- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies

- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed

## Breaking Changes

**Does this PR introduce breaking changes?**

- [ ] Yes
- [x] No

## Additional Notes

Follows the same component pattern as TotalClusters, Telemetry, and UpdateStatus widgets. Updated per Margot's review feedback: replaced kebab menu with "Open console" external link per row, added question-circle tooltip icon next to the title.

## Reviewer Guidelines

### Focus Areas

- Props API design for the shared widget (`onOpenConsole`, `titleTooltip`)
- Table accessibility
- Tooltip content wording

### Questions for Reviewers