### PR TITLE
Add CLAUDE.md for Claude Code users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Description

Claude Code doesn't read AGENTS.md natively, so team members using it get no project context. This adds a one-line CLAUDE.md that imports AGENTS.md via the @import syntax, so both tools share the same source of truth.

**Jira issue #** [FCN-400](https://redhat.atlassian.net/browse/FCN-400)

## Type of Change

- [x] Configuration change

## Testing

### Manual Testing

**Test Steps:**
1. Verified CLAUDE.md contains `@AGENTS.md`
2. Ran lint, type-check, prettier — all clean (pre-existing issues only)

**Test Environment:**
- [x] Tested locally

### Automated Testing

N/A — markdown file only, no code changes.

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Dependencies
- [x] Any dependent changes have been merged and published

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

## Additional Notes

Claude Code only reads CLAUDE.md, not AGENTS.md. The `@AGENTS.md` syntax is Claude Code's import mechanism, so it pulls in the full AGENTS.md content. If Anthropic adds native AGENTS.md support later, this file can be deleted.

[FCN-400]: https://redhat.atlassian.net/browse/FCN-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ