### PR TITLE
FCN-472 add jest unit tests to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,24 @@ jobs:
       - name: Run TypeScript type checking
         run: npm run type-check
 
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Jest unit tests
+        run: npm test -- --no-coverage
+
   test:
     name: Component Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+      - name: Install subpackage dependencies
+        run: cd packages/react-form-wizard && npm ci
 
       - name: Run Jest unit tests
         run: npm test -- --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jest-coverage
           path: coverage/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,15 @@ jobs:
         run: npm ci
 
       - name: Run Jest unit tests
-        run: npm test -- --no-coverage
+        run: npm test -- --coverage
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jest-coverage
+          path: coverage/
+          retention-days: 14
 
   test:
     name: Component Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: 'package.json'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Description

Jest tests have been growing as part of the yup schema work but weren't running in CI. Failures only surface if someone runs `npm run test:all` locally, which means regressions can slip through on PRs. This adds a `unit-test` job to the CI workflow and uploads a `jest-coverage` artifact for EPD coverage ingestion.

**Jira issue #** [FCN-472](https://redhat.atlassian.net/browse/FCN-472)

**Backport of** #


## Type of Change

- [x] Infrastructure/build change


## Testing

### Manual Testing

**Test Steps:**
1. Rebased branch on latest `main`
2. Ran `npm test -- --no-coverage`
3. Confirmed CI workflow updates for unit test + coverage artifact upload

**Observed results:**
- `Test Suites: 10 passed, 10 total`
- `Tests: 196 passed, 196 total`

**Test Environment:**
- [x] Tested locally

### Automated Testing

**Unit Tests:**
- [x] All unit tests pass (npm run test)


## Screenshots/Recordings

N/A, CI config change only


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Dependencies
- [ ] Any dependent changes have been merged and published

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No


[FCN-472]: https://redhat.atlassian.net/browse/FCN-472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ