### PR TITLE
Remove extra padding from PopoverHintWithTitle

### DIFF
--- a/src/components/Wizards/RosaWizard/common/PopoverHintWithTitle.css
+++ b/src/components/Wizards/RosaWizard/common/PopoverHintWithTitle.css
@@ -1,6 +1,5 @@
 .popover-with-title-div {
   display: inline-block;
-  padding-top: var(--pf-t--global--spacer--md);
 }
 
 .popover-with-title-button {


### PR DESCRIPTION
## Description
Remove the custom `padding-top: var(--pf-t--global--spacer--md)` from `.popover-with-title-div` in `PopoverHintWithTitle.css`. This custom CSS was adding ~16px of extra vertical space above every `PopoverHintWithTitle` usage, causing a visible spacing gap between the Amazon Resource Names (ARNs) section and the Operator roles header in the ROSA wizard.

**Jira issue #** FCN-211

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Manual Testing

**Test Steps:**
1. Navigate to the ROSA wizard Roles & Policies step
2. Observe the spacing between the ARN expandable section and the Operator roles section header
3. Verify the extra space is no longer present

### Automated Testing

**Unit Tests:**
- [x] All component tests pass (398 tests, 394 passed, 4 skipped)

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct

### Accessibility
- [x] No accessibility impact — only spacing change

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Additional Notes
The `PopoverHintWithTitle` component is also used in `OCMRole` and `UserRole` components. Removing this padding improves spacing consistency in those contexts as well, since PatternFly's own layout components (Stack, StackItem, etc.) already handle appropriate spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)