### PR TITLE
fix ct triage comment not posting on fork PRs

### DIFF
--- a/.github/workflows/ct-triage-comment.yml
+++ b/.github/workflows/ct-triage-comment.yml
@@ -42,7 +42,7 @@ jobs:
           # fallback for fork PRs: commits API can't resolve fork SHAs,
           # so search open PRs by head SHA instead
           if [ -z "$PR" ]; then
-            PR=$(gh pr list --repo "$REPO" --state open --json number,headRefOid \
+            PR=$(gh pr list --repo "$REPO" --state open --limit 200 --json number,headRefOid \
               --jq ".[] | select(.headRefOid == \"${SHA}\") | .number" | head -1)
           fi
 

--- a/.github/workflows/ct-triage-comment.yml
+++ b/.github/workflows/ct-triage-comment.yml
@@ -33,8 +33,19 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR=$(gh api repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls \
-            --jq '.[0].number // empty')
+          SHA="${{ github.event.workflow_run.head_sha }}"
+          REPO="${{ github.repository }}"
+
+          # works for same-repo branches
+          PR=$(gh api "repos/${REPO}/commits/${SHA}/pulls" --jq '.[0].number // empty' 2>/dev/null || echo "")
+
+          # fallback for fork PRs: commits API can't resolve fork SHAs,
+          # so search open PRs by head SHA instead
+          if [ -z "$PR" ]; then
+            PR=$(gh pr list --repo "$REPO" --state open --json number,headRefOid \
+              --jq ".[] | select(.headRefOid == \"${SHA}\") | .number" | head -1)
+          fi
+
           echo "number=${PR}" >> "$GITHUB_OUTPUT"
 
       - name: Download CT summary artifact


### PR DESCRIPTION
## Description

The CT triage workflow wasn't posting comments on PRs opened from forks. It uses the commits/{sha}/pulls API to find the PR number, but that API can't resolve commit SHAs that live on a fork. Since everyone on the team works from forks, the triage comment never actually fired in real usage.

Added a fallback: if the commits API returns nothing, search open PRs by head SHA using gh pr list. Fork PRs still expose their head SHA in PR metadata, so this reliably finds them.

Found this while testing the triage workflow for the hackathon demo (PR #217 from a fork had the workflow skip the comment step entirely because the PR number came back empty).

**Jira issue #** N/A (follow-up fix to FCN-322)


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

Verified the original failure by opening a demo PR from a fork (PR #217). The triage workflow ran but skipped the comment step because PR number was empty. Then pushed the same branch directly to upstream (PR #218) and the triage comment posted correctly, confirming the issue is the fork SHA lookup.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors