### PR TITLE
FCN-324 use PF theme API for chart colors in dark mode

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -3,7 +3,7 @@ import path from 'path';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
-  addons: ['@storybook/addon-docs'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-themes'],
   framework: {
     name: '@storybook/react-vite',
     options: {},

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<style>
+  body {
+    background-color: var(--pf-t--global--background--color--primary--default);
+    color: var(--pf-t--global--text--color--regular);
+  }
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
-import type { Preview } from "@storybook/react";
+import type { Preview } from '@storybook/react';
+import { withThemeByClassName } from '@storybook/addon-themes';
 
 const preview: Preview = {
   parameters: {
@@ -11,6 +12,16 @@ const preview: Preview = {
       },
     },
   },
+  decorators: [
+    withThemeByClassName({
+      themes: {
+        light: '',
+        dark: 'pf-v6-theme-dark',
+      },
+      defaultTheme: 'light',
+      parentSelector: 'html',
+    }),
+  ],
 };
 
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@playwright/test": "^1.56.1",
         "@react-hook/resize-observer": "^2.0.2",
         "@storybook/addon-docs": "^9.1.10",
+        "@storybook/addon-themes": "^9.1.20",
         "@storybook/react": "^9.1.15",
         "@storybook/react-vite": "^9.1.10",
         "@types/handlebars": "^4.0.40",
@@ -4741,6 +4742,23 @@
       },
       "peerDependencies": {
         "storybook": "^9.1.16"
+      }
+    },
+    "node_modules/@storybook/addon-themes": {
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-themes/-/addon-themes-9.1.20.tgz",
+      "integrity": "sha512-GY9WKJMxbsI24CTj1PToWbjZGuXnwLasahv51wpIQC94Sn/8NxRta8K2BO2Pqb7U3sdtjH6htUasnQnaL0/ZBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^9.1.20"
       }
     },
     "node_modules/@storybook/builder-vite": {
@@ -13257,10 +13275,11 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.16",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.16.tgz",
-      "integrity": "sha512-339U14K6l46EFyRvaPS2ZlL7v7Pb+LlcXT8KAETrGPxq8v1sAjj2HAOB6zrlAK3M+0+ricssfAwsLCwt7Eg8TQ==",
+      "version": "9.1.20",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.20.tgz",
+      "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@playwright/test": "^1.56.1",
     "@react-hook/resize-observer": "^2.0.2",
     "@storybook/addon-docs": "^9.1.10",
+    "@storybook/addon-themes": "^9.1.20",
     "@storybook/react": "^9.1.15",
     "@storybook/react-vite": "^9.1.10",
     "@types/handlebars": "^4.0.40",

--- a/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.tsx
+++ b/src/components/dashboard/AdvisorRecommendations/AdvisorRecommendations.tsx
@@ -1,5 +1,5 @@
 import { Divider, Flex, FlexItem, Label, Title } from '@patternfly/react-core';
-import { ChartDonut } from '@patternfly/react-charts/victory';
+import { ChartDonut, ChartThemeColor, getTheme } from '@patternfly/react-charts/victory';
 import SeverityCriticalIcon from '@patternfly/react-icons/dist/esm/icons/severity-critical-icon';
 import SeverityImportantIcon from '@patternfly/react-icons/dist/esm/icons/severity-important-icon';
 import EqualsIcon from '@patternfly/react-icons/dist/esm/icons/equals-icon';
@@ -60,7 +60,9 @@ const categoryLabels: Record<keyof CategoryCounts, string> = {
   faultTolerance: 'Fault tolerance',
 };
 
-const categoryColors = ['#004080', '#0066cc', '#4394e5', '#b8d4f0'];
+// derive legend colors from pf's blue theme so chart + dots stay in sync automatically
+const blueTheme = getTheme(ChartThemeColor.blue);
+const categoryColors = (blueTheme.chart?.colorScale?.slice(0, 4) ?? []) as string[];
 
 export const AdvisorRecommendations: React.FC<AdvisorRecommendationsProps> = ({
   data,

--- a/src/components/dashboard/CostManagement/CostChart.tsx
+++ b/src/components/dashboard/CostManagement/CostChart.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import { Flex, FlexItem, Title } from '@patternfly/react-core';
-import { Chart, ChartAxis, ChartBar, ChartLegend } from '@patternfly/react-charts/victory';
+import {
+  Chart,
+  ChartAxis,
+  ChartBar,
+  ChartLegend,
+  ChartThemeColor,
+  getTheme,
+} from '@patternfly/react-charts/victory';
 import styles from './CostChart.module.scss';
 
 interface ClusterCostData {
@@ -14,6 +21,10 @@ export interface CostChartProps {
   currency?: string;
 }
 
+// derive bar/legend colors from pf's multi-ordered theme so they adapt to dark mode
+const multiTheme = getTheme(ChartThemeColor.multiOrdered);
+const barColors = (multiTheme.chart?.colorScale?.slice(0, 3) ?? []) as string[];
+
 export const CostChart: React.FC<CostChartProps> = ({ costData, currency = '$' }) => {
   const { rosaClusters, osdClusters, aroClusters } = costData;
 
@@ -24,9 +35,9 @@ export const CostChart: React.FC<CostChartProps> = ({ costData, currency = '$' }
   ];
 
   const legendData = [
-    { name: 'ROSA Clusters', symbol: { fill: '#009596' } },
-    { name: 'OSD Clusters', symbol: { fill: '#002f5d' } },
-    { name: 'ARO Clusters', symbol: { fill: '#bde2b9' } },
+    { name: 'ROSA Clusters', symbol: { fill: barColors[0] } },
+    { name: 'OSD Clusters', symbol: { fill: barColors[1] } },
+    { name: 'ARO Clusters', symbol: { fill: barColors[2] } },
   ];
 
   const maxValue = Math.max(rosaClusters, osdClusters, aroClusters);
@@ -81,9 +92,9 @@ export const CostChart: React.FC<CostChartProps> = ({ costData, currency = '$' }
               style={{
                 data: {
                   fill: ({ datum }: { datum?: { name: string; x: number; y: number } }) => {
-                    if (datum?.name === 'ROSA Clusters') return '#009596';
-                    if (datum?.name === 'OSD Clusters') return '#002f5d';
-                    return '#bde2b9';
+                    if (datum?.name === 'ROSA Clusters') return barColors[0];
+                    if (datum?.name === 'OSD Clusters') return barColors[1];
+                    return barColors[2];
                   },
                 },
               }}


### PR DESCRIPTION
## Description

Replaces hardcoded hex colors in chart components with PF's `getTheme()` API so chart segments, bar fills, and legend dots adapt to dark mode automatically via CSS variables.

AdvisorRecommendations - categoryColors array now derives from `getTheme(ChartThemeColor.blue)` instead of hardcoded `#004080`, `#0066cc`, `#4394e5`, `#b8d4f0`. Donut colorScale and custom legend dot backgrounds both pull from the same theme-derived array.

CostChart - bar fills and legend symbol colors now derive from `getTheme(ChartThemeColor.multiOrdered)` instead of hardcoded `#009596`, `#002f5d`, `#bde2b9`.

ResourceUtilization - no changes needed, ChartDonutUtilization uses PF's default blue theme, which already adapts.

**Depends** on #112 (FCN-323 dark mode toggle) for Storybook verification.

**Jira issue #** [FCN-324](https://redhat.atlassian.net/browse/FCN-324)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Run `npm run storybook`
2. Open the AdvisorRecommendations story in Canvas tab
3. Toggle to dark mode using the toolbar paintbrush icon
4. Verify bar fills and legend dots use PF multi-ordered theme colors in both light and dark
5. Toggle back to light and confirm no regressions
6. Check ResourceUtilization chart too - its `ChartDonutUtilization` already uses PF theme natively

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)

- [x] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      All 17 tests pass.

**Unit Tests:**
- [ ] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

### Before
Hardcoded hex colors - chart looks washed out in dark mode, legend dots don't match PF palette
<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/249f94c6-70d9-4c7d-b621-f758ba5344c8" />


### After
AdvisorRecommendations story in dark mode
Colors derived from `getTheme(ChartThemeColor.blue)` - chart adapts to both light and dark themes automatically
<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/1aeff2c3-8eff-4cbb-84e9-78032a71a1ea" />



### Before
ResourceUtilization in dark mode
<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/02e02a86-f1ec-41e9-ab2e-e33ecfcb596f" />


### After
ResourceUtilization in dark mode
<img width="1920" height="929" alt="image" src="https://github.com/user-attachments/assets/edd4bdfd-165d-40bf-a0d1-2fb5e98962ea" />


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

One-file change. The `categoryColors` array is now derived from PF's blue chart theme instead of hardcoded hex values. The `?? []` fallback is defensive — `getTheme` always returns a valid scale, but TypeScript's types don't guarantee it.

Depends on FCN-323 (#112) for the Storybook dark mode toggle to visually verify


[FCN-324]: https://redhat.atlassian.net/browse/FCN-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ