### PR TITLE
FCN-369 Create resetFieldsToDefaultValues helper

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.test.ts
@@ -1,0 +1,26 @@
+import type { UseFormSetValue } from 'react-hook-form';
+
+import type { ROSAHCPCluster } from './types';
+import { getClusterValidationSchemaDefaultValues } from './yupSchemas';
+
+import { resetFieldsToDefaultValues } from './resetFieldsToDefaultValues';
+
+describe('resetFieldsToDefaultValues', () => {
+  it('sets each field from form defaults', () => {
+    const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+    const defaults = getClusterValidationSchemaDefaultValues();
+
+    resetFieldsToDefaultValues(setValue, ['name', 'autoscaling']);
+
+    expect(setValue).toHaveBeenCalledWith('name', defaults.name, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('autoscaling', defaults.autoscaling, expect.any(Object));
+  });
+
+  it('clears selected_vpc when it is omitted from form defaults', () => {
+    const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+
+    resetFieldsToDefaultValues(setValue, ['selected_vpc']);
+
+    expect(setValue).toHaveBeenCalledWith('selected_vpc', undefined, expect.any(Object));
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.test.ts
@@ -12,8 +12,16 @@ describe('resetFieldsToDefaultValues', () => {
 
     resetFieldsToDefaultValues(setValue, ['name', 'autoscaling']);
 
-    expect(setValue).toHaveBeenCalledWith('name', defaults.name, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('autoscaling', defaults.autoscaling, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('name', defaults.name, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: false,
+    });
+    expect(setValue).toHaveBeenCalledWith('autoscaling', defaults.autoscaling, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: false,
+    });
   });
 
   it('clears selected_vpc when it is omitted from form defaults', () => {
@@ -21,6 +29,10 @@ describe('resetFieldsToDefaultValues', () => {
 
     resetFieldsToDefaultValues(setValue, ['selected_vpc']);
 
-    expect(setValue).toHaveBeenCalledWith('selected_vpc', undefined, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('selected_vpc', undefined, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: false,
+    });
   });
 });

--- a/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.ts
@@ -1,9 +1,9 @@
-import type { FieldPath, FieldPathValue, UseFormSetValue } from 'react-hook-form';
+import type { FieldPathValue, UseFormSetValue } from 'react-hook-form';
 
 import type { ROSAHCPCluster } from './types';
 import { getClusterValidationSchemaDefaultValues } from './yupSchemas';
 
-type FormPath = FieldPath<Partial<ROSAHCPCluster>>;
+type FormPath = Extract<keyof ROSAHCPCluster, string>;
 
 export type ResetFieldsToDefaultValuesOptions = {
   shouldDirty?: boolean;

--- a/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/resetFieldsToDefaultValues.ts
@@ -1,0 +1,31 @@
+import type { FieldPath, FieldPathValue, UseFormSetValue } from 'react-hook-form';
+
+import type { ROSAHCPCluster } from './types';
+import { getClusterValidationSchemaDefaultValues } from './yupSchemas';
+
+type FormPath = FieldPath<Partial<ROSAHCPCluster>>;
+
+export type ResetFieldsToDefaultValuesOptions = {
+  shouldDirty?: boolean;
+  shouldTouch?: boolean;
+  shouldValidate?: boolean;
+};
+
+/** Sets form fields back to {@link getClusterValidationSchemaDefaultValues} (or `undefined` when omitted). */
+export function resetFieldsToDefaultValues(
+  setValue: UseFormSetValue<Partial<ROSAHCPCluster>>,
+  fieldNames: readonly FormPath[],
+  options: ResetFieldsToDefaultValuesOptions = {}
+): void {
+  const defaults = getClusterValidationSchemaDefaultValues();
+  const setOpts = {
+    shouldDirty: options.shouldDirty ?? true,
+    shouldTouch: options.shouldTouch ?? false,
+    shouldValidate: options.shouldValidate ?? false,
+  };
+
+  for (const name of fieldNames) {
+    const value = (defaults as Record<string, unknown>)[name];
+    setValue(name, value as FieldPathValue<Partial<ROSAHCPCluster>, typeof name>, setOpts);
+  }
+}


### PR DESCRIPTION
## Description

Adds a reusable ROSA HCP wizard helper that resets selected react-hook-form fields to values from `getClusterValidationSchemaDefaultValues()`, with configurable `shouldDirty`, `shouldTouch`, and `shouldValidate` options passed through to `setValue`. Fields omitted from the Yup defaults object (for example `selected_vpc`) are cleared to `undefined`.

This commit introduces the utility and Jest coverage only; consumers can wire it into field-dependency flows in follow-up work.

**Jira issue #** [FCN-369](https://redhat.atlassian.net/browse/FCN-369)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. From the repo root, run `npm test` .


**Test Environment:**
- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)

**Unit Tests:**
- [x] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A — no UI changes in this commit.

### Before

N/A

### After

N/A


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes



## Reviewer Guidelines

### Focus Areas



### Questions for Reviewers

- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-369]: https://redhat.atlassian.net/browse/FCN-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ