### PR TITLE
Adds ACP a11y review workflow for PRs

### DIFF
--- a/.github/workflows/a11y-review.yml
+++ b/.github/workflows/a11y-review.yml
@@ -1,0 +1,109 @@
+name: A11y PR Review
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number to review
+        required: true
+        type: number
+
+concurrency:
+  group: a11y-review-${{ github.event.pull_request.number || github.event.inputs.pr-number }}
+  cancel-in-progress: true
+
+jobs:
+  a11y-review:
+    name: Accessibility Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run ACP a11y review
+        uses: ambient-code/ambient-action@v2
+        with:
+          api-url: ${{ secrets.AMBIENT_API_URL }}
+          api-token: ${{ secrets.AMBIENT_BOT_TOKEN }}
+          project: ${{ secrets.ACP_PROJECT }}
+          prompt: |
+            You are an accessibility reviewer checking a pull request for WCAG 2.1 AA compliance.
+            This project uses React with PatternFly 6 and has axe-core via @axe-core/playwright for runtime a11y testing.
+
+            PR: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.inputs.pr-number }}
+
+            Steps:
+
+            1. Get the PR diff:
+               gh pr diff ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }}
+
+            2. Identify all changed or added .tsx files. Focus your review on those files only.
+
+            3. For each changed component file, check for these anti-patterns:
+
+               HTML semantics:
+               - <div onClick> or <span onClick> without role="button" and tabIndex (critical)
+               - <a> without href used as a button (serious)
+               - <img> without alt attribute (critical)
+               - heading level skips e.g. h1 -> h3 (serious)
+               - <input>/<select>/<textarea> without associated label (critical)
+
+               Keyboard and focus:
+               - outline: none or :focus { outline: 0 } removing focus indicators (critical)
+               - tabindex > 0 (serious)
+               - mouse-only handlers (onMouseDown/onMouseOver) without keyboard equivalents (serious)
+
+               ARIA usage:
+               - icon-only buttons without aria-label (critical)
+               - aria-hidden="true" on focusable elements (critical)
+               - dynamic content updates without aria-live (serious)
+
+               PatternFly-specific:
+               - PF FormGroup without fieldId (serious)
+               - PF FormGroup missing helperTextInvalid for validated fields (serious)
+               - PF action columns without screenReaderText (serious)
+               - custom dropdowns instead of PF Select/Dropdown (moderate)
+               - PF Spinner without aria-label (moderate)
+
+               Color and contrast:
+               - hardcoded hex/rgb colors instead of design tokens (moderate)
+               - color as the only indicator of state without icon or text (serious)
+
+            4. For each changed component, check if a corresponding .spec.tsx file exists and contains:
+               - a checkAccessibility() call (this project uses @axe-core/playwright)
+               - keyboard navigation tests (.focus(), .press('Tab'), .press('Enter'))
+               - screen reader text assertions (aria-label, aria-describedby)
+               If the component is new or modified and lacks these, flag it.
+
+            5. Post a comment on the PR with your findings using:
+               gh pr comment ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }} --body "YOUR_COMMENT"
+
+               Format the comment as:
+
+               ## A11y Review: PR #<number>
+
+               ### project context
+               - framework: PatternFly 6
+               - test tooling: Playwright CT with @axe-core/playwright
+               - a11y helper: checkAccessibility() in src/test-helpers.ts
+
+               ### critical (must fix)
+               List issues with [file:line] references and concrete fixes.
+
+               ### serious (should fix)
+               List issues with [file:line] references and concrete fixes.
+
+               ### moderate (consider fixing)
+               List issues with [file:line] references and concrete fixes.
+
+               ### test coverage gaps
+               List components missing checkAccessibility() calls or keyboard tests.
+
+               ### summary
+               One sentence overall assessment.
+
+               If no issues are found, post a short "no a11y issues found" comment instead.
+
+            6. Only review files that were actually changed in the PR. Do not review the entire codebase.
+          wait: 'true'
+          timeout: '30'


### PR DESCRIPTION
## Why a workflow and not just a Cursor skill?

This workflow automates accessibility checks at the PR level, so every change gets reviewed regardless of what IDE the developer uses or whether they remember to trigger anything manually. It builds on the team's existing checkAccessibility pattern in `src/test-helpers.ts` (which runs axe-core in Playwright CT specs) and extends it with static code review that catches things axe can't find without rendering -- like missing `aria-labels` on icon buttons, `div` `onClick` patterns, or PatternFly FormGroup without fieldId.

## Description

Adds a GitHub Actions workflow that runs an automated accessibility (WCAG 2.1 AA) review on every PR opened against main. Uses ACP (Ambient Code Platform) via `ambient-code/ambient-action@v2` to read the PR diff, check changed `.tsx` files for a11y anti-patterns, and post a structured comment with findings.

The review covers HTML semantics, ARIA usage, keyboard/focus issues, PatternFly-specific gaps, and checks whether changed components have `checkAccessibility()` in their Playwright CT specs.

Uses `pull_request_target` so it works for PRs from forks (which is how the team works).

**Jira issue #** N/A (infrastructure/tooling)


## Type of Change

- [x] New feature/enhancement (non-breaking change which adds functionality)
- [x] Infrastructure/build change


## Testing

### Manual Testing

**Test Steps:**
1. Merge this and configure repo secrets (`AMBIENT_API_URL`, `AMBIENT_BOT_TOKEN`, `ACP_PROJECT`)
2. Open any PR with `.tsx` changes
3. Verify the ACP a11y review comment appears on the PR

**Test Environment:**
- [x] Tested locally (YAML validation, workflow syntax)

### Automated Testing

**Unit Tests:**
- [ ] N/A -- this is a workflow file, no unit tests applicable


## Screenshots/Recordings

N/A -- workflow file only, no UI changes


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Dependencies
- [ ] Any dependent changes have been merged and published
  - Requires repo secrets to be configured: `AMBIENT_API_URL`, `AMBIENT_BOT_TOKEN`, `ACP_PROJECT`


## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No


## Additional Notes

This workflow won't do anything until the repo secrets are configured. Once secrets are set, it runs automatically on every PR.

The a11y audit prompt is derived from the team's existing `checkAccessibility` pattern and the a11y audit skill checklist. It does static code review (catches things axe-core can't find without rendering, like missing aria-labels on icon buttons or div-onClick patterns).


## Reviewer Guidelines

### Focus Areas
- Workflow trigger (`pull_request_target`) -- needed for fork PRs to access repo secrets
- ACP prompt content -- does the checklist cover everything the team cares about?
- Concurrency settings -- cancels stale runs when a PR is updated

### Questions for Reviewers
- Should we gate this behind a label (e.g. `a11y-review`) instead of running on every PR?
- Any additional a11y checks the team wants included in the prompt?