### PR TITLE
FCN-435 Show error on submission

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx
@@ -154,3 +154,46 @@ export const AllApiErrors: Story = {
     wizardData: rosaHcpWizardDetailsFieldsAllApiErrorsData,
   },
 };
+
+/**
+ * Default story that shows a submit error after the wizard is submitted.
+ * "Back to the wizard" clears the error after a one-second delay.
+ */
+function SubmitErrorWrapper(props: React.ComponentProps<typeof ROSAHCPWizard>) {
+  const [submitError, setSubmitError] = React.useState<string | boolean | undefined>(undefined);
+
+  return (
+    <DefaultWithInitialLoading
+      {...props}
+      onSubmitError={submitError}
+      onSubmit={async (data) => {
+        console.log('Wizard submitted with data:', data);
+        await new Promise((resolve) => setTimeout(resolve, 2000));
+        setSubmitError(
+          'There has been an error - any error message returned from the API will display here.'
+        );
+      }}
+      onCancel={() => {
+        setSubmitError(undefined);
+        props.onCancel();
+      }}
+      onBackToReviewStep={async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        setSubmitError(undefined);
+      }}
+    />
+  );
+}
+
+export const SubmitError: Story = {
+  render: (args) => <SubmitErrorWrapper {...args} />,
+  args: {
+    title: 'Create ROSA Cluster',
+    yaml: true,
+    wizardData: createMockRosaHcpWizardData(),
+    onCancel: () => {
+      console.log('Wizard cancelled');
+      alert('Wizard cancelled');
+    },
+  },
+};

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.spec-helpers.tsx
@@ -1,0 +1,72 @@
+/**
+ * Playwright CT mount targets for {@link ROSAHCPWizardBody}.
+ */
+import React from 'react';
+
+import fixtures from './ROSAHCPWizard.fixtures';
+import { RosaHcpWizardFormProvider } from './RosaHcpWizardFormProvider';
+import { RosaHcpWizardStringsProvider } from './stringsProvider/RosaHcpWizardStringsContext';
+import { makeMachineTypesResource, makeVpcListResource } from './rosaHcpWizardCtSpecHelpers';
+import type { RosaHCPWizardProps, ROSAHCPWizardData } from './types';
+
+const noopFetch = async (): Promise<void> => {};
+
+export function makeMinimalRosaHcpWizardData(
+  overrides?: Partial<ROSAHCPWizardData>
+): ROSAHCPWizardData {
+  return {
+    awsInfrastructureAccounts: fixtures.mockResource(fixtures.mockAwsInfrastructureAccounts),
+    awsBillingAccounts: fixtures.mockResource(fixtures.mockAwsBillingAccounts),
+    regions: {
+      ...fixtures.mockFetchResource(fixtures.mockRegions),
+      fetch: noopFetch,
+    },
+    versions: {
+      ...fixtures.mockFetchResource(fixtures.mockVersionsData),
+      fetch: noopFetch,
+    },
+    machineTypes: makeMachineTypesResource(),
+    roles: {
+      ...fixtures.mockFetchResource(fixtures.mockRoles),
+      fetch: noopFetch,
+    },
+    oidcConfig: fixtures.mockResource(fixtures.mockOicdConfig),
+    vpcList: makeVpcListResource(),
+    subnets: fixtures.mockResource([]),
+    securityGroups: fixtures.mockResource(fixtures.mockSecurityGroups),
+    clusterNameValidation: fixtures.mockValidationResource(),
+    ...overrides,
+  };
+}
+
+const defaultWizardProps: RosaHCPWizardProps = {
+  title: 'Create ROSA Cluster',
+  wizardData: makeMinimalRosaHcpWizardData(),
+  onSubmit: async () => {},
+  onCancel: () => {},
+};
+
+export type RosaHcpWizardBodyMountProps = Partial<RosaHCPWizardProps>;
+
+export function RosaHcpWizardBodyMount(props: RosaHcpWizardBodyMountProps = {}) {
+  return (
+    <RosaHcpWizardStringsProvider>
+      <RosaHcpWizardFormProvider {...defaultWizardProps} {...props} />
+    </RosaHcpWizardStringsProvider>
+  );
+}
+
+/** Starts in submit error state and clears error when "Back to the wizard" is clicked. */
+export function RosaHcpWizardBodyErrorThenBackMount(props: RosaHcpWizardBodyMountProps = {}) {
+  const [submitError, setSubmitError] = React.useState<string | boolean>(
+    'There has been an error creating the cluster'
+  );
+
+  return (
+    <RosaHcpWizardBodyMount
+      {...props}
+      onSubmitError={submitError}
+      onBackToReviewStep={async () => setSubmitError(false)}
+    />
+  );
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.spec.tsx
@@ -5,7 +5,7 @@ import {
   RosaHcpWizardBodyErrorThenBackMount,
   RosaHcpWizardBodyMount,
 } from './ROSAHCPWizardBody.spec-helpers';
-import { checkAccessibility } from '../../../test-helpers';
+import { checkAccessibility } from '@/test-helpers';
 
 const { submitError: submitErrorStrings, wizard } = defaultRosaHcpWizardStrings;
 const ERROR_MESSAGE = 'There has been an error creating the cluster';

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.spec.tsx
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+
+import { defaultRosaHcpWizardStrings } from './stringsProvider/rosaHcpWizardStrings.defaults';
+import {
+  RosaHcpWizardBodyErrorThenBackMount,
+  RosaHcpWizardBodyMount,
+} from './ROSAHCPWizardBody.spec-helpers';
+import { checkAccessibility } from '../../../test-helpers';
+
+const { submitError: submitErrorStrings, wizard } = defaultRosaHcpWizardStrings;
+const ERROR_MESSAGE = 'There has been an error creating the cluster';
+
+test.describe('ROSAHCPWizardBody', () => {
+  test('shows the wizard when onSubmitError is not set', async ({ mount }) => {
+    const component = await mount(<RosaHcpWizardBodyMount />);
+
+    await expect(
+      component.getByRole('button', { name: wizard.stepLabels.basicSetup })
+    ).toBeVisible();
+    await expect(component.getByRole('textbox', { name: /Cluster name/i })).toBeVisible();
+  });
+
+  test.describe('submit error state', () => {
+    test('shows error EmptyState and hides wizard when onSubmitError is set', async ({ mount }) => {
+      const component = await mount(<RosaHcpWizardBodyMount onSubmitError={ERROR_MESSAGE} />);
+
+      await expect(
+        component.getByRole('heading', { name: submitErrorStrings.title })
+      ).toBeVisible();
+      await expect(component.getByText(ERROR_MESSAGE)).toBeVisible();
+      await expect(
+        component.getByRole('button', { name: submitErrorStrings.exitWizard })
+      ).toBeVisible();
+      await expect(component.getByRole('textbox', { name: /Cluster name/i })).not.toBeVisible();
+    });
+
+    test('shows Back to the wizard when onBackToReviewStep is provided', async ({ mount }) => {
+      const component = await mount(
+        <RosaHcpWizardBodyMount onSubmitError={ERROR_MESSAGE} onBackToReviewStep={() => {}} />
+      );
+
+      await expect(
+        component.getByRole('button', { name: submitErrorStrings.backToReviewStep })
+      ).toBeVisible();
+    });
+
+    test('calls onCancel when Exit wizard is clicked', async ({ mount }) => {
+      let cancelCalled = false;
+      const component = await mount(
+        <RosaHcpWizardBodyMount
+          onSubmitError={ERROR_MESSAGE}
+          onCancel={() => {
+            cancelCalled = true;
+          }}
+        />
+      );
+
+      await component.getByRole('button', { name: submitErrorStrings.exitWizard }).click();
+      expect(cancelCalled).toBe(true);
+    });
+
+    test('calls onBackToReviewStep when Back to the wizard is clicked', async ({ mount }) => {
+      let backToReviewCalled = false;
+      const component = await mount(
+        <RosaHcpWizardBodyMount
+          onSubmitError={ERROR_MESSAGE}
+          onBackToReviewStep={() => {
+            backToReviewCalled = true;
+          }}
+        />
+      );
+
+      await component.getByRole('button', { name: submitErrorStrings.backToReviewStep }).click();
+      expect(backToReviewCalled).toBe(true);
+    });
+
+    test('hides error view and shows wizard when Back to the wizard clears the error', async ({
+      mount,
+    }) => {
+      const component = await mount(<RosaHcpWizardBodyErrorThenBackMount />);
+
+      await expect(
+        component.getByRole('heading', { name: submitErrorStrings.title })
+      ).toBeVisible();
+      await component.getByRole('button', { name: submitErrorStrings.backToReviewStep }).click();
+
+      await expect(
+        component.getByRole('heading', { name: submitErrorStrings.title })
+      ).not.toBeVisible();
+      await expect(component.getByRole('textbox', { name: /Cluster name/i })).toBeVisible();
+    });
+
+    test('passes accessibility tests when showing the error state', async ({ mount }) => {
+      const component = await mount(
+        <RosaHcpWizardBodyMount onSubmitError={ERROR_MESSAGE} onBackToReviewStep={() => {}} />
+      );
+
+      await checkAccessibility({ component });
+    });
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
@@ -14,9 +14,10 @@ import { createRosaHcpWizardFooter } from './Footer/RosaHcpWizardFooter';
 import { useRosaHcpWizardStrings } from './stringsProvider/RosaHcpWizardStringsContext';
 import { STEP_IDS } from './constants';
 import type { RosaHCPWizardProps } from './types';
+import { RosaWizardSubmitError } from './RosaWizardSubmitError';
 
 export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
-  const { wizardData, onSubmit } = props;
+  const { wizardData, onSubmit, onSubmitError, onBackToReviewStep, onCancel } = props;
   const footer = useMemo(() => createRosaHcpWizardFooter(onSubmit), [onSubmit]);
 
   const clusterWideProxySelected = useWatch({ name: 'configure_proxy' });
@@ -25,9 +26,33 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
   const { wizard } = rosaStrings;
   const sl = wizard.stepLabels;
 
+  const hasSubmitError = !!onSubmitError;
+  const [isNavigatingToReview, setIsNavigatingToReview] = React.useState(false);
+
+  const onBackToReviewClick = React.useCallback(async () => {
+    setIsNavigatingToReview(true);
+    if (onBackToReviewStep) {
+      await onBackToReviewStep();
+    }
+
+    setIsNavigatingToReview(false);
+  }, [onBackToReviewStep]);
+
   return (
     <div>
-      <Wizard height="100vh" footer={footer}>
+      {hasSubmitError && (
+        <RosaWizardSubmitError
+          onSubmitError={onSubmitError}
+          onBackToReviewStep={onBackToReviewStep ? onBackToReviewClick : undefined}
+          isNavigatingToReview={isNavigatingToReview}
+          onCancel={() => onCancel()}
+        />
+      )}
+      <Wizard
+        height="100vh"
+        footer={footer}
+        style={{ display: hasSubmitError ? 'none' : undefined }}
+      >
         <WizardStep
           isExpandable
           name={sl.basicSetup}

--- a/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.spec-helpers.tsx
@@ -1,0 +1,47 @@
+/**
+ * Playwright CT mount targets for {@link RosaWizardSubmitError}.
+ * Stateful wrappers live here so specs can mount them (Playwright CT cannot mount components defined in test files).
+ */
+import React from 'react';
+
+import { RosaWizardSubmitError } from './RosaWizardSubmitError';
+import { withRosaCt } from './components/WizFields/wizFieldCtSpecHelpers';
+
+export type RosaWizardSubmitErrorMountProps = React.ComponentProps<typeof RosaWizardSubmitError>;
+
+export function RosaWizardSubmitErrorMount(props: RosaWizardSubmitErrorMountProps) {
+  return withRosaCt(<RosaWizardSubmitError {...props} />);
+}
+
+/** Starts in submit error state and clears error when "Back to the wizard" is clicked. */
+export function RosaWizardSubmitErrorThenBackMount(
+  props: Omit<
+    RosaWizardSubmitErrorMountProps,
+    'onSubmitError' | 'onBackToReviewStep' | 'isNavigatingToReview'
+  >
+) {
+  const [submitError, setSubmitError] = React.useState<string | boolean>(
+    'There has been an error creating the cluster'
+  );
+  const [isNavigatingToReview, setIsNavigatingToReview] = React.useState(false);
+
+  const onBackToReviewStep = React.useCallback(async () => {
+    setIsNavigatingToReview(true);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    setSubmitError(false);
+    setIsNavigatingToReview(false);
+  }, []);
+
+  if (!submitError) {
+    return withRosaCt(<p>Wizard content restored</p>);
+  }
+
+  return withRosaCt(
+    <RosaWizardSubmitError
+      {...props}
+      onSubmitError={submitError}
+      onBackToReviewStep={onBackToReviewStep}
+      isNavigatingToReview={isNavigatingToReview}
+    />
+  );
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.spec.tsx
@@ -1,0 +1,148 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+
+import { defaultRosaHcpWizardStrings } from './stringsProvider/rosaHcpWizardStrings.defaults';
+import {
+  RosaWizardSubmitErrorMount,
+  RosaWizardSubmitErrorThenBackMount,
+} from './RosaWizardSubmitError.spec-helpers';
+import { checkAccessibility } from '../../../test-helpers';
+
+const { submitError: submitErrorStrings } = defaultRosaHcpWizardStrings;
+const ERROR_MESSAGE = 'There has been an error creating the cluster';
+
+test.describe('RosaWizardSubmitError', () => {
+  test('shows error title and message when onSubmitError is a non-empty string', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        isNavigatingToReview={false}
+        onCancel={() => {}}
+      />
+    );
+
+    await expect(component.getByRole('heading', { name: submitErrorStrings.title })).toBeVisible();
+    await expect(component.getByText(ERROR_MESSAGE)).toBeVisible();
+    await expect(
+      component.getByRole('button', { name: submitErrorStrings.exitWizard })
+    ).toBeVisible();
+  });
+
+  test('shows title only when onSubmitError is boolean true', async ({ mount }) => {
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={true}
+        isNavigatingToReview={false}
+        onCancel={() => {}}
+      />
+    );
+
+    await expect(component.getByRole('heading', { name: submitErrorStrings.title })).toBeVisible();
+    await expect(component.getByText(ERROR_MESSAGE)).toHaveCount(0);
+  });
+
+  test('shows Back to the wizard when onBackToReviewStep is provided', async ({ mount }) => {
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        onBackToReviewStep={() => {}}
+        isNavigatingToReview={false}
+        onCancel={() => {}}
+      />
+    );
+
+    await expect(
+      component.getByRole('button', { name: submitErrorStrings.backToReviewStep })
+    ).toBeVisible();
+  });
+
+  test('hides Back to the wizard when onBackToReviewStep is not provided', async ({ mount }) => {
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        isNavigatingToReview={false}
+        onCancel={() => {}}
+      />
+    );
+
+    await expect(
+      component.getByRole('button', { name: submitErrorStrings.backToReviewStep })
+    ).toHaveCount(0);
+  });
+
+  test('calls onCancel when Exit wizard is clicked', async ({ mount }) => {
+    let cancelCalled = false;
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        isNavigatingToReview={false}
+        onCancel={() => {
+          cancelCalled = true;
+        }}
+      />
+    );
+
+    await component.getByRole('button', { name: submitErrorStrings.exitWizard }).click();
+    expect(cancelCalled).toBe(true);
+  });
+
+  test('calls onBackToReviewStep when Back to the wizard is clicked', async ({ mount }) => {
+    let backToReviewCalled = false;
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        onBackToReviewStep={() => {
+          backToReviewCalled = true;
+        }}
+        isNavigatingToReview={false}
+        onCancel={() => {}}
+      />
+    );
+
+    await component.getByRole('button', { name: submitErrorStrings.backToReviewStep }).click();
+    expect(backToReviewCalled).toBe(true);
+  });
+
+  test('disables Back to the wizard while isNavigatingToReview is true', async ({ mount }) => {
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        onBackToReviewStep={() => {}}
+        isNavigatingToReview
+        onCancel={() => {}}
+      />
+    );
+
+    await expect(
+      component.getByRole('button', { name: submitErrorStrings.backToReviewStep })
+    ).toBeDisabled();
+  });
+
+  test('clears error view after Back to the wizard when parent clears onSubmitError', async ({
+    mount,
+  }) => {
+    const component = await mount(<RosaWizardSubmitErrorThenBackMount onCancel={() => {}} />);
+
+    await expect(component.getByRole('heading', { name: submitErrorStrings.title })).toBeVisible();
+    await component.getByRole('button', { name: submitErrorStrings.backToReviewStep }).click();
+
+    await expect(
+      component.getByRole('heading', { name: submitErrorStrings.title })
+    ).not.toBeVisible();
+    await expect(component.getByText('Wizard content restored')).toBeVisible();
+  });
+
+  test('passes accessibility tests in the error state', async ({ mount }) => {
+    const component = await mount(
+      <RosaWizardSubmitErrorMount
+        onSubmitError={ERROR_MESSAGE}
+        onBackToReviewStep={() => {}}
+        isNavigatingToReview={false}
+        onCancel={() => {}}
+      />
+    );
+
+    await checkAccessibility({ component });
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.spec.tsx
@@ -5,7 +5,7 @@ import {
   RosaWizardSubmitErrorMount,
   RosaWizardSubmitErrorThenBackMount,
 } from './RosaWizardSubmitError.spec-helpers';
-import { checkAccessibility } from '../../../test-helpers';
+import { checkAccessibility } from '@/test-helpers';
 
 const { submitError: submitErrorStrings } = defaultRosaHcpWizardStrings;
 const ERROR_MESSAGE = 'There has been an error creating the cluster';

--- a/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/RosaWizardSubmitError.tsx
@@ -1,0 +1,51 @@
+import {
+  Button,
+  EmptyState,
+  EmptyStateActions,
+  EmptyStateBody,
+  EmptyStateFooter,
+  EmptyStateStatus,
+} from '@patternfly/react-core';
+import { useRosaHcpWizardStrings } from './stringsProvider/RosaHcpWizardStringsContext';
+
+export type RosaWizardSubmitErrorProps = {
+  /** Error message or flag from parent (e.g. submit failure). */
+  onSubmitError: string | boolean;
+  /** When provided, "Back to the wizard" is shown and this is called when it is clicked. */
+  onBackToReviewStep?: () => void | Promise<void>;
+  /** True while the back-to-wizard action is in progress (disables button). */
+  isNavigatingToReview: boolean;
+  onCancel: () => void;
+};
+
+export function RosaWizardSubmitError(props: RosaWizardSubmitErrorProps) {
+  const { onSubmitError, onBackToReviewStep, isNavigatingToReview, onCancel } = props;
+  const { submitError } = useRosaHcpWizardStrings();
+
+  return (
+    <EmptyState status={EmptyStateStatus.danger} titleText={submitError.title} headingLevel="h2">
+      {typeof onSubmitError === 'string' && onSubmitError.length > 0 && (
+        <EmptyStateBody>{onSubmitError}</EmptyStateBody>
+      )}
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          {onBackToReviewStep && (
+            <Button
+              variant="primary"
+              onClick={() => void onBackToReviewStep()}
+              isLoading={isNavigatingToReview}
+              isDisabled={isNavigatingToReview}
+            >
+              {submitError.backToReviewStep}
+            </Button>
+          )}
+        </EmptyStateActions>
+        <EmptyStateActions>
+          <Button variant="link" onClick={onCancel}>
+            {submitError.exitWizard}
+          </Button>
+        </EmptyStateActions>
+      </EmptyStateFooter>
+    </EmptyState>
+  );
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/stringsProvider/rosaHcpWizardStrings.defaults.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/stringsProvider/rosaHcpWizardStrings.defaults.ts
@@ -56,7 +56,7 @@ export const defaultRosaHcpWizardStrings: RosaHcpWizardStrings = {
   },
   submitError: {
     title: 'Error creating cluster',
-    backToReviewStep: 'Back to review step',
+    backToReviewStep: 'Back to the wizard',
     exitWizard: 'Exit wizard',
   },
   yamlEditor: {


### PR DESCRIPTION


## Description
Adds submit-failure handling to the ROSA HCP wizard. When the consuming app sets `onSubmitError` (string or boolean), the wizard is hidden and a danger `EmptyState` is shown via the new `RosaWizardSubmitError` component. The error view supports an optional API error message, a primary **Back to the wizard** action (`onBackToReviewStep`), and a link to exit the wizard (`onCancel`). While navigating back, the button shows a loading state.

Includes Playwright component tests for `RosaWizardSubmitError` and `ROSAHCPWizardBody`, plus a Storybook **SubmitError** story to demo the flow.

NOTE that any changes to the left navigation are not part of this story.

**Jira issue #** [FCN-435](https://redhat.atlassian.net/browse/FCN-435)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Open Storybook → **SubmitError** story for ROSA HCP Wizard.
2. Complete/submit the wizard and confirm the danger EmptyState appears with the API error message.
3. Click **Back to the wizard** and confirm the wizard returns after the parent clears `onSubmitError`.
4. Trigger the error again and click **Exit wizard** to confirm `onCancel` is invoked.

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

N/A — see Storybook **SubmitError** story for the error EmptyState UI.

### Before
<!-- Screenshot or description of the previous behavior -->
No dedicated submit-error view; wizard remained visible on submission failure.

### After
<!-- Screenshot or description of the new behavior -->
Submit failure replaces the wizard with a danger EmptyState (title, optional message, back/exit actions).


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes



## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-435]: https://redhat.atlassian.net/browse/FCN-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ