### PR TITLE
FCN-263 Add Expired Trials dashboard widget component

### DIFF
--- a/src/components/dashboard/ExpiredTrials/ExpiredTrials.module.scss
+++ b/src/components/dashboard/ExpiredTrials/ExpiredTrials.module.scss
@@ -1,0 +1,39 @@
+.container {
+  padding: var(--pf-t--global--spacer--md);
+  height: 100%;
+}
+
+.tableWrapper {
+  flex-grow: 1;
+}
+
+.trialLink {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: var(--pf-t--global--text--color--link--default);
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid currentcolor;
+    outline-offset: 2px;
+    text-decoration: underline;
+  }
+}
+
+.pagination {
+  padding-top: var(--pf-t--global--spacer--sm);
+}
+
+.emptyState {
+  padding: var(--pf-t--global--spacer--xl) 0;
+  color: var(--pf-t--global--text--color--subtle);
+  font-size: var(--pf-t--global--font--size--sm);
+  text-align: center;
+}

--- a/src/components/dashboard/ExpiredTrials/ExpiredTrials.spec-helpers.tsx
+++ b/src/components/dashboard/ExpiredTrials/ExpiredTrials.spec-helpers.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ExpiredTrials, ExpiredTrialsProps } from './ExpiredTrials';
+
+// playwright CT can't serialize functions that return data across process
+// boundaries, so this wrapper defines rowActions in the browser context
+export const ExpiredTrialsWithActions: React.FC<{
+  data: ExpiredTrialsProps['data'];
+}> = ({ data }) => (
+  <ExpiredTrials
+    data={data}
+    rowActions={() => [{ title: 'Edit subscription' }, { title: 'Archive cluster' }]}
+  />
+);

--- a/src/components/dashboard/ExpiredTrials/ExpiredTrials.spec.tsx
+++ b/src/components/dashboard/ExpiredTrials/ExpiredTrials.spec.tsx
@@ -1,0 +1,147 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { ExpiredTrials, ExpiredTrialsProps } from './ExpiredTrials';
+import { ExpiredTrialsWithActions } from './ExpiredTrials.spec-helpers';
+import { checkAccessibility } from '../../../test-helpers';
+
+const defaultData: ExpiredTrialsProps['data'] = {
+  trials: [
+    { id: 's1', name: 'f4aaa179-54be-4c3e-a523-f344e76e182c' },
+    { id: 's2', name: 'test' },
+    { id: 's3', name: 'ss' },
+  ],
+  totalCount: 3,
+  currentPage: 1,
+  pageSize: 10,
+};
+
+test.describe('ExpiredTrials', () => {
+  test('should pass accessibility tests', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} />);
+    await checkAccessibility({ component });
+  });
+
+  test('should render cluster names in the table', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} />);
+
+    await expect(component.getByText('f4aaa179-54be-4c3e-a523-f344e76e182c')).toBeVisible();
+    await expect(component.getByText('test')).toBeVisible();
+    await expect(component.getByText('ss')).toBeVisible();
+  });
+
+  test('should render table header as Cluster name', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} />);
+    await expect(component.getByRole('columnheader', { name: 'Cluster name' })).toBeVisible();
+  });
+
+  test('should render names as links when onTrialClick is provided', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} onTrialClick={() => {}} />);
+
+    await expect(component.getByTestId('trial-link-s1')).toBeVisible();
+    await expect(component.getByTestId('trial-link-s2')).toBeVisible();
+    await expect(component.getByTestId('trial-link-s3')).toBeVisible();
+  });
+
+  test('should call onTrialClick when a cluster name is clicked', async ({ mount }) => {
+    let clickedTrial: { id: string; name: string } | null = null;
+    const handleClick = (trial: { id: string; name: string }) => {
+      clickedTrial = trial;
+    };
+
+    const component = await mount(<ExpiredTrials data={defaultData} onTrialClick={handleClick} />);
+
+    await component.getByTestId('trial-link-s2').click();
+    expect(clickedTrial).not.toBeNull();
+    expect(clickedTrial!.id).toBe('s2');
+    expect(clickedTrial!.name).toBe('test');
+  });
+
+  test('should render names as plain text when onTrialClick is not provided', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} />);
+
+    await expect(component.getByText('test')).toBeVisible();
+    const trialButtons = component.locator('[data-testid^="trial-link-"]');
+    expect(await trialButtons.count()).toBe(0);
+  });
+
+  test('should show empty state when no trials', async ({ mount }) => {
+    const component = await mount(
+      <ExpiredTrials data={{ trials: [], totalCount: 0, currentPage: 1, pageSize: 10 }} />
+    );
+
+    await expect(component.getByTestId('empty-state')).toContainText('No expired trials');
+  });
+
+  test('should render kebab actions when rowActions is provided', async ({ mount }) => {
+    const component = await mount(<ExpiredTrialsWithActions data={defaultData} />);
+
+    const kebabs = component.locator('[aria-label="Kebab toggle"]');
+    expect(await kebabs.count()).toBe(defaultData.trials.length);
+  });
+
+  test('should not render kebab column when rowActions is not provided', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} />);
+
+    const kebabs = component.locator('[aria-label="Kebab toggle"]');
+    expect(await kebabs.count()).toBe(0);
+  });
+
+  test('should render pagination when onPageChange is provided', async ({ mount }) => {
+    const component = await mount(
+      <ExpiredTrials data={{ ...defaultData, totalCount: 25 }} onPageChange={() => {}} />
+    );
+
+    await expect(component.locator('.pf-v6-c-pagination')).toBeVisible();
+  });
+
+  test('should not render pagination when onPageChange is not provided', async ({ mount }) => {
+    const component = await mount(<ExpiredTrials data={defaultData} />);
+
+    expect(await component.locator('.pf-v6-c-pagination').count()).toBe(0);
+  });
+
+  test('should call onPageChange when next page is clicked', async ({ mount }) => {
+    let changedPage: number | null = null;
+    const component = await mount(
+      <ExpiredTrials
+        data={{ ...defaultData, totalCount: 25 }}
+        onPageChange={(page) => {
+          changedPage = page;
+        }}
+      />
+    );
+
+    await component.getByRole('button', { name: 'Go to next page' }).click();
+    expect(changedPage).toBe(2);
+  });
+
+  test('should call onPageSizeChange when per-page is changed', async ({ mount, page }) => {
+    let changedSize: number | null = null;
+    const component = await mount(
+      <ExpiredTrials
+        data={{ ...defaultData, totalCount: 25 }}
+        onPageChange={() => {}}
+        onPageSizeChange={(size) => {
+          changedSize = size;
+        }}
+      />
+    );
+
+    // pf6 portals the dropdown menu to document body, so query via page
+    await component.locator('.pf-v6-c-pagination .pf-v6-c-menu-toggle').click();
+    await page.getByRole('menuitem', { name: /20 per page/i }).click();
+    expect(changedSize).toBe(20);
+  });
+
+  test('should handle single trial', async ({ mount }) => {
+    const data: ExpiredTrialsProps['data'] = {
+      trials: [{ id: 's1', name: 'my-expired-cluster' }],
+      totalCount: 1,
+      currentPage: 1,
+      pageSize: 10,
+    };
+    const component = await mount(<ExpiredTrials data={data} onTrialClick={() => {}} />);
+
+    await expect(component.getByTestId('trial-link-s1')).toContainText('my-expired-cluster');
+  });
+});

--- a/src/components/dashboard/ExpiredTrials/ExpiredTrials.stories.tsx
+++ b/src/components/dashboard/ExpiredTrials/ExpiredTrials.stories.tsx
@@ -1,0 +1,102 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
+import { ExpiredTrials } from './ExpiredTrials';
+
+const meta: Meta<typeof ExpiredTrials> = {
+  title: 'Components/Dashboard/ExpiredTrials',
+  component: ExpiredTrials,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ExpiredTrials>;
+
+const sampleTrials = [
+  { id: 's1', name: 'f4aaa179-54be-4c3e-a523-f344e76e182c' },
+  { id: 's2', name: 'test' },
+  { id: 's3', name: 'ss' },
+];
+
+export const Default: Story = {
+  args: {
+    data: {
+      trials: sampleTrials,
+      totalCount: 3,
+      currentPage: 1,
+      pageSize: 10,
+    },
+  },
+};
+
+export const WithClusterClick: Story = {
+  args: {
+    data: {
+      trials: sampleTrials,
+      totalCount: 3,
+      currentPage: 1,
+      pageSize: 10,
+    },
+    onTrialClick: fn(),
+  },
+};
+
+export const WithRowActions: Story = {
+  args: {
+    data: {
+      trials: sampleTrials,
+      totalCount: 3,
+      currentPage: 1,
+      pageSize: 10,
+    },
+    onTrialClick: fn(),
+    rowActions: () => [
+      { title: 'Edit subscription', onClick: fn() },
+      { title: 'Archive cluster', onClick: fn() },
+    ],
+  },
+};
+
+export const WithPagination: Story = {
+  args: {
+    data: {
+      trials: sampleTrials,
+      totalCount: 25,
+      currentPage: 1,
+      pageSize: 10,
+    },
+    onTrialClick: fn(),
+    onPageChange: fn(),
+    onPageSizeChange: fn(),
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    data: {
+      trials: [],
+      totalCount: 0,
+      currentPage: 1,
+      pageSize: 10,
+    },
+  },
+};
+
+export const SingleTrial: Story = {
+  args: {
+    data: {
+      trials: [{ id: 's1', name: 'my-expired-cluster' }],
+      totalCount: 1,
+      currentPage: 1,
+      pageSize: 10,
+    },
+    onTrialClick: fn(),
+    rowActions: () => [
+      { title: 'Edit subscription', onClick: fn() },
+      { title: 'Archive cluster', onClick: fn() },
+    ],
+    onPageChange: fn(),
+  },
+};

--- a/src/components/dashboard/ExpiredTrials/ExpiredTrials.tsx
+++ b/src/components/dashboard/ExpiredTrials/ExpiredTrials.tsx
@@ -1,0 +1,110 @@
+import { Flex, FlexItem, Pagination, PaginationVariant } from '@patternfly/react-core';
+import { ActionsColumn, IAction, Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import React from 'react';
+import styles from './ExpiredTrials.module.scss';
+
+export type ExpiredTrial = {
+  /** unique subscription / cluster identifier */
+  id: string;
+  /** cluster display name */
+  name: string;
+};
+
+export type ExpiredTrialsData = {
+  /** paginated list of expired trial clusters */
+  trials: ExpiredTrial[];
+  /** total count across all pages */
+  totalCount: number;
+  /** current page (1-based) */
+  currentPage: number;
+  /** items per page */
+  pageSize: number;
+};
+
+export type ExpiredTrialsProps = {
+  /** expired trials data */
+  data: ExpiredTrialsData;
+  /** fired when a cluster name is clicked */
+  onTrialClick?: (trial: ExpiredTrial) => void;
+  /** fired when the user changes page */
+  onPageChange?: (page: number) => void;
+  /** fired when the user changes page size */
+  onPageSizeChange?: (size: number) => void;
+  /** builds the kebab actions per row; if omitted the kebab column is hidden */
+  rowActions?: (trial: ExpiredTrial) => IAction[];
+};
+
+export const ExpiredTrials: React.FC<ExpiredTrialsProps> = ({
+  data,
+  onTrialClick,
+  onPageChange,
+  onPageSizeChange,
+  rowActions,
+}) => {
+  const { trials, totalCount, currentPage, pageSize } = data;
+  const hasActions = typeof rowActions === 'function';
+  const hasPagination =
+    typeof onPageChange === 'function' || typeof onPageSizeChange === 'function';
+
+  return (
+    <Flex direction={{ default: 'column' }} className={styles.container}>
+      {trials.length > 0 ? (
+        <>
+          <FlexItem className={styles.tableWrapper}>
+            <Table aria-label="Expired trials" variant="compact">
+              <Thead>
+                <Tr>
+                  <Th>Cluster name</Th>
+                  {hasActions && <Th screenReaderText="Actions" />}
+                </Tr>
+              </Thead>
+              <Tbody>
+                {trials.map((trial) => (
+                  <Tr key={trial.id}>
+                    <Td dataLabel="Cluster name">
+                      {onTrialClick ? (
+                        <button
+                          type="button"
+                          className={styles.trialLink}
+                          data-testid={`trial-link-${trial.id}`}
+                          onClick={() => onTrialClick(trial)}
+                        >
+                          {trial.name}
+                        </button>
+                      ) : (
+                        trial.name
+                      )}
+                    </Td>
+                    {hasActions && (
+                      <Td isActionCell>
+                        <ActionsColumn items={rowActions(trial)} />
+                      </Td>
+                    )}
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </FlexItem>
+
+          {hasPagination && (
+            <FlexItem className={styles.pagination}>
+              <Pagination
+                itemCount={totalCount}
+                perPage={pageSize}
+                page={currentPage}
+                variant={PaginationVariant.bottom}
+                onSetPage={(_e, page) => onPageChange?.(page)}
+                onPerPageSelect={(_e, size) => onPageSizeChange?.(size)}
+                isCompact
+              />
+            </FlexItem>
+          )}
+        </>
+      ) : (
+        <FlexItem className={styles.emptyState} data-testid="empty-state">
+          No expired trials
+        </FlexItem>
+      )}
+    </Flex>
+  );
+};

--- a/src/components/dashboard/ExpiredTrials/index.ts
+++ b/src/components/dashboard/ExpiredTrials/index.ts
@@ -1,0 +1,2 @@
+export { ExpiredTrials } from './ExpiredTrials';
+export type { ExpiredTrialsProps, ExpiredTrialsData, ExpiredTrial } from './ExpiredTrials';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -17,3 +17,4 @@ export * from './dashboard/LoadingPanel';
 export * from './dashboard/TotalClusters';
 export * from './dashboard/Telemetry';
 export * from './dashboard/UpdateStatus';
+export * from './dashboard/ExpiredTrials';


### PR DESCRIPTION
## Description

Add the Expired Trials shared dashboard widget for the OCM dashboard. Shows clusters whose trial subscriptions have expired (`support_level='None'`), with a single "Cluster name" column (per UXD feedback from Margot confirming the table shows cluster names, not trial names).

**Jira issue #** [FCN-263](https://redhat.atlassian.net/browse/FCN-263)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Run `npm run storybook`
2. Navigate to Components > Dashboard > ExpiredTrials
3. Verify Default, WithClusterClick, WithRowActions, WithPagination, Empty, and SingleTrial stories

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)

- [x] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      14 component tests passing

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

### Default
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/6fbefe5e-2797-4216-be38-1f9ebec0446a" />

### WithRowActions
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/21166cd4-61dc-4af1-a29b-38445f12c72b" />

### WithPagination
<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/d803b25c-adc7-4bd3-9cce-6e9a9316d243" />

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

Component props:
- `data` — `ExpiredTrialsData` with `trials[]`, `totalCount`, `currentPage`, `pageSize`
- `onTrialClick` — optional callback when a cluster name is clicked
- `onPageChange` / `onPageSizeChange` — optional pagination callbacks
- `rowActions` — optional per-row kebab actions (e.g. "Edit subscription", "Archive cluster")

The widget card title ("Expired Trials") comes from the dashboard layout wrapper, not from this component — same pattern as TotalClusters, Telemetry, etc.

## Reviewer Guidelines

### Focus Areas
- Prop API design — does `ExpiredTrialsData` make sense for consumers?
- Pagination callback split (`onPageChange` + `onPageSizeChange`) vs single callback

### Questions for Reviewers
- Column header is "Cluster name" per Margot's UXD feedback — waiting on her final confirmation on the rename suggestion

---
<!-- Thank you for contributing to nxtcm-components! -->

[FCN-263]: https://redhat.atlassian.net/browse/FCN-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ