### PR TITLE
FCN-410 New required validation message

### DIFF
--- a/src/components/Wizards/ROSAHCPWizard/stringsProvider/rosaHcpWizardStrings.defaults.ts
+++ b/src/components/Wizards/ROSAHCPWizard/stringsProvider/rosaHcpWizardStrings.defaults.ts
@@ -393,6 +393,7 @@ export const defaultRosaHcpWizardStrings: RosaHcpWizardStrings = {
 
 /** Default validation messages (English). Keep function signatures when translating. */
 export const defaultRosaHcpWizardValidatorStrings: RosaHcpWizardValidatorStrings = {
+  commonRequired: 'This field is required',
   clusterName: {
     maxLength: 'This value can contain at most 54 characters',
     invalidChars: "This value can only contain lowercase alphanumeric characters or '-' or '.'",

--- a/src/components/Wizards/ROSAHCPWizard/stringsProvider/rosaHcpWizardStrings.types.ts
+++ b/src/components/Wizards/ROSAHCPWizard/stringsProvider/rosaHcpWizardStrings.types.ts
@@ -133,6 +133,8 @@ export type RosaHcpWizardHostPrefixValidatorStrings = {
 };
 
 export type RosaHcpWizardValidatorStrings = {
+  /** Generic empty required-field message for Yup checks (override via `strings.validators.commonRequired`). */
+  commonRequired: string;
   clusterName: RosaHcpWizardClusterNameValidatorStrings;
   operatorRolesPrefix: RosaHcpWizardOperatorRolesPrefixValidatorStrings;
   kmsKeyArn: RosaHcpWizardKmsKeyValidatorStrings;

--- a/src/components/Wizards/ROSAHCPWizard/yupSchemas/detailsFields.ts
+++ b/src/components/Wizards/ROSAHCPWizard/yupSchemas/detailsFields.ts
@@ -3,12 +3,13 @@ import * as yup from 'yup';
 import { STEP_IDS } from '../constants';
 import type { ClusterFormData } from '../../types';
 import type { WizardFieldMeta } from './types';
-import { ctx, requiredMessage, validateClusterNameSync } from './helpers';
+import { ctx, rosaCommonRequiredNonEmptyTest, validateClusterNameSync } from './helpers';
 
 export const nameSchema = yup
   .string()
   .default('')
-  .required(requiredMessage)
+  .test(rosaCommonRequiredNonEmptyTest)
+  .required()
   .meta({
     id: 'name',
     labelKey: 'details.clusterNameLabel',
@@ -37,7 +38,8 @@ export const nameSchema = yup
 export const clusterVersionSchema = yup
   .string()
   .default('')
-  .required(requiredMessage)
+  .test(rosaCommonRequiredNonEmptyTest)
+  .required()
   .meta({
     id: 'cluster_version',
     labelKey: 'details.openShiftVersionLabel',
@@ -50,7 +52,8 @@ export const clusterVersionSchema = yup
 export const associatedAwsIdSchema = yup
   .string()
   .default('')
-  .required(requiredMessage)
+  .test(rosaCommonRequiredNonEmptyTest)
+  .required()
   .meta({
     id: 'associated_aws_id',
     labelKey: 'details.awsInfraLabel',
@@ -64,7 +67,8 @@ export const associatedAwsIdSchema = yup
 export const billingAccountIdSchema = yup
   .string()
   .default('')
-  .required(requiredMessage)
+  .test(rosaCommonRequiredNonEmptyTest)
+  .required()
   .meta({
     id: 'billing_account_id',
     labelKey: 'details.billingLabel',
@@ -79,7 +83,8 @@ export const billingAccountIdSchema = yup
 export const regionSchema = yup
   .string()
   .default('')
-  .required(requiredMessage)
+  .test(rosaCommonRequiredNonEmptyTest)
+  .required()
   .meta({
     id: 'region',
     labelKey: 'details.regionLabel',

--- a/src/components/Wizards/ROSAHCPWizard/yupSchemas/helpers.ts
+++ b/src/components/Wizards/ROSAHCPWizard/yupSchemas/helpers.ts
@@ -77,6 +77,36 @@ export function findOverlappingCidrFields(
   return overlapping;
 }
 
-export const requiredMessage = (_params: yup.TestContext) => {
-  return 'This field is required';
+/**
+ * Yup test (use before `.required()` on the same chain) so the message comes from
+ * {@link RosaHcpWizardValidatorStrings.commonRequired} (override via `strings.validators.commonRequired`
+ * on {@link RosaHCPWizard} / the strings provider).
+ *
+ * Treats a value as **missing** when it is `null`/`undefined`, an empty string, or an empty array.
+ * Non-empty strings, non-empty arrays, and non-null objects (e.g. a selected VPC record from the machine pools step)
+ * count as present. Yup’s `.required(fn)` message callbacks do not receive validation `context`, so this
+ * pattern is required for contextual copy.
+ */
+export function rosaRequiredPresentValue(
+  this: yup.TestContext,
+  value: unknown
+): true | yup.ValidationError {
+  if (value == null) {
+    return this.createError({ message: ctx(this).msgs.commonRequired });
+  }
+  if (typeof value === 'string' && value.length === 0) {
+    return this.createError({ message: ctx(this).msgs.commonRequired });
+  }
+  if (Array.isArray(value) && value.length === 0) {
+    return this.createError({ message: ctx(this).msgs.commonRequired });
+  }
+  return true;
+}
+
+/** Use on `string` / `mixed` / `array` schemas before `.required()` — see {@link rosaRequiredPresentValue}. */
+export const rosaCommonRequiredNonEmptyTest = {
+  name: 'rosa-common-required-nonempty',
+  exclusive: true,
+  skipAbsent: true,
+  test: rosaRequiredPresentValue,
 };

--- a/src/components/Wizards/ROSAHCPWizard/yupSchemas/machinePoolsFields.ts
+++ b/src/components/Wizards/ROSAHCPWizard/yupSchemas/machinePoolsFields.ts
@@ -2,10 +2,11 @@ import * as yup from 'yup';
 
 import { STEP_IDS } from '../constants';
 import type { WizardFieldMeta } from './types';
-import { ctx } from './helpers';
+import { ctx, rosaCommonRequiredNonEmptyTest } from './helpers';
 
 export const selectedVpcSchema = yup
   .mixed()
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'selected_vpc',
@@ -20,6 +21,7 @@ export const selectedVpcSchema = yup
 export const machinePoolsSubnetsSchema = yup
   .array()
   .default([])
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'machine_pools_subnets',
@@ -31,6 +33,7 @@ export const machinePoolsSubnetsSchema = yup
 
 export const machineTypeSchema = yup
   .string()
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'machine_type',

--- a/src/components/Wizards/ROSAHCPWizard/yupSchemas/networkingFields.ts
+++ b/src/components/Wizards/ROSAHCPWizard/yupSchemas/networkingFields.ts
@@ -23,11 +23,13 @@ import {
   getStartingIP,
   isCidrSubnetAddress,
   isValidCidr,
+  rosaCommonRequiredNonEmptyTest,
 } from './helpers';
 
 export const clusterPrivacySchema = yup
   .string()
   .default(ClusterNetwork.external)
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'cluster_privacy',

--- a/src/components/Wizards/ROSAHCPWizard/yupSchemas/rolesAndPoliciesFields.ts
+++ b/src/components/Wizards/ROSAHCPWizard/yupSchemas/rolesAndPoliciesFields.ts
@@ -2,11 +2,12 @@ import * as yup from 'yup';
 
 import { DNS_LABEL_REGEXP, MAX_CUSTOM_OPERATOR_ROLES_PREFIX_LENGTH, STEP_IDS } from '../constants';
 import type { WizardFieldMeta } from './types';
-import { ctx } from './helpers';
+import { ctx, rosaCommonRequiredNonEmptyTest } from './helpers';
 
 export const installerRoleArnSchema = yup
   .string()
   .default('')
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'installer_role_arn',
@@ -19,6 +20,7 @@ export const installerRoleArnSchema = yup
 export const supportRoleArnSchema = yup
   .string()
   .default('')
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'support_role_arn',
@@ -30,6 +32,7 @@ export const supportRoleArnSchema = yup
 export const workerRoleArnSchema = yup
   .string()
   .default('')
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'worker_role_arn',
@@ -41,6 +44,7 @@ export const workerRoleArnSchema = yup
 export const byoOidcConfigIdSchema = yup
   .string()
   .default('')
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'byo_oidc_config_id',
@@ -53,6 +57,7 @@ export const byoOidcConfigIdSchema = yup
 export const customOperatorRolesPrefixSchema = yup
   .string()
   .default('')
+  .test(rosaCommonRequiredNonEmptyTest)
   .required()
   .meta({
     id: 'custom_operator_roles_prefix',

--- a/src/components/Wizards/ROSAHCPWizard/yupSchemas/yupSchemas.test.ts
+++ b/src/components/Wizards/ROSAHCPWizard/yupSchemas/yupSchemas.test.ts
@@ -89,7 +89,7 @@ function buildFormData(overrides: Partial<ClusterFormData> = {}): Partial<Cluste
     byo_oidc_config_id: 'oidc-123',
     custom_operator_roles_prefix: 'mycluster-a1b2',
     selected_vpc: 'vpc-123',
-    machine_pools_subnets: [],
+    machine_pools_subnets: [{ machine_pool_subnet: 'subnet-123' }],
     machine_type: 'm5.xlarge',
     cluster_privacy: 'external' as ClusterFormData['cluster_privacy'],
     network_machine_cidr: '10.0.0.0/16',
@@ -302,6 +302,42 @@ describe('yupSchemas – composed clusterValidationSchema', () => {
         field
       );
       expect(error).toBeNull();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Machine pools — required presence (string | VPC, subnet array)
+  // -----------------------------------------------------------------------
+  describe('machine pools required fields', () => {
+    it('selected_vpc accepts a VPC object (mixed)', async () => {
+      const error = await validate(
+        buildContext(),
+        buildFormData({
+          selected_vpc: { id: 'vpc-abc', name: 'my-vpc', aws_subnets: [] },
+        }),
+        'selected_vpc'
+      );
+      expect(error).toBeNull();
+    });
+
+    it('machine_pools_subnets accepts a non-empty array', async () => {
+      const error = await validate(
+        buildContext(),
+        buildFormData({
+          machine_pools_subnets: [{ machine_pool_subnet: 'subnet-a' }],
+        }),
+        'machine_pools_subnets'
+      );
+      expect(error).toBeNull();
+    });
+
+    it('machine_pools_subnets rejects empty array with common required message', async () => {
+      const error = await validate(
+        buildContext(),
+        buildFormData({ machine_pools_subnets: [] }),
+        'machine_pools_subnets'
+      );
+      expect(error).toBe(msgs.commonRequired);
     });
   });
 


### PR DESCRIPTION
# Pull request description

<!-- Paste into GitHub when opening/updating the PR. Filled from team template + review. -->

## Description

Extends the shared Yup “required with context” pattern so it works it trigger validation when a required field is "empty".  The displayed message comes from the string props so it can be changed/i18n.

**Jira issue #** [FCN-410](https://redhat.atlassian.net/browse/FCN-410)

**Backport of** #

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):

## Testing

### Manual Testing

**Test Steps:**

1. Go to storybook
2. On the details page click into the name field and then click outside.  This should trigger the empty required validation message
3. Ensure that validation messages says "This field is required".

**Test Environment:**

- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**Unit Tests:**

- [x] Unit tests added/updated
- [x] All unit tests pass (`npm run test` / `npm run test:all`)

## Checklist

_(Mark what you actually did: self-review, stories, a11y, deps, etc. — see `.github/pull_request_template.md`.)_

## Breaking Changes

**Does this PR introduce breaking changes?**

- [ ] Yes
- [x] No



## Additional Notes



[FCN-410]: https://redhat.atlassian.net/browse/FCN-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ