### PR TITLE
fix extra spacing in roles and policies substep

### DIFF
--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.css
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.css
@@ -1,0 +1,3 @@
+#operator-roles.pf-v6-c-form__section {
+  --pf-v6-c-form__section--MarginBlockStart: 0;
+}

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
@@ -25,6 +25,7 @@ import links from '../../../externalLinks';
 import { useRosaWizardStrings, useRosaWizardValidators } from '../../../RosaWizardStringsContext';
 import { FieldWithAPIErrorAlert } from '../../../common/FieldWithAPIErrorAlert';
 import { useResetFieldOnOptionsChange } from '../../../hooks/useResetFieldOnOptionsChange';
+import './RolesAndPoliciesSubStep.css';
 
 type RolesAndPoliciesSubStepProps = {
   roles: Resource<Role[], [awsAccount: string]> & {

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/RolesAndPoliciesSubStep/RolesAndPoliciesSubStep.tsx
@@ -262,7 +262,7 @@ export const RolesAndPoliciesSubStep: React.FunctionComponent<RolesAndPoliciesSu
           </Grid>
         </ExpandableSection>
       </Section>
-      <Section label={rp.operatorRolesSection}>
+      <Section id="operator-roles" label={rp.operatorRolesSection}>
         <Grid>
           <GridItem span={7}>
             <Stack>

--- a/src/components/Wizards/RosaWizard/common/PopoverHintWithTitle.css
+++ b/src/components/Wizards/RosaWizard/common/PopoverHintWithTitle.css
@@ -1,6 +1,5 @@
 .popover-with-title-div {
   display: inline-block;
-  padding-top: var(--pf-t--global--spacer--md);
 }
 
 .popover-with-title-button {


### PR DESCRIPTION
## Description

Fixes the extra vertical space between the "Amazon Resource Names (ARNs)" expandable section and the "Operator roles" section in the ROSA wizard's Roles and Policies substep.

two sources of extra spacing were stacking:
1. PF6 form section margin — `.pf-v6-c-form__section:not(:first-child)` adds `margin-block-start` on top of the form's grid gap
2. PopoverHintWithTitle custom padding — `.popover-with-title-div` had a hardcoded `padding-top`

**Jira issue #** [FCN-211](https://redhat.atlassian.net/browse/FCN-211)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Manual Testing

**Test Steps:**
1. open Storybook → Wizards / RosaWizard → Extensive Options
2. navigate to "Roles and policies" substep
3. verify the spacing between ARNs section and Operator roles is no longer excessive

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**Unit Tests:**
- [x] All unit tests pass (npm run test)

**Component Tests:**
- [x] RolesAndPoliciesSubStep: 16 passed, 2 skipped

## Screenshots/Recordings

### After
verified in Storybook — spacing between "Amazon Resource Names (ARNs)" and "Operator roles" is now tight and correct

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Accessibility
- [x] My changes follow accessibility best practices

### Dependencies
- [x] Any dependent changes have been merged and published

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Additional Notes

branch was rebased clean off main to remove an unrelated FCN-237 commit that was polluting the diff. the only changes are the 3 files listed in the Jira description.

## Reviewer Guidelines

### Focus Areas
- verify the CSS selector `#operator-roles.pf-v6-c-form__section` is specific enough and doesn't collide with other uses
- confirm removing `padding-top` from `.popover-with-title-div` doesn't affect other usages (UserRole.tsx, OCMRole.tsx, PopoverHint.tsx)

[FCN-211]: https://redhat.atlassian.net/browse/FCN-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ