### PR TITLE
Fix extra space above Operator roles

### DIFF
--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.css
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.css
@@ -1,0 +1,3 @@
+#operator-roles.pf-v6-c-form__section {
+  --pf-v6-c-form__section--MarginBlockStart: 0;
+}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
@@ -25,6 +25,7 @@ import links from '../../../externalLinks';
 import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 import { FieldWithAPIErrorAlert } from '../../../common/FieldWithAPIErrorAlert';
 import { useResetFieldOnOptionsChange } from '../../../hooks/useResetFieldOnOptionsChange';
+import './RolesAndPoliciesSubStep.css';
 
 type RolesAndPoliciesSubStepProps = {
   roles: Resource<Role[], [awsAccount: string]> & {

--- a/src/components/Wizards/RosaWizard/common/PopoverHintWithTitle.css
+++ b/src/components/Wizards/RosaWizard/common/PopoverHintWithTitle.css
@@ -1,6 +1,5 @@
 .popover-with-title-div {
   display: inline-block;
-  padding-top: var(--pf-t--global--spacer--md);
 }
 
 .popover-with-title-button {


### PR DESCRIPTION
## Description

Fix extra vertical spacing between the "Amazon Resource Names (ARNs)" expandable section and the "Operator roles" section header in the ROSA wizard's Roles and Policies substep.

**Root cause:** Two sources of extra spacing stacked on top of each other:
1. PF6's `.pf-v6-c-form__section:not(:first-child)` adds `margin-block-start` (32px) on top of the Form's own grid gap.
2. `.popover-with-title-div` had a custom `padding-top` that added an extra 16px above the OIDC popover hint.

**Fix:**
1. Created `RolesAndPoliciesSubStep.css` that overrides `--pf-v6-c-form__section--MarginBlockStart` to `0` on the `#operator-roles` section element.
2. Removed the custom `padding-top` rule from `.popover-with-title-div` in `PopoverHintWithTitle.css` — PF layout components (Stack, StackItem) already handle spacing.

**Jira issue #** FCN-211

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Manual Testing

**Test Steps:**
1. Navigate to the ROSA wizard Roles and Policies substep
2. Verify no extra vertical gap between the ARNs expandable section and the Operator roles section header
3. Confirm OIDC popover hint still has appropriate spacing from surrounding elements

**Test Environment:**
- [x] Tested locally

### Automated Testing

**Unit Tests:**
- [x] All unit tests pass (npm run test:ct) — 394/394 passing

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Accessibility
- [x] My changes follow accessibility best practices

### Dependencies
- [x] No dependency changes needed

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Additional Notes

The `#operator-roles` ID is auto-generated by the `Section` component from the label "Operator roles" via `label.toLowerCase().split(" ").join("-")`. The CSS override is scoped to only this specific section element.