### PR TITLE
FCN-321 Apply Margot's UX feedback to resource and advisor widgets

### DIFF
--- a/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.spec.tsx
+++ b/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.spec.tsx
@@ -137,4 +137,37 @@ test.describe('AdvisorRecommendations', () => {
     await expect(component.getByTestId('severity-count-important')).toHaveText('2000');
     await expect(component.getByText('Service availability: 5000')).toBeVisible();
   });
+
+  test('should render the default card title', async ({ mount }) => {
+    const component = await mount(<AdvisorRecommendations data={defaultData} />);
+    const title = component.getByTestId('card-title');
+    await expect(title).toBeVisible();
+    await expect(title).toHaveText('Advisor recommendations by severity');
+  });
+
+  test('should render a custom card title', async ({ mount }) => {
+    const component = await mount(
+      <AdvisorRecommendations data={defaultData} title="Custom title" />
+    );
+    await expect(component.getByTestId('card-title')).toHaveText('Custom title');
+  });
+
+  test('should hide the card title when title is empty', async ({ mount }) => {
+    const component = await mount(<AdvisorRecommendations data={defaultData} title="" />);
+    await expect(component.getByTestId('card-title')).toHaveCount(0);
+  });
+
+  test('should render the lightspeed badge inline with the title by default', async ({ mount }) => {
+    const component = await mount(<AdvisorRecommendations data={defaultData} />);
+    const badge = component.getByTestId('lightspeed-badge');
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveText('Powered by Red Hat Lightspeed');
+  });
+
+  test('should hide the lightspeed badge when showLightspeedBadge is false', async ({ mount }) => {
+    const component = await mount(
+      <AdvisorRecommendations data={defaultData} showLightspeedBadge={false} />
+    );
+    await expect(component.getByTestId('lightspeed-badge')).toHaveCount(0);
+  });
 });

--- a/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.stories.tsx
+++ b/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { AdvisorRecommendations } from './AdvisorRecommendations';
+import { AdvisorRecommendations, AdvisorRecommendationsData } from './AdvisorRecommendations';
 
 const meta: Meta<typeof AdvisorRecommendations> = {
   title: 'Components/Dashboard/AdvisorRecommendations',
@@ -13,22 +13,14 @@ const meta: Meta<typeof AdvisorRecommendations> = {
 export default meta;
 type Story = StoryObj<typeof AdvisorRecommendations>;
 
+const defaultData: AdvisorRecommendationsData = {
+  severity: { critical: 3, important: 7, moderate: 15, low: 2 },
+  categories: { serviceAvailability: 25, performance: 8, security: 12, faultTolerance: 4 },
+};
+
 export const Default: Story = {
   args: {
-    data: {
-      severity: {
-        critical: 3,
-        important: 7,
-        moderate: 15,
-        low: 2,
-      },
-      categories: {
-        serviceAvailability: 25,
-        performance: 8,
-        security: 12,
-        faultTolerance: 4,
-      },
-    },
+    data: defaultData,
     onViewMore: () => {},
   },
 };
@@ -128,6 +120,30 @@ export const MockupValues: Story = {
         faultTolerance: 4,
       },
     },
+    onViewMore: () => {},
+  },
+};
+
+export const WithoutLightspeedBadge: Story = {
+  args: {
+    data: defaultData,
+    showLightspeedBadge: false,
+    onViewMore: () => {},
+  },
+};
+
+export const CustomTitle: Story = {
+  args: {
+    data: defaultData,
+    title: 'Cluster recommendations',
+    onViewMore: () => {},
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    data: defaultData,
+    title: '',
     onViewMore: () => {},
   },
 };

--- a/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.tsx
+++ b/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, FlexItem, Title } from '@patternfly/react-core';
+import { Divider, Flex, FlexItem, Label, Title } from '@patternfly/react-core';
 import { ChartDonut } from '@patternfly/react-charts/victory';
 import AngleDoubleUpIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-up-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
@@ -28,11 +28,17 @@ export type AdvisorRecommendationsData = {
   categories: CategoryCounts;
 };
 
+const DEFAULT_TITLE = 'Advisor recommendations by severity';
+
 export type AdvisorRecommendationsProps = {
   /** advisor recommendations data */
   data: AdvisorRecommendationsData;
+  /** card title — defaults to "Advisor recommendations by severity"; pass "" to hide */
+  title?: string;
   /** callback when "View more in Red Hat Advisor" link is clicked */
   onViewMore?: () => void;
+  /** show the "Powered by Red Hat Lightspeed" badge inline with the title; defaults to true */
+  showLightspeedBadge?: boolean;
 };
 
 const severityConfig = [
@@ -58,7 +64,9 @@ const categoryColors = ['#004080', '#0066cc', '#4394e5', '#b8d4f0'];
 
 export const AdvisorRecommendations: React.FC<AdvisorRecommendationsProps> = ({
   data,
+  title = DEFAULT_TITLE,
   onViewMore,
+  showLightspeedBadge = true,
 }) => {
   const { severity, categories } = data;
 
@@ -72,6 +80,31 @@ export const AdvisorRecommendations: React.FC<AdvisorRecommendationsProps> = ({
 
   return (
     <Flex direction={{ default: 'column' }} className={styles.container}>
+      {/* card heading */}
+      {(title || showLightspeedBadge) && (
+        <FlexItem>
+          <Flex
+            alignItems={{ default: 'alignItemsCenter' }}
+            justifyContent={{ default: 'justifyContentSpaceBetween' }}
+          >
+            {title && (
+              <FlexItem>
+                <Title headingLevel="h3" size="md" data-testid="card-title">
+                  {title}
+                </Title>
+              </FlexItem>
+            )}
+            {showLightspeedBadge && (
+              <FlexItem>
+                <Label color="orange" isCompact data-testid="lightspeed-badge">
+                  Powered by Red Hat Lightspeed
+                </Label>
+              </FlexItem>
+            )}
+          </Flex>
+        </FlexItem>
+      )}
+
       {/* severity counts */}
       <FlexItem>
         <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
@@ -114,7 +147,7 @@ export const AdvisorRecommendations: React.FC<AdvisorRecommendationsProps> = ({
       {/* recommendations by category */}
       <FlexItem>
         <Title
-          headingLevel="h5"
+          headingLevel="h4"
           size="lg"
           className={styles.categoryTitle}
           data-testid="category-title"
@@ -159,7 +192,7 @@ export const AdvisorRecommendations: React.FC<AdvisorRecommendationsProps> = ({
         </Flex>
       </FlexItem>
 
-      {/* "view more" link */}
+      {/* footer */}
       {onViewMore && (
         <FlexItem>
           <button

--- a/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.tsx
+++ b/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.tsx
@@ -1,9 +1,9 @@
 import { Divider, Flex, FlexItem, Label, Title } from '@patternfly/react-core';
 import { ChartDonut } from '@patternfly/react-charts/victory';
-import AngleDoubleUpIcon from '@patternfly/react-icons/dist/esm/icons/angle-double-up-icon';
-import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
+import SeverityCriticalIcon from '@patternfly/react-icons/dist/esm/icons/severity-critical-icon';
+import SeverityImportantIcon from '@patternfly/react-icons/dist/esm/icons/severity-important-icon';
 import EqualsIcon from '@patternfly/react-icons/dist/esm/icons/equals-icon';
-import ArrowDownIcon from '@patternfly/react-icons/dist/esm/icons/arrow-down-icon';
+import SeverityMinorIcon from '@patternfly/react-icons/dist/esm/icons/severity-minor-icon';
 import React from 'react';
 import styles from './AdvisorRecommendations.module.scss';
 
@@ -42,15 +42,15 @@ export type AdvisorRecommendationsProps = {
 };
 
 const severityConfig = [
-  { key: 'critical' as const, label: 'Critical', Icon: AngleDoubleUpIcon, style: 'critical' },
+  { key: 'critical' as const, label: 'Critical', Icon: SeverityCriticalIcon, style: 'critical' },
   {
     key: 'important' as const,
     label: 'Important',
-    Icon: ExclamationTriangleIcon,
+    Icon: SeverityImportantIcon,
     style: 'important',
   },
   { key: 'moderate' as const, label: 'Moderate', Icon: EqualsIcon, style: 'moderate' },
-  { key: 'low' as const, label: 'Low', Icon: ArrowDownIcon, style: 'low' },
+  { key: 'low' as const, label: 'Low', Icon: SeverityMinorIcon, style: 'low' },
 ] as const;
 
 const categoryLabels: Record<keyof CategoryCounts, string> = {

--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.spec.tsx
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.spec.tsx
@@ -8,6 +8,23 @@ const defaultData: ResourceUtilizationData = {
 };
 
 test.describe('ResourceUtilization', () => {
+  test('should render the default "Resource usage" title', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} />);
+    await expect(component.getByTestId('card-title')).toHaveText('Resource usage');
+  });
+
+  test('should render a custom title when provided', async ({ mount }) => {
+    const component = await mount(
+      <ResourceUtilization data={defaultData} title="CPU and Memory utilization" />
+    );
+    await expect(component.getByTestId('card-title')).toHaveText('CPU and Memory utilization');
+  });
+
+  test('should hide the title when empty string is passed', async ({ mount }) => {
+    const component = await mount(<ResourceUtilization data={defaultData} title="" />);
+    await expect(component.getByTestId('card-title')).toHaveCount(0);
+  });
+
   test('should render vCPU metric section', async ({ mount }) => {
     const component = await mount(<ResourceUtilization data={defaultData} />);
     await expect(component.getByTestId('metric-vcpu-donut')).toBeVisible();

--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.stories.tsx
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.stories.tsx
@@ -77,3 +77,24 @@ export const MockupValues: Story = {
     onViewMore: () => alert('View more clicked'),
   },
 };
+
+export const CustomTitle: Story = {
+  args: {
+    data: {
+      vCPU: { used: 32, total: 128, unit: 'Cores' },
+      memory: { used: 48, total: 256, unit: 'GiB' },
+    },
+    title: 'CPU and Memory utilization',
+    onViewMore: () => alert('View more clicked'),
+  },
+};
+
+export const NoTitle: Story = {
+  args: {
+    data: {
+      vCPU: { used: 32, total: 128, unit: 'Cores' },
+      memory: { used: 48, total: 256, unit: 'GiB' },
+    },
+    title: '',
+  },
+};

--- a/src/components/dashboard/ResourceUtilization/ResourceUtilization.tsx
+++ b/src/components/dashboard/ResourceUtilization/ResourceUtilization.tsx
@@ -3,6 +3,8 @@ import { ChartDonutUtilization } from '@patternfly/react-charts/victory';
 import React from 'react';
 import styles from './ResourceUtilization.module.scss';
 
+const DEFAULT_TITLE = 'Resource usage';
+
 export type ResourceMetric = {
   /** amount currently in use */
   used: number;
@@ -24,6 +26,8 @@ export type ResourceUtilizationData = {
 export type ResourceUtilizationProps = {
   /** resource utilization metrics */
   data: ResourceUtilizationData;
+  /** card title — defaults to "Resource usage"; pass "" to hide */
+  title?: string;
   /** callback when "View more" is clicked; omit to hide the link */
   onViewMore?: () => void;
 };
@@ -71,11 +75,22 @@ const MetricChart: React.FC<MetricChartProps> = ({ label, metric, chartId }) => 
   );
 };
 
-export const ResourceUtilization: React.FC<ResourceUtilizationProps> = ({ data, onViewMore }) => {
+export const ResourceUtilization: React.FC<ResourceUtilizationProps> = ({
+  data,
+  title = DEFAULT_TITLE,
+  onViewMore,
+}) => {
   const { vCPU, memory, storage } = data;
 
   return (
     <Flex direction={{ default: 'column' }} className={styles.container}>
+      {title && (
+        <FlexItem>
+          <Title headingLevel="h3" size="md" data-testid="card-title">
+            {title}
+          </Title>
+        </FlexItem>
+      )}
       <FlexItem>
         <Flex
           justifyContent={{ default: 'justifyContentSpaceEvenly' }}


### PR DESCRIPTION
## Description

Apply Margot's UX review feedback to two merged dashboard widgets:

- **ResourceUtilization**: added a `title` prop defaulting to "Resource usage" (renamed from "CPU and Memory utilization" per Margot's doc). Pass a custom string or `""` to hide the title.
- **AdvisorRecommendations**:
  - Added a `title` prop defaulting to "Advisor recommendations by severity". Pass a custom string or `""` to hide it.
  - Added a "Powered by Red Hat Lightspeed" inline badge next to the card title (matching Margot's mockup placement). Shown by default, hideable via `showLightspeedBadge={false}`.
  - Fixed heading-order a11y violation (category sub-heading was `h5` after `h3` title; now `h4`).
  - Swapped severity icons to PF's dedicated severity icons per Margot's feedback: Critical → `SeverityCriticalIcon`, Important → `SeverityImportantIcon`, Low → `SeverityMinorIcon`. Moderate stays as `EqualsIcon`.

Mockups

**Jira issue #** [FCN-321](https://redhat.atlassian.net/browse/FCN-321)
**Parent** FCN-259

**Backport of** #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):

## Testing

### Manual Testing

**Test Steps:**
1. Run Storybook (`npm run storybook`)
2. Navigate to Components → Dashboard → ResourceUtilization
3. Verify "Resource usage" title renders by default (Default story)
4. Verify custom title works (CustomTitle story)
5. Verify empty string hides the title (NoTitle story)
6. Navigate to Components → Dashboard → AdvisorRecommendations
7. Verify "Advisor recommendations by severity" title renders by default
8. Verify "Powered by Red Hat Lightspeed" badge appears **inline with the title** (not in the footer)
9. Verify badge is hidden (WithoutLightspeedBadge story)
10. Verify custom title (CustomTitle story) and no title (NoTitle story)
11. Verify severity icons match PF severity icon set (Critical, Important, Moderate, Low)

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**
- Cypress Tests: N/A
- Playwright Tests: Component tests pass (38/38 — 18 AdvisorRecommendations + 20 ResourceUtilization)

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass

**Integration Tests:**
- Integration tests added/updated
- All integration tests pass

## Screenshots/Recordings

### AdvisorRecommendations - severity icons updated to PF severity set
Critical (SeverityCriticalIcon), Important (SeverityImportantIcon), Moderate (EqualsIcon), Low (SeverityMinorIcon)

### AdvisorRecommendations - "Powered by Red Hat Lightspeed" badge inline with title
badge renders as a small bordered pill next to the card heading

<img width="2992" height="1634" alt="image" src="https://github.com/user-attachments/assets/9e479095-247e-4c44-b6c6-bd605d99fb5b" />


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [x] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed

## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

## Additional Notes

Severity icon change was per Margot's review — she wanted the PF dedicated severity icons (`pficon-severity-critical`, `pficon-severity-important`, `pficon-severity-minor`) instead of generic arrow/triangle icons.

## Reviewer Guidelines

### Focus Areas
- Severity icon choices matching PF/Insights conventions
- Lightspeed badge placement and styling
- Title prop API (`""` to hide)

### Questions for Reviewers
-

[FCN-321]: https://redhat.atlassian.net/browse/FCN-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ