### PR TITLE
FCN-323 add dark mode toggle to Storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-docs'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-themes'],
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style>
+  body {
+    background-color: var(--pf-t--global--background--color--primary--default);
+    color: var(--pf-t--global--text--color--regular);
+  }
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
-import type { Preview } from "@storybook/react";
+import type { Preview } from '@storybook/react';
+import { withThemeByClassName } from '@storybook/addon-themes';
 
 const preview: Preview = {
   parameters: {
@@ -11,6 +12,16 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: '',
+        dark: 'pf-v6-theme-dark',
+      },
+      defaultTheme: 'light',
+      parentSelector: 'html',
+    }),
+  ],
 };
 
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@playwright/test": "^1.56.1",
         "@react-hook/resize-observer": "^2.0.2",
         "@storybook/addon-docs": "^9.1.10",
+        "@storybook/addon-themes": "^9.1.20",
         "@storybook/react": "^9.1.15",
         "@storybook/react-vite": "^9.1.10",
         "@types/handlebars": "^4.0.40",
@@ -4741,6 +4742,23 @@
       },
       "peerDependencies": {
         "storybook": "^9.1.16"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-9.1.20.tgz",
+      "integrity": "sha512-GY9WKJMxbsI24CTj1PToWbjZGuXnwLasahv51wpIQC94Sn/8NxRta8K2BO2Pqb7U3sdtjH6htUasnQnaL0/ZBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/builder-vite": {
@@ -13257,10 +13275,11 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.16.tgz",
-      "integrity": "sha512-339U14K6l46EFyRvaPS2ZlL7v7Pb+LlcXT8KAETrGPxq8v1sAjj2HAOB6zrlAK3M+0+ricssfAwsLCwt7Eg8TQ==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.20.tgz",
+      "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@playwright/test": "^1.56.1",
     "@react-hook/resize-observer": "^2.0.2",
     "@storybook/addon-docs": "^9.1.10",
+    "@storybook/addon-themes": "^9.1.20",
     "@storybook/react": "^9.1.15",
     "@storybook/react-vite": "^9.1.10",
     "@types/handlebars": "^4.0.40",


### PR DESCRIPTION
## Description

Adds a dark mode toggle to the Storybook toolbar so we can QA widgets in both PF light and dark themes without leaving the browser.

Uses `@storybook/addon-themes` with `withThemeByClassName` to `toggle pf-v6-theme-dark` on the preview iframe's `<html>`. Also added a small `preview-head.html` that wires the body's background and text color to PF design tokens so they react to the class change.

### Toggle only works on the Canvas tab - Docs stays light ###

**Team decision:** The toggle only applies to the Canvas tab. Docs pages stay light. This is due to a [known Storybook bug (#30928)](https://github.com/storybookjs/storybook/issues/30928) where the theme toggle doesn't propagate to the Docs renderer. The team discussed three options (Canvas-only, DocsRenderer workaround, community addon) and agreed on Canvas-only since that's where we actually QA widgets. If we want to revisit later, option 3 (community addon) is the fallback.

Unblocks [FCN-324 ](https://redhat.atlassian.net/browse/FCN-324)(chart dark mode fixes).

**Jira issue #** [FCN-323](https://redhat.atlassian.net/browse/FCN-323)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [x] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Run `npm run storybook`
2. Open any story in the Canvas tab
3. Click the theme toggle in the toolbar (paintbrush icon) and switch to "dark"
4. Verify the preview background goes dark and all PF components pick up dark theme tokens
5. Switch back to "light" and verify no regressions
6. Check the Docs tab - it should remain light (expected, per team decision)

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

### Before
No dark mode toggle existed. All stories rendered in light theme only.

### After
Toolbar toggle switches between PF light and dark themes on the Canvas tab. All 126 stories QA'd in both modes with no regressions.
<img width="1905" height="985" alt="storybook-dark:light-toggle" src="https://github.com/user-attachments/assets/f2f50dff-4132-4c35-abec-caf38f8bf611" />

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [x] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

This unblocks FCN-324 (chart dark mode fixes) which needs the toggle to visually verify color changes in AdvisorRecommendations and ResourceUtilization.

Config-only change - no component code was modified.


## Reviewer Guidelines

### Focus Areas
- `preview.ts` decorator config - is the `parentSelector: 'html'` approach correct for PF v6?
- `preview-head.html` CSS injection - using PF CSS variables so it auto-adapts to theme

### Questions for Reviewers
- Any concerns with adding `@storybook/addon-themes` as a dev dependency?

---

[FCN-323]: https://redhat.atlassian.net/browse/FCN-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ