### PR TITLE
FCN-489 - Fix bug with typeahead selects not able to reselect

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/Select.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/Select.tsx
@@ -288,11 +288,16 @@ export function Select<T = unknown>(props: SelectProps<T>) {
     setTypeaheadQuery(v);
   }, []);
 
-  const onClearTypeahead = useCallback(() => {
-    onChange(undefined as T | string | number | undefined);
-    setTypeaheadQuery('');
-    textInputRef.current?.focus();
-  }, [onChange]);
+  const onClearTypeahead = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+      onChange(undefined as T | string | number | undefined);
+      setTypeaheadQuery('');
+      textInputRef.current?.focus();
+    },
+    [onChange]
+  );
 
   const toggleOpen = useCallback(() => setOpen((o) => !o), []);
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.spec-helpers.tsx
@@ -25,6 +25,9 @@ export const WIZ_SELECT_EXPLICIT_TOGGLE_NAME = /select the explicit region label
 
 export const WIZ_SELECT_SUBMIT_TOGGLE_NAME = /select the region \(submit demo\)/i;
 
+export const WIZ_SELECT_TYPEAHEAD_CLEAR_TOGGLE = /select the region/i;
+export const WIZ_SELECT_TYPEAHEAD_CLEAR_STATUS = 'region value after typeahead clear';
+
 type ExplicitFormValues = { region?: string };
 
 export function WizSelectExplicitHarness() {
@@ -217,6 +220,35 @@ type ControlOnlyVpcValues = {
 
 export const WIZ_SELECT_ONLY_CONTROL_TOGGLE = /select the vpc identifier/i;
 export const WIZ_SELECT_CONTROL_ONLY_STATUS = 'vpcId control prop status';
+
+type TypeaheadClearFormValues = { region: string };
+
+/** Mirrors Details step typeahead selects: Yup default `''`, clear via toggle X. */
+export function WizSelectTypeaheadClearHarness() {
+  const methods = useForm<TypeaheadClearFormValues>({
+    defaultValues: { region: '' },
+    mode: 'onTouched',
+  });
+
+  return withRosaCt(
+    <FormProvider {...methods}>
+      <Form>
+        <WizSelect<TypeaheadClearFormValues>
+          name="region"
+          label="Region"
+          options={['us-east-1', 'eu-west-1']}
+          isTypeAhead
+        />
+        <WizCtWatchStatus
+          control={methods.control}
+          name="region"
+          ariaLabel={WIZ_SELECT_TYPEAHEAD_CLEAR_STATUS}
+          format={(v) => (v === undefined || v === '' ? '(empty)' : String(v))}
+        />
+      </Form>
+    </FormProvider>
+  );
+}
 
 /** No surrounding FormProvider — uses `control` from `useForm` via the prop. */
 export function WizSelectExplicitControlOnlyHarness() {

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.spec.tsx
@@ -8,6 +8,7 @@ import {
   WizSelectNestedFallbackHarness,
   WizSelectNumericMetaLabelHarness,
   WizSelectSubmitValidationHarness,
+  WizSelectTypeaheadClearHarness,
   WizSelectYupMetaHarness,
 } from './WizSelect.spec-helpers';
 import {
@@ -28,6 +29,8 @@ import {
   WIZ_SELECT_VALUE_STATUS_LABEL,
   WIZ_SELECT_YUP_META_HELPER,
   WIZ_SELECT_YUP_META_LABEL,
+  WIZ_SELECT_TYPEAHEAD_CLEAR_STATUS,
+  WIZ_SELECT_TYPEAHEAD_CLEAR_TOGGLE,
 } from './WizSelect.spec-helpers';
 
 test.describe('WizSelect', () => {
@@ -107,6 +110,23 @@ test.describe('WizSelect', () => {
   }) => {
     await mount(<WizSelectNumericMetaLabelHarness />);
     await expect(page.getByRole('button', { name: WIZ_SELECT_NUMERIC_TOGGLE })).toBeVisible();
+  });
+
+  test('clears react-hook-form value when the typeahead clear control is pressed', async ({
+    mount,
+    page,
+  }) => {
+    await mount(<WizSelectTypeaheadClearHarness />);
+    const status = page.getByRole('status', { name: WIZ_SELECT_TYPEAHEAD_CLEAR_STATUS });
+    const combo = page.getByRole('combobox', { name: WIZ_SELECT_TYPEAHEAD_CLEAR_TOGGLE });
+
+    await combo.click();
+    await page.getByRole('option', { name: 'eu-west-1' }).click();
+    await expect(status).toHaveText('eu-west-1');
+
+    await page.getByRole('button', { name: 'Clear selection' }).click();
+    await expect(status).toHaveText('(empty)');
+    await expect(combo).toHaveValue('');
   });
 
   test('binds through the control prop without a FormProvider wrapper', async ({ mount, page }) => {

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
@@ -98,12 +98,19 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
   const stepValidationRevealed = useWizStepValidationRevealed(String(name));
   const showError = wizFieldShowsError(invalid, isTouched, isSubmitted || stepValidationRevealed);
 
-  /** Select clears with `undefined`; RHF keeps the prior value for Yup string fields (default `''`). */
+  /** Select clears with `undefined`; map to `''` only for string-backed RHF values (Yup string fields). */
   const handleChange = useCallback(
     (next: TOption | string | number | undefined) => {
-      field.onChange(next === undefined ? '' : next);
+      if (next !== undefined) {
+        field.onChange(next);
+        return;
+      }
+      const isStringBacked =
+        typeof field.value === 'string' ||
+        (Array.isArray(field.value) && typeof field.value[0] === 'string');
+      field.onChange(isStringBacked ? '' : undefined);
     },
-    [field.onChange]
+    [field.onChange, field.value]
   );
 
   const select = (

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 import { type FieldValues, useController } from 'react-hook-form';
 
 import { requiredFromYup } from '@/utilities/yupFieldRequired';
@@ -98,6 +98,14 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
   const stepValidationRevealed = useWizStepValidationRevealed(String(name));
   const showError = wizFieldShowsError(invalid, isTouched, isSubmitted || stepValidationRevealed);
 
+  /** Select clears with `undefined`; RHF keeps the prior value for Yup string fields (default `''`). */
+  const handleChange = useCallback(
+    (next: TOption | string | number | undefined) => {
+      field.onChange(next === undefined ? '' : next);
+    },
+    [field.onChange]
+  );
+
   const select = (
     <Select<TOption>
       {...rest}
@@ -110,7 +118,7 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
       isRequired={isRequired}
       value={field.value}
       onBlur={field.onBlur}
-      onChange={field.onChange}
+      onChange={handleChange}
       errorMessage={error?.message}
       isError={showError && !isMenuOpen}
       onMenuOpenChange={setIsMenuOpen}


### PR DESCRIPTION
## Description

Fixes a bug where typeahead `WizSelect` fields could not reselect a previously chosen option after clearing the value with the [x] control, especially when navigating away from and back to a wizard step.

When the typeahead clear button was pressed, the UI appeared empty but react-hook-form retained the prior value (Yup string fields default to `''`, while `Select` cleared with `undefined`). That mismatch left a stale checkmark in the menu and blocked reselecting the same option. This change maps `undefined` clears to `''` in `WizSelect`, and stops clear-button event propagation in the shared `Select` component so the form value actually clears.

**Jira issue #** [FCN-489](https://redhat.atlassian.net/browse/FCN-489)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**

1. Open the RosaHCPWizard in Storybook.
2. Go to the Details step.
3. Select a region and version.
4. Click Next or navigate to another step.
5. Return to the Details step using the Back button or left navigation.
6. Click the [x] button on the region and version fields to clear the values.
7. Reselect the previously selected value for each field.

**Expected result (fix verification):**

- After clicking [x], the checkmark is removed from all menu options and the field displays as empty.
- Reselecting the previously chosen region and version displays the value in the field again.
- The wizard no longer retains a hidden/stale value that passes validation while the UI looks empty.

**Test Environment:**
- [ ] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [x] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

N/A — see reproduction steps and expected behavior above. Before/after screenshots are attached to [FCN-489](https://redhat.atlassian.net/browse/FCN-489).

### Before
<!-- Screenshot or description of the previous behavior -->

After clearing with [x], the field looked empty but the prior option stayed checked internally; reselecting the same value showed nothing while validation still passed.

### After
<!-- Screenshot or description of the new behavior -->

Clearing removes the selection from form state; reselecting the same value displays correctly in the field.


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->

Playwright CT coverage added in `WizSelect.spec.tsx` for clearing a typeahead select and confirming react-hook-form value resets to empty.


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->


### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-489]: https://redhat.atlassian.net/browse/FCN-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FCN-489]: https://redhat.atlassian.net/browse/FCN-489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ