### PR TITLE
FCN-262 Add Resource Utilization dashboard widget component

### DIFF
--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.module.scss
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.module.scss
@@ -1,0 +1,36 @@
+.container {
+  padding: var(--pf-t--global--spacer--md);
+  height: 100%;
+}
+
+.chartsRow {
+  padding-bottom: var(--pf-t--global--spacer--sm);
+}
+
+.metricColumn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 180px;
+}
+
+.metricTitle {
+  text-align: center;
+  margin-bottom: var(--pf-t--global--spacer--xs);
+  color: var(--pf-t--global--text--color--regular);
+}
+
+.chartWrapper {
+  width: 200px;
+  height: 200px;
+}
+
+.viewLink {
+  padding-top: var(--pf-t--global--spacer--md);
+}
+
+.viewMoreBtn:focus-visible {
+  outline: 2px solid var(--pf-t--global--color--brand--default);
+  outline-offset: 2px;
+  border-radius: var(--pf-t--global--border--radius--sm);
+}

--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.spec.tsx
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.spec.tsx
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import React from 'react';
+import { ResourceUtilization, ResourceUtilizationData } from './ResourceUtilization';
+
+const defaultData: ResourceUtilizationData = {
+  vCPU: { used: 32, total: 128, unit: 'Cores' },
+  memory: { used: 48, total: 256, unit: 'GiB' },
+};
+
+test.describe('ResourceUtilization', () => {
+  test('should render vCPU metric section', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    await expect(component.getByTestId('metric-vcpu-donut')).toBeVisible();
+  });
+
+  test('should render Memory metric section', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    await expect(component.getByTestId('metric-memory-donut')).toBeVisible();
+  });
+
+  test('should display vCPU title', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection.getByRole('heading', { name: 'vCPU' })).toBeVisible();
+  });
+
+  test('should display Memory title', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    const memorySection = component.getByTestId('metric-memory-donut');
+    await expect(memorySection.getByRole('heading', { name: 'Memory' })).toBeVisible();
+  });
+
+  test('should calculate and display vCPU percentage (25%)', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection).toContainText('25%');
+  });
+
+  test('should calculate and display Memory percentage (19%)', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    const memorySection = component.getByTestId('metric-memory-donut');
+    await expect(memorySection).toContainText('19%');
+  });
+
+  test('should display vCPU subtitle with total and unit', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection).toContainText('of 128 Cores');
+  });
+
+  test('should display Memory subtitle with total and unit', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    const memorySection = component.getByTestId('metric-memory-donut');
+    await expect(memorySection).toContainText('of 256 GiB');
+  });
+
+  test('should not render Storage when not provided', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    await expect(component.getByTestId('metric-storage-donut')).not.toBeVisible();
+  });
+
+  test('should render Storage when provided', async ({ mount }) => {
+    const dataWithStorage: ResourceUtilizationData = {
+      ...defaultData,
+      storage: { used: 500, total: 2048, unit: 'GiB' },
+    };
+    const component = await mount(<ResourceUtilization data={dataWithStorage} />);
+    await expect(component.getByTestId('metric-storage-donut')).toBeVisible();
+    const storageSection = component.getByTestId('metric-storage-donut');
+    await expect(storageSection.getByRole('heading', { name: 'Storage' })).toBeVisible();
+    await expect(storageSection).toContainText('24%');
+    await expect(storageSection).toContainText('of 2,048 GiB');
+  });
+
+  test('should show View more button when onViewMore is provided', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} onViewMore={() => {}} />);
+    await expect(component.getByRole('button', { name: /View more/i })).toBeVisible();
+  });
+
+  test('should not show View more button when onViewMore is omitted', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    await expect(component.getByRole('button', { name: /View more/i })).not.toBeVisible();
+  });
+
+  test('should call onViewMore when button is clicked', async ({ mount }) => {
+    let clicked = false;
+    const component = await mount(
+      <ResourceUtilization
+        data={defaultData}
+        onViewMore={() => {
+          clicked = true;
+        }}
+      />
+    );
+    await component.getByRole('button', { name: /View more/i }).click();
+    expect(clicked).toBe(true);
+  });
+
+  test('should handle zero usage gracefully', async ({ mount }) => {
+    const zeroData: ResourceUtilizationData = {
+      vCPU: { used: 0, total: 128, unit: 'Cores' },
+      memory: { used: 0, total: 256, unit: 'GiB' },
+    };
+    const component = await mount(<ResourceUtilization data={zeroData} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection).toContainText('0%');
+    const memorySection = component.getByTestId('metric-memory-donut');
+    await expect(memorySection).toContainText('0%');
+  });
+
+  test('should handle high utilization values', async ({ mount }) => {
+    const highData: ResourceUtilizationData = {
+      vCPU: { used: 126, total: 128, unit: 'Cores' },
+      memory: { used: 250, total: 256, unit: 'GiB' },
+    };
+    const component = await mount(<ResourceUtilization data={highData} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection).toContainText('98%');
+    const memorySection = component.getByTestId('metric-memory-donut');
+    await expect(memorySection).toContainText('98%');
+  });
+
+  test('should handle zero total without crashing', async ({ mount }) => {
+    const zeroTotal: ResourceUtilizationData = {
+      vCPU: { used: 0, total: 0, unit: 'Cores' },
+      memory: { used: 0, total: 0, unit: 'GiB' },
+    };
+    const component = await mount(<ResourceUtilization data={zeroTotal} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection).toContainText('0%');
+  });
+
+  test('should format large total values with locale string', async ({ mount }) => {
+    const largeData: ResourceUtilizationData = {
+      vCPU: { used: 500, total: 10000, unit: 'Cores' },
+      memory: { used: 2048, total: 8192, unit: 'GiB' },
+    };
+    const component = await mount(<ResourceUtilization data={largeData} />);
+    const vcpuSection = component.getByTestId('metric-vcpu-donut');
+    await expect(vcpuSection).toContainText('10,000');
+  });
+});

--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.stories.tsx
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ResourceUtilization } from './ResourceUtilization';
+
+const meta: Meta<typeof ResourceUtilization> = {
+  title: 'Components/Dashboard/ResourceUtilization',
+  component: ResourceUtilization,
+};
+
+export default meta;
+type Story = StoryObj<typeof ResourceUtilization>;
+
+export const Default: Story = {
+  args: {
+    data: {
+      vCPU: { used: 32, total: 128, unit: 'Cores' },
+      memory: { used: 48, total: 256, unit: 'GiB' },
+    },
+    onViewMore: () => alert('View more clicked'),
+  },
+};
+
+export const WithStorage: Story = {
+  args: {
+    data: {
+      vCPU: { used: 32, total: 128, unit: 'Cores' },
+      memory: { used: 48, total: 256, unit: 'GiB' },
+      storage: { used: 500, total: 2048, unit: 'GiB' },
+    },
+    onViewMore: () => alert('View more clicked'),
+  },
+};
+
+export const WithoutViewMore: Story = {
+  args: {
+    data: {
+      vCPU: { used: 64, total: 128, unit: 'Cores' },
+      memory: { used: 200, total: 256, unit: 'GiB' },
+    },
+  },
+};
+
+export const HighUtilization: Story = {
+  args: {
+    data: {
+      vCPU: { used: 120, total: 128, unit: 'Cores' },
+      memory: { used: 240, total: 256, unit: 'GiB' },
+    },
+    onViewMore: () => alert('View more clicked'),
+  },
+};
+
+export const LowUtilization: Story = {
+  args: {
+    data: {
+      vCPU: { used: 2, total: 128, unit: 'Cores' },
+      memory: { used: 4, total: 256, unit: 'GiB' },
+    },
+    onViewMore: () => alert('View more clicked'),
+  },
+};
+
+export const ZeroUsage: Story = {
+  args: {
+    data: {
+      vCPU: { used: 0, total: 128, unit: 'Cores' },
+      memory: { used: 0, total: 256, unit: 'GiB' },
+    },
+  },
+};
+
+export const MockupValues: Story = {
+  args: {
+    data: {
+      vCPU: { used: 32, total: 128, unit: 'Cores' },
+      memory: { used: 64, total: 256, unit: 'GiB' },
+    },
+    onViewMore: () => alert('View more clicked'),
+  },
+};

--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.tsx
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.tsx
@@ -1,0 +1,110 @@
+import { Button, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
+import React from 'react';
+import styles from './ResourceUtilization.module.scss';
+
+export type ResourceMetric = {
+  /** amount currently in use */
+  used: number;
+  /** total available capacity */
+  total: number;
+  /** display unit (e.g. "Cores", "GiB", "TiB") */
+  unit: string;
+};
+
+export type ResourceUtilizationData = {
+  /** vcpu utilization */
+  vCPU: ResourceMetric;
+  /** memory utilization */
+  memory: ResourceMetric;
+  /** storage utilization (optional — API source TBD) */
+  storage?: ResourceMetric;
+};
+
+export type ResourceUtilizationProps = {
+  /** resource utilization metrics */
+  data: ResourceUtilizationData;
+  /** callback when "View more" is clicked; omit to hide the link */
+  onViewMore?: () => void;
+};
+
+const formatValue = (value: number): string => {
+  if (Number.isInteger(value)) return value.toLocaleString();
+  return value.toFixed(1);
+};
+
+const calcPercentage = (used: number, total: number): number => {
+  if (total <= 0) return 0;
+  return Math.round((used / total) * 100);
+};
+
+type MetricChartProps = {
+  label: string;
+  metric: ResourceMetric;
+  chartId: string;
+};
+
+const MetricChart: React.FC<MetricChartProps> = ({ label, metric, chartId }) => {
+  const { used, total, unit } = metric;
+  const pct = calcPercentage(used, total);
+
+  return (
+    <div className={styles.metricColumn} data-testid={`metric-${chartId}`}>
+      <Title headingLevel="h4" size="md" className={styles.metricTitle}>
+        {label}
+      </Title>
+      <div className={styles.chartWrapper}>
+        <ChartDonutUtilization
+          ariaDesc={`${label} utilization`}
+          ariaTitle={`${label} utilization chart`}
+          constrainToVisibleArea
+          data={{ x: `${label} capacity`, y: pct }}
+          height={200}
+          subTitle={`of ${formatValue(total)} ${unit}`}
+          title={`${pct}%`}
+          width={200}
+          padding={{ top: 20, bottom: 20, left: 20, right: 20 }}
+          name={chartId}
+        />
+      </div>
+    </div>
+  );
+};
+
+export const ResourceUtilization: React.FC<ResourceUtilizationProps> = ({ data, onViewMore }) => {
+  const { vCPU, memory, storage } = data;
+
+  return (
+    <Flex direction={{ default: 'column' }} className={styles.container}>
+      <FlexItem>
+        <Flex
+          justifyContent={{ default: 'justifyContentSpaceEvenly' }}
+          alignItems={{ default: 'alignItemsFlexStart' }}
+          className={styles.chartsRow}
+        >
+          <FlexItem>
+            <MetricChart label="vCPU" metric={vCPU} chartId="vcpu-donut" />
+          </FlexItem>
+          <FlexItem>
+            <MetricChart label="Memory" metric={memory} chartId="memory-donut" />
+          </FlexItem>
+          {storage && (
+            <FlexItem>
+              <MetricChart label="Storage" metric={storage} chartId="storage-donut" />
+            </FlexItem>
+          )}
+        </Flex>
+      </FlexItem>
+
+      {onViewMore && (
+        <Flex justifyContent={{ default: 'justifyContentFlexEnd' }} className={styles.viewLink}>
+          <FlexItem>
+            <Button variant="link" onClick={onViewMore} className={styles.viewMoreBtn}>
+              View more
+            </Button>
+          </FlexItem>
+        </Flex>
+      )}
+    </Flex>
+  );
+};

--- a/src/components/dashboard/ResourceUtilization/index.ts
+++ b/src/components/dashboard/ResourceUtilization/index.ts
@@ -1,0 +1,6 @@
+export { ResourceUtilization } from './ResourceUtilization';
+export type {
+  ResourceUtilizationProps,
+  ResourceUtilizationData,
+  ResourceMetric,
+} from './ResourceUtilization';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -18,3 +18,4 @@ export * from './dashboard/TotalClusters';
 export * from './dashboard/Telemetry';
 export * from './dashboard/UpdateStatus';
 export * from './dashboard/ExpiredTrials';
+export * from './dashboard/ResourceUtilization';


### PR DESCRIPTION
## Description
New shared dashboard widget for "Resource Utilization" (OCM dashboard). Renders ChartDonutUtilization donuts for vCPU and Memory side by side, with an optional third donut for Storage. Each donut shows the usage percentage in the center and "of X [unit]" subtitle. Includes an optional "View more" link.

Storage is an optional prop since the API source isn't confirmed yet — vCPU and Memory map to `sum_used_cpu`/`sum_total_cpu` and `sum_used_memory`/`sum_total_memory` from the `summary_dashboard` endpoint.

[Mockups]( https://www.figma.com/design/yZYcrJVh8kjNELHrtwRKL5/OCM-and-ACM-Unified-Dashboard?node-id=0-1&p=f&t=UQF2YydateMsFf5z-0)

**Jira issue #** [FCN-262](https://redhat.atlassian.net/browse/FCN-262)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Run `npm run storybook` and navigate to Components > Dashboard > ResourceUtilization
2. Verify all 7 stories render correctly (Default, WithStorage, WithoutViewMore, HighUtilization, LowUtilization, ZeroUsage, MockupValues)
3. Confirm donut charts show correct percentages, subtitles, and optional Storage/View more link

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

### Before
N/A — new component

### After
Verified in Storybook — vCPU and Memory donut charts render side by side with correct percentages and subtitles across all stories (zero, low, high, with/without storage).


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes
- Uses PatternFly's `ChartDonutUtilization` from `@patternfly/react-charts/victory` (already a project dependency)
- `storage` prop is optional — omit to show only vCPU + Memory (pending API confirmation from Roberto/Aneela)
- `onViewMore` callback is optional — omit to hide the link
- Internal `MetricChart` subcomponent handles individual donut rendering with `data-testid` for stable test selectors
- `formatValue` helper uses `toLocaleString()` for integers and `toFixed(1)` for decimals
- `calcPercentage` safely handles zero total (returns 0%)
- 17 Playwright CT tests cover: metric sections render, titles, percentages, subtitles, storage present/absent, view more present/absent/click, zero usage, high utilization, zero total, large number formatting

---
<!-- Thank you for contributing to nxtcm-components! -->

[FCN-262]: https://redhat.atlassian.net/browse/FCN-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ