### PR TITLE
FCN-484 emit canonical test-coverage-data artifact for EPD consumption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,14 +78,16 @@ jobs:
         run: cd packages/react-form-wizard && npm ci
 
       - name: Run Jest unit tests
-        run: npm test -- --coverage
+        run: npm test -- --coverage --json --outputFile=test-results/jest-results.json
 
       - name: Upload coverage artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: jest-coverage
-          path: coverage/
+          path: |
+            coverage/
+            test-results/jest-results.json
           retention-days: 14
 
   test:
@@ -194,15 +196,69 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
-        run: npm run test:e2e
+        env:
+          PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/playwright-e2e-results.json
+        run: npx playwright test --reporter=list,html,json
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          path: |
+            playwright-report/
+            test-results/playwright-e2e-results.json
           retention-days: 7
+
+  coverage-contract:
+    name: Assemble Coverage Contract
+    runs-on: ubuntu-latest
+    needs: [unit-test, test, e2e]
+    if: always()
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Download jest coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: jest-coverage
+          path: artifacts/jest-coverage
+        continue-on-error: true
+
+      - name: Download CT report artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: playwright-ct-report
+          path: artifacts/playwright-ct-report
+        continue-on-error: true
+
+      - name: Download E2E report artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: playwright-report
+          path: artifacts/playwright-report
+        continue-on-error: true
+
+      - name: Build test-coverage-data.json
+        run: |
+          node utils/build-test-coverage-data.mjs \
+            --jest-results artifacts/jest-coverage/test-results/jest-results.json \
+            --ct-summary artifacts/playwright-ct-report/test-results/playwright-ct-summary.json \
+            --e2e-results artifacts/playwright-report/test-results/playwright-e2e-results.json \
+            --output test-coverage-data.json
+
+      - name: Upload canonical coverage contract
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: test-coverage-data
+          path: test-coverage-data.json
+          retention-days: 30
 
   storybook:
     name: Build Storybook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
         run: cd packages/react-form-wizard && npm ci
 
       - name: Run Jest unit tests
-        run: npm test -- --coverage --json --outputFile=test-results/jest-results.json
+        run: |
+          mkdir -p test-results
+          npm test -- --coverage --json --outputFile=test-results/jest-results.json
 
       - name: Upload coverage artifact
         if: always()
@@ -198,7 +200,9 @@ jobs:
       - name: Run Playwright tests
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: test-results/playwright-e2e-results.json
-        run: npx playwright test --reporter=list,html,json
+        run: |
+          mkdir -p test-results
+          npx playwright test --reporter=list,html,json
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/utils/build-test-coverage-data.mjs
+++ b/utils/build-test-coverage-data.mjs
@@ -1,0 +1,242 @@
+#!/usr/bin/env node
+
+/**
+ * assembles unit (jest) + component (playwright CT) + e2e (playwright) results
+ * into a single test-coverage-data.json artifact that EPD consumes.
+ *
+ * inputs (all optional — missing sources produce zeroed sections):
+ *   --jest-results    path to jest JSON output (jest --json --outputFile=...)
+ *   --ct-summary      path to playwright-ct-summary.json
+ *   --e2e-results     path to playwright e2e JSON output
+ *   --output          path to write test-coverage-data.json (default: test-coverage-data.json)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const opts = {
+    jestResults: null,
+    ctSummary: null,
+    e2eResults: null,
+    output: 'test-coverage-data.json',
+  };
+
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--jest-results' && next) {
+      opts.jestResults = next;
+      i += 1;
+    } else if (arg === '--ct-summary' && next) {
+      opts.ctSummary = next;
+      i += 1;
+    } else if (arg === '--e2e-results' && next) {
+      opts.e2eResults = next;
+      i += 1;
+    } else if (arg === '--output' && next) {
+      opts.output = next;
+      i += 1;
+    }
+  }
+
+  return opts;
+}
+
+function readJson(filePath) {
+  if (!filePath || !fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function emptySuite(framework) {
+  return { framework, total: 0, passed: 0, failed: 0, skipped: 0, duration_s: 0, files: [] };
+}
+
+function buildUnitSection(jestData) {
+  if (!jestData || !jestData.testResults) return emptySuite('jest');
+
+  let total = 0;
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let durationMs = 0;
+  const files = [];
+
+  for (const suite of jestData.testResults) {
+    const fileTests = suite.assertionResults?.length || 0;
+    const filePassed = suite.assertionResults?.filter((t) => t.status === 'passed').length || 0;
+    const fileFailed = suite.assertionResults?.filter((t) => t.status === 'failed').length || 0;
+    const fileSkipped =
+      suite.assertionResults?.filter((t) => t.status === 'pending' || t.status === 'skipped')
+        .length || 0;
+    const fileDuration = (suite.endTime || 0) - (suite.startTime || 0);
+
+    total += fileTests;
+    passed += filePassed;
+    failed += fileFailed;
+    skipped += fileSkipped;
+    durationMs += fileDuration;
+
+    if (fileTests > 0) {
+      files.push({
+        name: suite.name ? path.relative(process.cwd(), suite.name) : 'unknown',
+        tests: fileTests,
+        passed: filePassed,
+        failed: fileFailed,
+        skipped: fileSkipped,
+        duration_ms: Math.max(0, fileDuration),
+      });
+    }
+  }
+
+  return {
+    framework: 'jest',
+    total,
+    passed,
+    failed,
+    skipped,
+    duration_s: Math.round((durationMs / 1000) * 100) / 100,
+    files,
+  };
+}
+
+function buildCtSection(ctSummary) {
+  if (!ctSummary || !ctSummary.totals) return emptySuite('playwright-ct');
+
+  const totals = ctSummary.totals;
+  const files = [];
+
+  if (Array.isArray(ctSummary.tests)) {
+    const byFile = new Map();
+    for (const test of ctSummary.tests) {
+      const fileName = test.file || 'unknown';
+      if (!byFile.has(fileName)) {
+        byFile.set(fileName, { tests: 0, passed: 0, failed: 0, skipped: 0, duration_ms: 0 });
+      }
+      const entry = byFile.get(fileName);
+      entry.tests += 1;
+      entry.duration_ms += test.durationMs || 0;
+
+      const status = test.finalStatus || test.status || '';
+      if (status === 'passed' || status === 'flaky') entry.passed += 1;
+      else if (status === 'failed') entry.failed += 1;
+      else if (status === 'skipped') entry.skipped += 1;
+      else entry.passed += 1;
+    }
+
+    for (const [name, data] of byFile) {
+      files.push({ name, ...data });
+    }
+  }
+
+  return {
+    framework: 'playwright-ct',
+    total: totals.total || 0,
+    passed: (totals.passed || 0) + (totals.flaky || 0),
+    failed: totals.failed || 0,
+    skipped: totals.skipped || 0,
+    duration_s: files.reduce((sum, f) => sum + f.duration_ms, 0) / 1000,
+    files,
+  };
+}
+
+function buildE2eSection(playwrightData) {
+  if (!playwrightData || !playwrightData.suites) return emptySuite('playwright');
+
+  let total = 0;
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+  let durationMs = 0;
+  const files = [];
+
+  function walkSuites(suites, parentFile) {
+    for (const suite of suites) {
+      const fileName = suite.file || parentFile || 'unknown';
+
+      if (Array.isArray(suite.specs)) {
+        let fileTests = 0;
+        let filePassed = 0;
+        let fileFailed = 0;
+        let fileSkipped = 0;
+        let fileDuration = 0;
+
+        for (const spec of suite.specs) {
+          for (const test of spec.tests || []) {
+            fileTests += 1;
+            total += 1;
+            const status = test.status || test.expectedStatus;
+            if (status === 'expected' || status === 'passed' || status === 'flaky') {
+              filePassed += 1;
+              passed += 1;
+            } else if (status === 'unexpected' || status === 'failed') {
+              fileFailed += 1;
+              failed += 1;
+            } else if (status === 'skipped') {
+              fileSkipped += 1;
+              skipped += 1;
+            }
+            for (const result of test.results || []) {
+              fileDuration += result.duration || 0;
+              durationMs += result.duration || 0;
+            }
+          }
+        }
+
+        if (fileTests > 0 && fileName !== parentFile) {
+          files.push({
+            name: fileName,
+            tests: fileTests,
+            passed: filePassed,
+            failed: fileFailed,
+            skipped: fileSkipped,
+            duration_ms: fileDuration,
+          });
+        }
+      }
+
+      if (Array.isArray(suite.suites)) {
+        walkSuites(suite.suites, fileName);
+      }
+    }
+  }
+
+  walkSuites(playwrightData.suites, null);
+
+  return {
+    framework: 'playwright',
+    total,
+    passed,
+    failed,
+    skipped,
+    duration_s: Math.round((durationMs / 1000) * 100) / 100,
+    files,
+  };
+}
+
+const opts = parseArgs(process.argv);
+
+const jestData = readJson(opts.jestResults);
+const ctSummary = readJson(opts.ctSummary);
+const e2eData = readJson(opts.e2eResults);
+
+const contract = {
+  schemaVersion: '1.0',
+  repo: 'RedHatInsights/nxtcm-components',
+  generated_at: new Date().toISOString(),
+  unit: buildUnitSection(jestData),
+  component: buildCtSection(ctSummary),
+  e2e: buildE2eSection(e2eData),
+};
+
+const dir = path.dirname(opts.output);
+if (dir !== '.') fs.mkdirSync(dir, { recursive: true });
+
+fs.writeFileSync(opts.output, JSON.stringify(contract, null, 2) + '\n');
+
+const totals = contract.unit.total + contract.component.total + contract.e2e.total;
+console.log(`test-coverage-data.json written (${totals} total tests across 3 suites)`);

--- a/utils/build-test-coverage-data.mjs
+++ b/utils/build-test-coverage-data.mjs
@@ -47,7 +47,8 @@ function readJson(filePath) {
   if (!filePath || !fs.existsSync(filePath)) return null;
   try {
     return JSON.parse(fs.readFileSync(filePath, 'utf8'));
-  } catch {
+  } catch (err) {
+    console.warn(`warning: failed to parse ${filePath}: ${err.message}`);
     return null;
   }
 }
@@ -152,50 +153,38 @@ function buildE2eSection(playwrightData) {
   let failed = 0;
   let skipped = 0;
   let durationMs = 0;
-  const files = [];
+  const byFile = new Map();
 
   function walkSuites(suites, parentFile) {
     for (const suite of suites) {
       const fileName = suite.file || parentFile || 'unknown';
 
       if (Array.isArray(suite.specs)) {
-        let fileTests = 0;
-        let filePassed = 0;
-        let fileFailed = 0;
-        let fileSkipped = 0;
-        let fileDuration = 0;
+        if (!byFile.has(fileName)) {
+          byFile.set(fileName, { tests: 0, passed: 0, failed: 0, skipped: 0, duration_ms: 0 });
+        }
+        const entry = byFile.get(fileName);
 
         for (const spec of suite.specs) {
           for (const test of spec.tests || []) {
-            fileTests += 1;
+            entry.tests += 1;
             total += 1;
             const status = test.status || test.expectedStatus;
             if (status === 'expected' || status === 'passed' || status === 'flaky') {
-              filePassed += 1;
+              entry.passed += 1;
               passed += 1;
             } else if (status === 'unexpected' || status === 'failed') {
-              fileFailed += 1;
+              entry.failed += 1;
               failed += 1;
             } else if (status === 'skipped') {
-              fileSkipped += 1;
+              entry.skipped += 1;
               skipped += 1;
             }
             for (const result of test.results || []) {
-              fileDuration += result.duration || 0;
+              entry.duration_ms += result.duration || 0;
               durationMs += result.duration || 0;
             }
           }
-        }
-
-        if (fileTests > 0 && fileName !== parentFile) {
-          files.push({
-            name: fileName,
-            tests: fileTests,
-            passed: filePassed,
-            failed: fileFailed,
-            skipped: fileSkipped,
-            duration_ms: fileDuration,
-          });
         }
       }
 
@@ -206,6 +195,11 @@ function buildE2eSection(playwrightData) {
   }
 
   walkSuites(playwrightData.suites, null);
+
+  const files = [];
+  for (const [name, data] of byFile) {
+    if (data.tests > 0) files.push({ name, ...data });
+  }
 
   return {
     framework: 'playwright',

--- a/utils/build-test-coverage-data.mjs
+++ b/utils/build-test-coverage-data.mjs
@@ -72,8 +72,9 @@ function buildUnitSection(jestData) {
     const filePassed = suite.assertionResults?.filter((t) => t.status === 'passed').length || 0;
     const fileFailed = suite.assertionResults?.filter((t) => t.status === 'failed').length || 0;
     const fileSkipped =
-      suite.assertionResults?.filter((t) => t.status === 'pending' || t.status === 'skipped')
-        .length || 0;
+      suite.assertionResults?.filter((t) =>
+        ['pending', 'skipped', 'todo', 'disabled'].includes(t.status)
+      ).length || 0;
     const fileDuration = (suite.endTime || 0) - (suite.startTime || 0);
 
     total += fileTests;


### PR DESCRIPTION
## Summary
- Adds a `coverage-contract` CI job that assembles Jest, Playwright CT, and E2E test results into a single `test-coverage-data.json` artifact
- New `utils/build-test-coverage-data.mjs` assembler script handles all three frameworks, falls back gracefully when any source is missing
- Updates existing `unit-test` and `e2e` jobs to emit machine-readable JSON alongside existing reports

## Context
[FCN-484](https://redhat.atlassian.net/browse/FCN-484) - the EPD test coverage page needs a canonical source of truth from nxtcm-components CI. This artifact follows a stable schema (`schemaVersion: "1.0"`) that the EPD generator ([FCN-485](https://redhat.atlassian.net/browse/FCN-485)) will consume downstream.

## What changed
| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | `unit-test` now emits `jest-results.json`; `e2e` emits `playwright-e2e-results.json`; new `coverage-contract` job downloads all three and runs assembler |
| `utils/build-test-coverage-data.mjs` | New script — merges jest/CT/e2e JSON into one canonical artifact |

## Test plan
- [x] `node --check utils/build-test-coverage-data.mjs` — syntax OK
- [x] Script runs with no inputs → emits zeroed JSON (graceful fallback)
- [x] Script runs with real Jest output → correctly counts 225 tests
- [x] `npm test` passes (225/225)
- [x] `tsc --noEmit` passes
- [ ] CI runs successfully on this PR (validates the workflow changes end-to-end)

[FCN-484]: https://redhat.atlassian.net/browse/FCN-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FCN-485]: https://redhat.atlassian.net/browse/FCN-485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ