### PR TITLE
Adds ACP jira acceptance criteria check for PRs

### DIFF
--- a/.github/JIRA_AC_CHECK.md
+++ b/.github/JIRA_AC_CHECK.md
@@ -1,0 +1,90 @@
+# Jira AC Check Workflow - Security Model
+
+## How It Works
+
+The `jira-ac-check.yml` workflow automatically reviews PRs against their linked Jira ticket's acceptance criteria using an AI agent.
+
+### Security Controls
+
+This workflow uses `pull_request_target`, which means it runs with write permissions in the context of the base repository (not the fork). To prevent malicious PRs from exploiting this:
+
+#### 1. **Label Gate** (Primary Control)
+PRs from external contributors require manual approval:
+- **Trusted contributors** (org members, collaborators, repo owners): runs automatically
+- **External/fork PRs**: require a maintainer to add the `safe-to-review` label
+
+When a fork PR is opened, the workflow posts a notice:
+> 👋 Thanks for your contribution! A maintainer will add the `safe-to-review` label to trigger the automated Jira AC check once the PR has been reviewed for safety.
+
+#### 2. **Input Validation** (Defense-in-Depth)
+Even after approval, untrusted inputs are validated:
+- Jira key must match `^FCN-[0-9]+$` (strict regex)
+- Additional sanitization strips all non-alphanumeric chars except hyphens
+- Only the sanitized key is used in the AI prompt
+
+#### 3. **Limited Permissions**
+The GitHub token is scoped to:
+- `contents: read` - can't modify code
+- `pull-requests: write` - can only comment on PRs
+- `issues: write` - can only comment on issues
+
+No access to secrets, workflows, or push permissions.
+
+## Usage
+
+### For Maintainers
+
+**To approve a fork PR for AI review:**
+1. Review the PR diff and description for malicious content
+2. Add the `safe-to-review` label
+3. The workflow will trigger automatically
+
+**Manual trigger:**
+```bash
+# Via GitHub UI: Actions → Jira AC Check → Run workflow
+# Specify PR number and optionally override the Jira key
+```
+
+### For Contributors
+
+**Org members/collaborators:**
+- Workflow runs automatically when you open/update a PR
+
+**External contributors:**
+- Workflow will post a notice when you open a PR
+- Wait for a maintainer to review and add `safe-to-review`
+- Include a Jira key in your PR title (e.g., `FCN-123: Add feature`)
+
+## Attack Surface Analysis
+
+| Vector | Risk | Mitigation |
+|--------|------|------------|
+| PR title | Low | Regex extraction `grep -oE 'FCN-[0-9]+'` only captures the key pattern |
+| PR body/diff | Medium | Label gate prevents untrusted execution; maintainer reviews before approval |
+| GitHub token | Low | Scoped to read + comment only; can't modify code or access secrets |
+| ACP credentials | Unknown | Depends on `ambient-action` implementation; should not expose secrets to agent |
+
+## Workflow Diagram
+
+```
+Fork PR opened
+    ↓
+Is author trusted? (member/collaborator/owner)
+    ↓ NO                          ↓ YES
+Post "waiting for approval"       Extract Jira key
+    ↓                              ↓
+Maintainer reviews                Validate format (FCN-###)
+    ↓                              ↓
+Add 'safe-to-review' label        Sanitize for prompt
+    ↓                              ↓
+    └──────────→ Run AI review ←──┘
+                      ↓
+                Post PR comment with findings
+```
+
+## References
+
+This pattern follows industry standards:
+- Kubernetes: `ok-to-test` label for fork PRs
+- OpenShift CI: `lgtm` label requirement
+- GitHub Security: [Keeping your GitHub Actions secure](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-pull_request_target)

--- a/.github/JIRA_AC_CHECK.md
+++ b/.github/JIRA_AC_CHECK.md
@@ -23,12 +23,12 @@ Even after approval, untrusted inputs are validated:
 - Only the sanitized key is used in the AI prompt
 
 #### 3. **Limited Permissions**
-The GitHub token is scoped to:
+The `GITHUB_TOKEN` is scoped to:
 - `contents: read` - can't modify code
 - `pull-requests: write` - can only comment on PRs
 - `issues: write` - can only comment on issues
 
-No access to secrets, workflows, or push permissions.
+The `GITHUB_TOKEN` has no access to repository secrets, workflows, or push permissions. However, three repository secrets (`ACP_API_URL`, `ACP_TOKEN`, `ACP_PROJECT`) are passed as inputs to `ambient-code/ambient-action`. These are used by the action to authenticate the AI agent session — they are not exposed as shell environment variables within the workflow steps themselves.
 
 ## Usage
 

--- a/.github/workflows/jira-ac-check.yml
+++ b/.github/workflows/jira-ac-check.yml
@@ -8,7 +8,7 @@ permissions:
 on:
   pull_request_target:
     branches: [main]
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       pr-number:
@@ -25,10 +25,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Post a notice if the workflow is waiting for approval
+  approval-notice:
+    name: Post Approval Notice
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'opened' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      !contains(github.event.pull_request.labels.*.name, 'safe-to-review')
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post notice
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "👋 Thanks for your contribution! A maintainer will add the \`safe-to-review\` label to trigger the automated Jira AC check once the PR has been reviewed for safety."
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   jira-ac-check:
     name: Jira Acceptance Criteria Check
     runs-on: ubuntu-latest
+    # Security: Only run on PRs from trusted contributors or when manually approved
+    # Fork PRs require a maintainer to add the 'safe-to-review' label first
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'OWNER' ||
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      contains(github.event.pull_request.labels.*.name, 'safe-to-review')
     steps:
+      # Security: Extract and validate Jira key from untrusted PR title
+      # This runs in pull_request_target context, so PR title is untrusted input
       - name: Extract Jira key from PR title
         id: jira
         env:
@@ -36,15 +66,17 @@ jobs:
           MANUAL_KEY: ${{ github.event.inputs.jira-key || '' }}
         run: |
           if [ -n "$MANUAL_KEY" ]; then
-            echo "key=$MANUAL_KEY" >> "$GITHUB_OUTPUT"
+            KEY="$MANUAL_KEY"
           else
             KEY=$(echo "$PR_TITLE" | grep -oE 'FCN-[0-9]+' | head -1)
-            if [ -z "$KEY" ]; then
-              echo "No Jira key found in PR title: $PR_TITLE"
-              echo "key=" >> "$GITHUB_OUTPUT"
-            else
-              echo "key=$KEY" >> "$GITHUB_OUTPUT"
-            fi
+          fi
+
+          # Validate that the key strictly matches the expected format
+          if [[ "$KEY" =~ ^FCN-[0-9]+$ ]]; then
+            echo "key=$KEY" >> "$GITHUB_OUTPUT"
+          else
+            echo "No valid Jira key found (expected format: FCN-####)"
+            echo "key=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Skip if no Jira key
@@ -52,6 +84,16 @@ jobs:
         run: |
           echo "No Jira ticket key found in PR title. Skipping AC check."
           echo "To run manually, use workflow_dispatch with the jira-key input."
+
+      # Security: Defense-in-depth sanitization before using in AI prompt
+      # Prevents prompt injection even if regex validation is bypassed
+      - name: Sanitize Jira key for prompt
+        if: steps.jira.outputs.key != ''
+        id: sanitize
+        run: |
+          # Additional safety: ensure no newlines or special chars in the key
+          SANITIZED=$(echo "${{ steps.jira.outputs.key }}" | tr -cd 'A-Z0-9-')
+          echo "safe_key=$SANITIZED" >> "$GITHUB_OUTPUT"
 
       - name: Run ACP Jira AC review
         if: steps.jira.outputs.key != ''
@@ -63,12 +105,12 @@ jobs:
           prompt: |
             You are a PR reviewer checking whether a pull request satisfies the acceptance criteria from its linked Jira ticket.
 
-            Jira ticket: ${{ steps.jira.outputs.key }}
+            Jira ticket: ${{ steps.sanitize.outputs.safe_key }}
             PR: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.inputs.pr-number }}
 
             Steps:
 
-            1. Wait 10-15 seconds for the Jira MCP to initialize, then use the Atlassian MCP to read the Jira ticket ${{ steps.jira.outputs.key }} and extract the acceptance criteria.
+            1. Wait 10-15 seconds for the Jira MCP to initialize, then use the Atlassian MCP to read the Jira ticket ${{ steps.sanitize.outputs.safe_key }} and extract the acceptance criteria.
 
             1b. If the ticket has no acceptance criteria field or it is empty, note this in your comment and review the PR against its own stated goals in the PR description instead. Do not fail or block -- just note the limitation transparently.
 
@@ -81,9 +123,9 @@ jobs:
 
                Format the comment as:
 
-               ## PR Review: ${{ steps.jira.outputs.key }} — <PR title>
+               ## PR Review: ${{ steps.sanitize.outputs.safe_key }} — <PR title>
 
-               Reviewed against the acceptance criteria in ${{ steps.jira.outputs.key }}.
+               Reviewed against the acceptance criteria in ${{ steps.sanitize.outputs.safe_key }}.
 
                ### Acceptance Criteria Checklist
 

--- a/.github/workflows/jira-ac-check.yml
+++ b/.github/workflows/jira-ac-check.yml
@@ -57,8 +57,8 @@ jobs:
         if: steps.jira.outputs.key != ''
         uses: ambient-code/ambient-action@3f01516d00ba5628f210f9390a98970b5567c835 # v0.0.5
         with:
-          api-url: ${{ secrets.AMBIENT_API_URL }}
-          api-token: ${{ secrets.AMBIENT_BOT_TOKEN }}
+          api-url: ${{ secrets.ACP_API_URL }}
+          api-token: ${{ secrets.ACP_TOKEN }}
           project: ${{ secrets.ACP_PROJECT }}
           prompt: |
             You are a PR reviewer checking whether a pull request satisfies the acceptance criteria from its linked Jira ticket.

--- a/.github/workflows/jira-ac-check.yml
+++ b/.github/workflows/jira-ac-check.yml
@@ -1,5 +1,10 @@
 name: Jira AC Check
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 on:
   pull_request_target:
     branches: [main]
@@ -50,7 +55,7 @@ jobs:
 
       - name: Run ACP Jira AC review
         if: steps.jira.outputs.key != ''
-        uses: ambient-code/ambient-action@v2
+        uses: ambient-code/ambient-action@3f01516d00ba5628f210f9390a98970b5567c835 # v0.0.5
         with:
           api-url: ${{ secrets.AMBIENT_API_URL }}
           api-token: ${{ secrets.AMBIENT_BOT_TOKEN }}

--- a/.github/workflows/jira-ac-check.yml
+++ b/.github/workflows/jira-ac-check.yml
@@ -64,11 +64,18 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title || '' }}
           MANUAL_KEY: ${{ github.event.inputs.jira-key || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr-number || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ -n "$MANUAL_KEY" ]; then
             KEY="$MANUAL_KEY"
           else
-            KEY=$(echo "$PR_TITLE" | grep -oE 'FCN-[0-9]+' | head -1)
+            TITLE="$PR_TITLE"
+            # workflow_dispatch doesn't have pull_request.title — fetch it
+            if [ -z "$TITLE" ] && [ -n "$PR_NUMBER" ]; then
+              TITLE=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json title --jq .title 2>/dev/null || echo "")
+            fi
+            KEY=$(printf '%s\n' "$TITLE" | grep -oE 'FCN-[0-9]+' | head -1)
           fi
 
           # Validate that the key strictly matches the expected format

--- a/.github/workflows/jira-ac-check.yml
+++ b/.github/workflows/jira-ac-check.yml
@@ -1,0 +1,98 @@
+name: Jira AC Check
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: PR number to review
+        required: true
+        type: number
+      jira-key:
+        description: Jira ticket key (e.g. FCN-325). If empty, extracted from PR title.
+        required: false
+        type: string
+
+concurrency:
+  group: jira-ac-check-${{ github.event.pull_request.number || github.event.inputs.pr-number }}
+  cancel-in-progress: true
+
+jobs:
+  jira-ac-check:
+    name: Jira Acceptance Criteria Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract Jira key from PR title
+        id: jira
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
+          MANUAL_KEY: ${{ github.event.inputs.jira-key || '' }}
+        run: |
+          if [ -n "$MANUAL_KEY" ]; then
+            echo "key=$MANUAL_KEY" >> "$GITHUB_OUTPUT"
+          else
+            KEY=$(echo "$PR_TITLE" | grep -oE 'FCN-[0-9]+' | head -1)
+            if [ -z "$KEY" ]; then
+              echo "No Jira key found in PR title: $PR_TITLE"
+              echo "key=" >> "$GITHUB_OUTPUT"
+            else
+              echo "key=$KEY" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+      - name: Skip if no Jira key
+        if: steps.jira.outputs.key == ''
+        run: |
+          echo "No Jira ticket key found in PR title. Skipping AC check."
+          echo "To run manually, use workflow_dispatch with the jira-key input."
+
+      - name: Run ACP Jira AC review
+        if: steps.jira.outputs.key != ''
+        uses: ambient-code/ambient-action@v2
+        with:
+          api-url: ${{ secrets.AMBIENT_API_URL }}
+          api-token: ${{ secrets.AMBIENT_BOT_TOKEN }}
+          project: ${{ secrets.ACP_PROJECT }}
+          prompt: |
+            You are a PR reviewer checking whether a pull request satisfies the acceptance criteria from its linked Jira ticket.
+
+            Jira ticket: ${{ steps.jira.outputs.key }}
+            PR: https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number || github.event.inputs.pr-number }}
+
+            Steps:
+
+            1. Wait 10-15 seconds for the Jira MCP to initialize, then use the Atlassian MCP to read the Jira ticket ${{ steps.jira.outputs.key }} and extract the acceptance criteria.
+
+            2. Use gh pr view ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }} and gh pr diff ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }} to read the PR description and code changes.
+
+            3. For each acceptance criterion, check whether the PR addresses it. Be specific -- reference actual code changes, file names, and line ranges.
+
+            4. Post your review as a comment on the PR using:
+               gh pr comment ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }} --body "YOUR_COMMENT"
+
+               Format the comment as:
+
+               ## PR Review: ${{ steps.jira.outputs.key }} — <PR title>
+
+               Reviewed against the acceptance criteria in ${{ steps.jira.outputs.key }}.
+
+               ### Acceptance Criteria Checklist
+
+               | # | AC Item | Status | Evidence |
+               |---|---------|--------|----------|
+               | 1 | <criterion> | Met / Partially Met / Not Met | <specific evidence from the PR> |
+               | 2 | ... | ... | ... |
+
+               ### Additional Observations
+               Note anything that doesn't map to a specific AC but is worth calling out (e.g. scope creep, missing edge cases, test coverage gaps).
+
+               ### Summary
+               One paragraph overall assessment of whether the PR satisfies the ticket.
+
+            5. If the Jira MCP fails to access the ticket, base the review on the PR's own stated goals and diff. Note the limitation transparently in the comment.
+
+            6. Only review what's in the PR diff. Do not review the entire codebase.
+          wait: 'true'
+          timeout: '30'

--- a/.github/workflows/jira-ac-check.yml
+++ b/.github/workflows/jira-ac-check.yml
@@ -65,6 +65,8 @@ jobs:
 
             1. Wait 10-15 seconds for the Jira MCP to initialize, then use the Atlassian MCP to read the Jira ticket ${{ steps.jira.outputs.key }} and extract the acceptance criteria.
 
+            1b. If the ticket has no acceptance criteria field or it is empty, note this in your comment and review the PR against its own stated goals in the PR description instead. Do not fail or block -- just note the limitation transparently.
+
             2. Use gh pr view ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }} and gh pr diff ${{ github.event.pull_request.number || github.event.inputs.pr-number }} --repo ${{ github.repository }} to read the PR description and code changes.
 
             3. For each acceptance criterion, check whether the PR addresses it. Be specific -- reference actual code changes, file names, and line ranges.


### PR DESCRIPTION
## Why a workflow and not just a Cursor skill?

This is inherently a PR-level concern -- comparing a finalized diff against Jira acceptance criteria. It doesn't make sense as a local skill because your diff isn't finalized until you push. As a workflow, it runs automatically on every PR without anyone needing to remember to trigger it, and it works regardless of what IDE you use.

## Description

Adds a GitHub Actions workflow that automatically checks whether a PR satisfies the acceptance criteria from its linked Jira ticket. Uses ACP (Ambient Code Platform) via `ambient-code/ambient-action@v2` to read the Jira ticket AC, compare it against the PR diff, and post a structured review comment.

The workflow extracts the Jira key from the PR title (e.g. `FCN-325`), waits for the Jira MCP to initialize, reads the AC, then reviews the PR diff against each criterion with specific file/line references. If no Jira key is found in the title, it skips gracefully.

Uses `pull_request_target` so it works for PRs from forks (which is how the team works).

This is the same workflow we demoed at the hackathon, now automated as a GitHub Action.

**Jira issue #** N/A (infrastructure/tooling)


## Type of Change

- [x] New feature/enhancement (non-breaking change which adds functionality)
- [x] Infrastructure/build change


## Testing

### Manual Testing

**Test Steps:**
1. Merge this and configure repo secrets (`AMBIENT_API_URL`, `AMBIENT_BOT_TOKEN`, `ACP_PROJECT`)
2. Open a PR with a Jira ticket key in the title (e.g. `FCN-325 do something`)
3. Verify the ACP Jira AC review comment appears on the PR
4. Open a PR without a Jira key in the title and verify it skips gracefully

**Test Environment:**
- [x] Tested locally (YAML validation, workflow syntax)
- [x] Prompt tested manually via ACP session during hackathon demo

### Automated Testing

**Unit Tests:**
- [ ] N/A -- this is a workflow file, no unit tests applicable


## Screenshots/Recordings

N/A -- workflow file only, no UI changes


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Dependencies
- [ ] Any dependent changes have been merged and published
  - Requires repo secrets to be configured: `AMBIENT_API_URL`, `AMBIENT_BOT_TOKEN`, `ACP_PROJECT`
  - Requires ACP project with Atlassian MCP enabled


## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No


## Additional Notes

This workflow won't do anything until the repo secrets are configured. Once secrets are set, it runs automatically on every PR that has a Jira key in its title.

The workflow also supports `workflow_dispatch` so you can manually trigger it from the GitHub Actions tab for any PR + ticket combo, which is useful for re-running or testing on older PRs.

If the Jira MCP fails to access a ticket (e.g. permissions), the review falls back to the PR's own stated goals and notes the limitation.


## Reviewer Guidelines

### Focus Areas
- Jira key extraction regex -- currently matches `FCN-\d+`, adjust if the team uses other project prefixes
- ACP prompt content -- does the review format match what the team expects?
- Skip behavior when no Jira key is found

### Questions for Reviewers
- Should we support other Jira project prefixes besides `FCN`?
- Any additional context the prompt should include (e.g. epic context, linked tickets)?