### PR TITLE
FCN-439 feat(Networking): add public subnet filtering and reset logic to ROSA HCP wizard

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.fixtures.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.fixtures.ts
@@ -1,5 +1,18 @@
 import React from 'react';
-import { Resource, ValidationResource, OpenShiftVersionsData } from './types';
+import {
+  AWSBillingAccounts,
+  AWSInfrastructureAccounts,
+  CIDRSubnet,
+  MachineTypesDropdownType,
+  OIDCConfig,
+  OpenShiftVersionsData,
+  Region,
+  Resource,
+  Role,
+  SecurityGroup,
+  ValidationResource,
+  VPC,
+} from './types';
 
 const REFETCH_ALL_DELAY_MS = 2000;
 /** Shared API error string for the `AllApiErrors` story (popover/detail body). */
@@ -50,7 +63,7 @@ const mockVersionsData: OpenShiftVersionsData = {
 };
 
 /** When default and latest share the same value, wizard shows a single "Default (Recommended)" group. */
-const mockOpenShiftVersionsDataDefaultEqualsLatest = {
+const mockOpenShiftVersionsDataDefaultEqualsLatest: OpenShiftVersionsData = {
   latest: { label: 'OpenShift 4.21.8', value: '4.21.8' },
   default: { label: 'OpenShift 4.21.8', value: '4.21.8' },
   releases: [
@@ -60,7 +73,7 @@ const mockOpenShiftVersionsDataDefaultEqualsLatest = {
   ],
 };
 
-const mockAwsInfrastructureAccounts = [
+const mockAwsInfrastructureAccounts: AWSInfrastructureAccounts[] = [
   {
     label: 'AWS Account - Production (123456789012)',
     value: 'aws-prod-123456789012',
@@ -75,7 +88,7 @@ const mockAwsInfrastructureAccounts = [
   },
 ];
 
-const mockAwsBillingAccounts = [
+const mockAwsBillingAccounts: AWSBillingAccounts[] = [
   {
     label: 'Billing Account - Main (123456789012)',
     value: 'billing-main-123456789012',
@@ -86,7 +99,7 @@ const mockAwsBillingAccounts = [
   },
 ];
 
-const mockRegions = [
+const mockRegions: Region[] = [
   { label: 'US West (N. California)', value: 'us-west-1' },
   { label: 'US West (Oregon)', value: 'us-west-2' },
   { label: 'EU (Ireland)', value: 'eu-west-1' },
@@ -95,13 +108,13 @@ const mockRegions = [
   { label: 'Region for machine types (us-east-1)', value: 'us-east-1' },
 ];
 
-const mockRegionsLimited = [
+const mockRegionsLimited: Region[] = [
   { label: 'US West (Oregon) - Limited', value: 'us-west-2' },
   { label: 'EU (Frankfurt)', value: 'eu-west-4' },
   { label: 'EU (Rome)', value: 'eu-west-5' },
 ];
 
-const mockRoles = [
+const mockRoles: Role[] = [
   {
     installerRole: {
       label: 'arn:aws:iam::720424066366:role/ManagedOpenShift-HCP-ROSA-Installer-Role',
@@ -161,7 +174,7 @@ const mockRoles = [
   },
 ];
 
-const mockOicdConfig = [
+const mockOicdConfig: OIDCConfig[] = [
   {
     label: '2kl4t2st8eg2u5jppv8kjeemkvimfm99',
     value: '2kl4t2st8eg2u5jppv8kjeemkvimfm99',
@@ -174,7 +187,7 @@ const mockOicdConfig = [
   },
 ];
 
-const mockMachineTypes = [
+const mockMachineTypes: MachineTypesDropdownType[] = [
   {
     id: 'm5a.xlarge',
     label: 'm5a.xlarge',
@@ -188,7 +201,7 @@ const mockMachineTypes = [
     value: 'm6a.xlarge',
   },
 ];
-const mockAdditionalMachineTypes = [
+const mockAdditionalMachineTypes: MachineTypesDropdownType[] = [
   {
     id: 'c5.2xlarge',
     label: 'c5.2xlarge',
@@ -209,7 +222,7 @@ const mockAdditionalMachineTypes = [
   },
 ];
 
-const mockMachineTypesLimited = [
+const mockMachineTypesLimited: MachineTypesDropdownType[] = [
   {
     id: 'm6a.xlarge',
     label: 'm6a.xlarge',
@@ -218,7 +231,7 @@ const mockMachineTypesLimited = [
   },
 ];
 
-const mockSecurityGroups = [
+const mockSecurityGroups: SecurityGroup[] = [
   { id: 'sg-0a1b2c3d4e5f00001', name: 'default' },
   { id: 'sg-0a1b2c3d4e5f00002', name: 'k8s-traffic-rules' },
   { id: 'sg-0a1b2c3d4e5f00003', name: 'web-server-sg' },
@@ -226,7 +239,7 @@ const mockSecurityGroups = [
   { id: 'sg-0a1b2c3d4e5f00005', name: '' },
 ];
 
-const mockVPCs = [
+const mockVPCs: VPC[] = [
   {
     name: 'test-vpc-1',
     id: 'vpc-01496860a4b0475a3',
@@ -234,28 +247,32 @@ const mockVPCs = [
       {
         subnet_id: 'subnet-0cd89766e94deb008',
         name: 'test-1-subnet-public1-us-east-1b',
+        public: true,
         availability_zone: 'us-east-1b',
         cidr_block: '10.0.16.0/20',
       },
       {
         subnet_id: 'subnet-032asd766e94deb008',
         name: 'test-1-subnet-private1-us-east-1a',
+        public: false,
         availability_zone: 'us-east-1a',
         cidr_block: '10.0.128.0/20',
       },
       {
         subnet_id: 'subnet-032as34ty2a6e94deb008',
         name: 'test-1-subnet-public1-us-east-1a',
+        public: true,
         availability_zone: 'us-east-1a',
         cidr_block: '10.0.160.0/20',
       },
       {
         subnet_id: 'subnet-03aas45qwe94deb008',
         name: 'test-1-subnet-private1-us-east-1b',
+        public: false,
         availability_zone: 'us-east-1b',
         cidr_block: '10.0.144.0/20',
       },
-    ],
+    ] as CIDRSubnet[],
     aws_security_groups: mockSecurityGroups,
   },
   {
@@ -264,21 +281,25 @@ const mockVPCs = [
     aws_subnets: [
       {
         name: 'test-subnet-private1-us-east-1a',
+        public: false,
         availability_zone: 'us-east-1a',
         subnet_id: 'subnet-0b5b55dvdv12236d',
       },
       {
         name: 'test-subnet-public1-us-east-1a',
+        public: true,
         availability_zone: 'us-east-1a',
         subnet_id: 'subnet-0b5b33hgvdv12236d',
       },
       {
         name: 'test-subnet-private1-us-east-1b',
+        public: false,
         availability_zone: 'us-east-1b',
         subnet_id: 'subnet-0b5b5611aser12236d',
       },
       {
         name: 'test-subnet-public1-us-east-1b',
+        public: true,
         availability_zone: 'us-east-1b',
         subnet_id: 'subnet-0b776hbdfdfdv12236d',
       },
@@ -286,7 +307,7 @@ const mockVPCs = [
   },
 ];
 
-const mockAdditionalVPCs = [
+const mockAdditionalVPCs: VPC[] = [
   {
     name: 'prod-vpc-multi-az',
     id: 'vpc-prod-multi-az-001',
@@ -294,21 +315,25 @@ const mockAdditionalVPCs = [
       {
         subnet_id: 'subnet-mp-private-1a',
         name: 'prod-vpc-subnet-private1-us-east-1a',
+        public: false,
         availability_zone: 'us-east-1a',
       },
       {
         subnet_id: 'subnet-mp-public-1a',
         name: 'prod-vpc-subnet-public1-us-east-1a',
+        public: true,
         availability_zone: 'us-east-1a',
       },
       {
         subnet_id: 'subnet-mp-private-1b',
         name: 'prod-vpc-subnet-private1-us-east-1b',
+        public: false,
         availability_zone: 'us-east-1b',
       },
       {
         subnet_id: 'subnet-mp-public-1b',
         name: 'prod-vpc-subnet-public1-us-east-1b',
+        public: true,
         availability_zone: 'us-east-1b',
       },
     ],
@@ -316,7 +341,7 @@ const mockAdditionalVPCs = [
   },
 ];
 
-const mockUpdatedAwsInfrastructureAccounts = [
+const mockUpdatedAwsInfrastructureAccounts: AWSInfrastructureAccounts[] = [
   {
     label: 'AWS Account - US Sandbox (555000555666)',
     value: 'aws-us-sandbox-555000555666',
@@ -327,7 +352,7 @@ const mockUpdatedAwsInfrastructureAccounts = [
   },
 ];
 
-const mockUpdatedAwsBillingAccounts = [
+const mockUpdatedAwsBillingAccounts: AWSBillingAccounts[] = [
   {
     label: 'Billing - EMEA Cost Center (600111222333)',
     value: 'billing-emea-600111222333',
@@ -338,7 +363,7 @@ const mockUpdatedAwsBillingAccounts = [
   },
 ];
 
-const mockUpdatedOpenShiftVersions = {
+const mockUpdatedOpenShiftVersions: OpenShiftVersionsData = {
   latest: { label: 'OpenShift 4.22.1', value: '4.22.1' },
   default: { label: 'OpenShift 4.21.10', value: '4.21.10' },
   releases: [
@@ -349,7 +374,7 @@ const mockUpdatedOpenShiftVersions = {
   ],
 };
 
-const mockUpdatedOIDCConfig = [
+const mockUpdatedOIDCConfig: OIDCConfig[] = [
   {
     label: '7xk9m3bc4dp1qw2ef6ghjt5nrs8uv0ya',
     value: '7xk9m3bc4dp1qw2ef6ghjt5nrs8uv0ya',
@@ -362,7 +387,7 @@ const mockUpdatedOIDCConfig = [
   },
 ];
 
-const mockUpdatedVPCList = [
+const mockUpdatedVPCList: VPC[] = [
   {
     name: 'refreshed-prod-vpc',
     id: 'vpc-refreshed-prod-001',
@@ -370,21 +395,25 @@ const mockUpdatedVPCList = [
       {
         subnet_id: 'subnet-ref-priv-1a',
         name: 'refreshed-prod-subnet-private1-us-west-2a',
+        public: false,
         availability_zone: 'us-west-2a',
       },
       {
         subnet_id: 'subnet-ref-pub-1a',
         name: 'refreshed-prod-subnet-public1-us-west-2a',
+        public: true,
         availability_zone: 'us-west-2a',
       },
       {
         subnet_id: 'subnet-ref-priv-1b',
         name: 'refreshed-prod-subnet-private1-us-west-2b',
+        public: false,
         availability_zone: 'us-west-2b',
       },
       {
         subnet_id: 'subnet-ref-pub-1b',
         name: 'refreshed-prod-subnet-public1-us-west-2b',
+        public: true,
         availability_zone: 'us-west-2b',
       },
     ],
@@ -400,11 +429,13 @@ const mockUpdatedVPCList = [
       {
         subnet_id: 'subnet-ref-stg-priv-1a',
         name: 'refreshed-staging-subnet-private1-eu-west-1a',
+        public: false,
         availability_zone: 'eu-west-1a',
       },
       {
         subnet_id: 'subnet-ref-stg-pub-1a',
         name: 'refreshed-staging-subnet-public1-eu-west-1a',
+        public: true,
         availability_zone: 'eu-west-1a',
       },
     ],
@@ -416,38 +447,40 @@ const mockUpdatedVPCList = [
       {
         subnet_id: 'subnet-ref-dev-priv-1a',
         name: 'refreshed-dev-subnet-private1-ap-southeast-1a',
+        public: false,
         availability_zone: 'ap-southeast-1a',
       },
       {
         subnet_id: 'subnet-ref-dev-pub-1a',
         name: 'refreshed-dev-subnet-public1-ap-southeast-1a',
+        public: true,
         availability_zone: 'ap-southeast-1a',
       },
     ],
   },
 ];
 
-const mockLimitedOpenShiftVersions = {
+const mockLimitedOpenShiftVersions: OpenShiftVersionsData = {
   latest: { label: 'OpenShift 4.12.0', value: '4.12.0' },
   default: { label: 'OpenShift 4.12.0', value: '4.12.0' },
   releases: [],
 };
 
-const mockLimitedAwsInfrastructureAccounts = [
+const mockLimitedAwsInfrastructureAccounts: AWSInfrastructureAccounts[] = [
   {
     label: 'AWS Account - Production (123456789012)',
     value: 'aws-prod-123456789012',
   },
 ];
 
-const mockLimitedAwsBillingAccounts = [
+const mockLimitedAwsBillingAccounts: AWSBillingAccounts[] = [
   {
     label: 'Billing Account - Main (123456789012)',
     value: 'billing-main-123456789012',
   },
 ];
 
-const mockExtensiveNumOpenShiftVersions = {
+const mockExtensiveNumOpenShiftVersions: OpenShiftVersionsData = {
   latest: { label: 'OpenShift 4.12.0', value: '4.12.0' },
   default: { label: 'OpenShift 4.11.4', value: '4.11.4' },
   releases: Array.from({ length: 18 }, (_, i) => ({
@@ -456,49 +489,62 @@ const mockExtensiveNumOpenShiftVersions = {
   })),
 };
 
-const mockExtensiveNumAWsInfrastructureAccounts = Array.from({ length: 15 }, (_, i) => ({
-  label: `AWS Account - Environment ${i + 1} (${100000000000 + i})`,
-  value: `aws-env-${i + 1}-${100000000000 + i}`,
-}));
+const mockExtensiveNumAWsInfrastructureAccounts: AWSInfrastructureAccounts[] = Array.from(
+  { length: 15 },
+  (_, i) => ({
+    label: `AWS Account - Environment ${i + 1} (${100000000000 + i})`,
+    value: `aws-env-${i + 1}-${100000000000 + i}`,
+  })
+);
 
-const mockExtensiveNumAwsBillingAccounts = Array.from({ length: 10 }, (_, i) => ({
-  label: `Billing Account ${i + 1} (${100000000000 + i})`,
-  value: `billing-${i + 1}-${100000000000 + i}`,
-}));
+const mockExtensiveNumAwsBillingAccounts: AWSBillingAccounts[] = Array.from(
+  { length: 10 },
+  (_, i) => ({
+    label: `Billing Account ${i + 1} (${100000000000 + i})`,
+    value: `billing-${i + 1}-${100000000000 + i}`,
+  })
+);
 
-const mockExtensiveNumVPCs = Array.from({ length: 5 }, (_, i) => ({
+const mockExtensiveNumVPCs: VPC[] = Array.from({ length: 5 }, (_, i) => ({
   name: `extensive-vpc-${i + 3}`,
   id: `vpc-extensive-${i + 3}`,
   aws_subnets: [
     {
       subnet_id: `subnet-ext-private-${i}-a`,
       name: `extensive-vpc-${i + 3}-subnet-private1-us-east-1a`,
+      public: false,
       availability_zone: 'us-east-1a',
     },
     {
       subnet_id: `subnet-ext-public-${i}-a`,
       name: `extensive-vpc-${i + 3}-subnet-public1-us-east-1a`,
+      public: true,
       availability_zone: 'us-east-1a',
     },
     {
       subnet_id: `subnet-ext-private-${i}-b`,
       name: `extensive-vpc-${i + 3}-subnet-private1-us-east-1b`,
+      public: false,
       availability_zone: 'us-east-1b',
     },
     {
       subnet_id: `subnet-ext-public-${i}-b`,
       name: `extensive-vpc-${i + 3}-subnet-public1-us-east-1b`,
+      public: true,
       availability_zone: 'us-east-1b',
     },
   ],
 }));
 
-const mockExtensiveNumMachineTypes = Array.from({ length: 10 }, (_, i) => ({
-  id: `ext-instance-${i + 1}`,
-  label: `ext-instance-${i + 1}.xlarge`,
-  description: `${(i + 2) * 2} vCPU ${(i + 2) * 8} GiB RAM`,
-  value: `ext-instance-${i + 1}.xlarge`,
-}));
+const mockExtensiveNumMachineTypes: MachineTypesDropdownType[] = Array.from(
+  { length: 10 },
+  (_, i) => ({
+    id: `ext-instance-${i + 1}`,
+    label: `ext-instance-${i + 1}.xlarge`,
+    description: `${(i + 2) * 2} vCPU ${(i + 2) * 8} GiB RAM`,
+    value: `ext-instance-${i + 1}.xlarge`,
+  })
+);
 
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.helpers.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.helpers.ts
@@ -4,11 +4,12 @@ import type { OpenShiftVersionsData, ROSAHCPWizardData, Subnet } from './types';
 /** Private subnets from the first HCP wizard fixture VPC (names include `private`, matching `subnetsFilter`). */
 export function getMockStoryPrivateSubnets(): Subnet[] {
   return (fixtures.mockVPCs?.[0]?.aws_subnets ?? [])
-    .filter((s) => s.name.includes('private'))
-    .map(({ subnet_id, name, availability_zone }) => ({
+    .filter((s) => s.public === false)
+    .map(({ subnet_id, name, availability_zone, public: isPublic }) => ({
       subnet_id,
       name,
       availability_zone,
+      public: isPublic,
     }));
 }
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.fixtures.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.fixtures.ts
@@ -1,9 +1,9 @@
 import type { Subnet, VPC } from '../../../types';
 
 export const mockSubnets: Subnet[] = [
-  { subnet_id: 'subnet-001', name: 'Public Subnet A', availability_zone: 'us-east-1a' },
-  { subnet_id: 'subnet-002', name: 'Private Subnet A', availability_zone: 'us-east-1a' },
-  { subnet_id: 'subnet-003', name: 'Public Subnet B', availability_zone: 'us-east-1b' },
+  { subnet_id: 'subnet-001', name: 'public-subnet-a', availability_zone: 'us-east-1a' },
+  { subnet_id: 'subnet-002', name: 'private-subnet-a', availability_zone: 'us-east-1a' },
+  { subnet_id: 'subnet-003', name: 'public-subnet-b', availability_zone: 'us-east-1b' },
 ];
 
 export const mockVpcList: VPC[] = [
@@ -16,7 +16,7 @@ export const mockVpcList: VPC[] = [
     id: 'vpc-67890',
     name: 'Staging VPC',
     aws_subnets: [
-      { subnet_id: 'subnet-004', name: 'Staging Subnet A', availability_zone: 'us-west-2a' },
+      { subnet_id: 'subnet-004', name: 'staging-subnet-a', availability_zone: 'us-west-2a' },
     ],
   },
 ];

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.fixtures.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.fixtures.ts
@@ -1,9 +1,24 @@
 import type { Subnet, VPC } from '../../../types';
 
 export const mockSubnets: Subnet[] = [
-  { subnet_id: 'subnet-001', name: 'public-subnet-a', availability_zone: 'us-east-1a' },
-  { subnet_id: 'subnet-002', name: 'private-subnet-a', availability_zone: 'us-east-1a' },
-  { subnet_id: 'subnet-003', name: 'public-subnet-b', availability_zone: 'us-east-1b' },
+  {
+    subnet_id: 'subnet-001',
+    name: 'public-subnet-a',
+    availability_zone: 'us-east-1a',
+    public: true,
+  },
+  {
+    subnet_id: 'subnet-002',
+    name: 'private-subnet-a',
+    availability_zone: 'us-east-1a',
+    public: true,
+  },
+  {
+    subnet_id: 'subnet-003',
+    name: 'public-subnet-b',
+    availability_zone: 'us-east-1b',
+    public: true,
+  },
 ];
 
 export const mockVpcList: VPC[] = [
@@ -16,7 +31,12 @@ export const mockVpcList: VPC[] = [
     id: 'vpc-67890',
     name: 'Staging VPC',
     aws_subnets: [
-      { subnet_id: 'subnet-004', name: 'staging-subnet-a', availability_zone: 'us-west-2a' },
+      {
+        subnet_id: 'subnet-004',
+        name: 'staging-subnet-a',
+        availability_zone: 'us-west-2a',
+        public: true,
+      },
     ],
   },
 ];

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.fixtures.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.fixtures.ts
@@ -11,7 +11,7 @@ export const mockSubnets: Subnet[] = [
     subnet_id: 'subnet-002',
     name: 'private-subnet-a',
     availability_zone: 'us-east-1a',
-    public: true,
+    public: false,
   },
   {
     subnet_id: 'subnet-003',
@@ -35,7 +35,7 @@ export const mockVpcList: VPC[] = [
         subnet_id: 'subnet-004',
         name: 'staging-subnet-a',
         availability_zone: 'us-west-2a',
-        public: true,
+        public: false,
       },
     ],
   },

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.spec.tsx
@@ -307,4 +307,107 @@ test.describe('Networking (ROSA HCP)', () => {
       await expect(component.getByText(n.cidrLearnMoreLink)).toBeVisible();
     });
   });
+
+  test.describe('Networking — public subnet select', () => {
+    test('should render the public subnet select when Public radio is selected', async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <NetworkingMount defaultValues={{ selected_vpc: 'vpc-12345' }} />
+      );
+
+      await expect(
+        component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') })
+      ).toBeVisible();
+    });
+
+    test('should hide the public subnet select when Private radio is selected', async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <NetworkingMount
+          defaultValues={{
+            cluster_privacy: ClusterNetwork.internal,
+            selected_vpc: 'vpc-12345',
+          }}
+        />
+      );
+
+      await expect(
+        component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') })
+      ).toHaveCount(0);
+    });
+
+    test('should hide the public subnet select after switching from Public to Private', async ({
+      mount,
+    }) => {
+      const component = await mount(
+        <NetworkingMount defaultValues={{ selected_vpc: 'vpc-12345' }} />
+      );
+
+      await expect(
+        component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') })
+      ).toBeVisible();
+
+      await component.getByRole('radio', { name: n.privateLabel }).click();
+
+      await expect(
+        component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') })
+      ).toHaveCount(0);
+    });
+
+    test('should show public subnet options from the selected VPC', async ({ mount, page }) => {
+      const component = await mount(
+        <NetworkingMount defaultValues={{ selected_vpc: 'vpc-12345' }} />
+      );
+
+      await component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') }).click();
+
+      await expect(page.getByRole('option', { name: 'public-subnet-a' })).toBeVisible();
+      await expect(page.getByRole('option', { name: 'public-subnet-b' })).toBeVisible();
+    });
+
+    test('should not list private subnets in the public subnet select', async ({ mount, page }) => {
+      const component = await mount(
+        <NetworkingMount defaultValues={{ selected_vpc: 'vpc-12345' }} />
+      );
+
+      await component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') }).click();
+
+      await expect(page.getByRole('option', { name: 'private-subnet-a' })).toHaveCount(0);
+    });
+
+    test('should allow selecting a public subnet option', async ({ mount, page }) => {
+      const component = await mount(
+        <NetworkingMount defaultValues={{ selected_vpc: 'vpc-12345' }} />
+      );
+
+      await component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') }).click();
+
+      await page.getByRole('option', { name: 'public-subnet-a' }).click();
+
+      await expect(component.getByText('public-subnet-a')).toBeVisible();
+    });
+
+    test('should show no public subnet options when a VPC with no public subnets is selected', async ({
+      mount,
+      page,
+    }) => {
+      const component = await mount(
+        <NetworkingMount defaultValues={{ selected_vpc: 'vpc-67890' }} />
+      );
+
+      await component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') }).click();
+
+      await expect(page.getByRole('option', { name: /no results found/i })).toBeVisible();
+    });
+
+    test('should show no public subnet options when no VPC is selected', async ({ mount }) => {
+      const component = await mount(<NetworkingMount />);
+
+      await expect(
+        component.getByRole('button', { name: new RegExp(n.publicSubnetLabel, 'i') })
+      ).toBeVisible();
+    });
+  });
 });

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.tsx
@@ -19,14 +19,26 @@ import { useWatch } from 'react-hook-form';
 import { WizSelect } from '../../../components/WizFields/WizSelect';
 import { WizCheckbox } from '../../../components/WizFields/WizCheckbox';
 import { WizTextInput } from '../../../components/WizFields/WizTextInput';
+import {
+  buildMachinePoolsReviewSelectOptions,
+  resolveSelectedVpc,
+} from '@redhat-cloud-services/nxtcm-rosa-hcp-wizard/helpers';
+import { useMemo } from 'react';
 
 type NetworkingStepProps = Pick<ROSAHCPWizardData, 'vpcList' | 'subnets'>;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const Networking = (props: NetworkingStepProps) => {
   const { networking: n } = useRosaHcpWizardStrings();
 
   const cidrDefaultChecked = useWatch({ name: 'cidr_default' });
+  const selectedVPCRaw = useWatch({ name: 'selected_vpc' });
+
+  const selectedVPC = resolveSelectedVpc(selectedVPCRaw, props.vpcList.data);
+
+  const { publicSubnet } = useMemo(
+    () => buildMachinePoolsReviewSelectOptions(selectedVPC, props.vpcList.data),
+    [selectedVPC, props.vpcList.data]
+  );
 
   return (
     <Section label={n.sectionLabel} description={n.privacyHelper}>
@@ -38,7 +50,11 @@ export const Networking = (props: NetworkingStepProps) => {
             value={ClusterNetwork.external}
             label={n.publicLabel}
           >
-            <WizSelect name="cluster_privacy_public_subnet_id" schema={clusterValidationSchema} />
+            <WizSelect
+              name="cluster_privacy_public_subnet_id"
+              schema={clusterValidationSchema}
+              options={publicSubnet}
+            />
           </Radio>
 
           <Radio

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.tsx
@@ -15,7 +15,7 @@ import { WizRadioGroup } from '../../../components/WizFields/WizRadioGroup';
 import { Radio } from '../../../components/Fields/RadioGroup';
 import { clusterValidationSchema } from '../../../yupSchemas';
 import { FieldWrapper } from '../../../components/FieldWrapper';
-import { useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import { WizSelect } from '../../../components/WizFields/WizSelect';
 import { WizCheckbox } from '../../../components/WizFields/WizCheckbox';
 import { WizTextInput } from '../../../components/WizFields/WizTextInput';
@@ -23,7 +23,8 @@ import {
   buildMachinePoolsReviewSelectOptions,
   resolveSelectedVpc,
 } from '@redhat-cloud-services/nxtcm-rosa-hcp-wizard/helpers';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
+import { useClearFieldWhenHidden } from '../../OptionalSetup/Encryption/useClearFieldWhenHidden';
 
 type NetworkingStepProps = Pick<ROSAHCPWizardData, 'vpcList' | 'subnets'>;
 
@@ -39,6 +40,26 @@ export const Networking = (props: NetworkingStepProps) => {
     () => buildMachinePoolsReviewSelectOptions(selectedVPC, props.vpcList.data),
     [selectedVPC, props.vpcList.data]
   );
+
+  const clusterPrivacy = useWatch({ name: 'cluster_privacy' });
+  useClearFieldWhenHidden<ROSAHCPCluster>(
+    'cluster_privacy_public_subnet_id',
+    clusterPrivacy === ClusterNetwork.internal
+  );
+
+  const { setValue } = useFormContext<ROSAHCPCluster>();
+  const previousVpcRef = useRef<string | undefined>(selectedVPC?.id);
+  useEffect(() => {
+    const currentVpcId = selectedVPC?.id;
+    if (previousVpcRef.current === null || previousVpcRef.current === undefined) {
+      previousVpcRef.current = currentVpcId;
+      return;
+    }
+    if (currentVpcId !== previousVpcRef.current) {
+      setValue('cluster_privacy_public_subnet_id', undefined as never, { shouldValidate: true });
+    }
+    previousVpcRef.current = currentVpcId;
+  }, [selectedVPC?.id, setValue]);
 
   return (
     <Section label={n.sectionLabel} description={n.privacyHelper}>

--- a/packages/nxtcm-rosa-hcp-wizard/src/helpers.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/helpers.ts
@@ -148,12 +148,12 @@ const constructSelectedSubnets = (formValues?: ROSAHCPCluster): CIDRSubnet[] => 
 };
 
 const subnetsFilter = (selectedVPC: VPC | undefined) => {
-  const privateSubnets = selectedVPC?.aws_subnets.filter((privateSubnet: Subnet) =>
-    privateSubnet.name.includes('private')
+  const privateSubnets = selectedVPC?.aws_subnets.filter(
+    (privateSubnet: Subnet) => privateSubnet.public === false
   );
 
-  const publicSubnets = selectedVPC?.aws_subnets.filter((publicSubnet: Subnet) =>
-    publicSubnet.name.includes('public')
+  const publicSubnets = selectedVPC?.aws_subnets.filter(
+    (publicSubnet: Subnet) => publicSubnet.public === true
   );
 
   return {

--- a/packages/nxtcm-rosa-hcp-wizard/src/helpers.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/helpers.ts
@@ -14,6 +14,7 @@ export type LabelValueOption = { label: string; value: string };
 export type MachinePoolsReviewSelectOptions = {
   vpc: LabelValueOption[];
   subnet: LabelValueOption[];
+  publicSubnet: LabelValueOption[];
   securityGroup: LabelValueOption[];
 };
 
@@ -42,7 +43,7 @@ export function buildMachinePoolsReviewSelectOptions(
   selectedVPC: VPC | undefined,
   vpcListData: VPC[]
 ): MachinePoolsReviewSelectOptions {
-  const { privateSubnets } = subnetsFilter(selectedVPC);
+  const { privateSubnets, publicSubnets } = subnetsFilter(selectedVPC);
   const securityGroups = [...(selectedVPC?.aws_security_groups ?? [])];
   securityGroups.sort(securityGroupsSort);
 
@@ -52,6 +53,10 @@ export function buildMachinePoolsReviewSelectOptions(
       value: vpc.id,
     })),
     subnet: (privateSubnets ?? []).map((subnet) => ({
+      label: subnet.name,
+      value: subnet.subnet_id,
+    })),
+    publicSubnet: (publicSubnets ?? []).map((subnet) => ({
       label: subnet.name,
       value: subnet.subnet_id,
     })),

--- a/packages/nxtcm-rosa-hcp-wizard/src/types.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/types.ts
@@ -65,11 +65,13 @@ export type Subnet = {
   subnet_id: string;
   name: string;
   availability_zone: string;
+  public: boolean;
 };
 
 export type CIDRSubnet = {
   cidr_block: string;
   name: string;
+  public: boolean;
   subnet_id: string;
   availability_zone: string;
 };
@@ -82,8 +84,8 @@ export type VPC = {
 };
 
 export type SecurityGroup = {
-  id?: string;
-  name?: string;
+  id: string;
+  name: string;
   red_hat_managed?: boolean;
 };
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/yupSchemas.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/yupSchemas.test.ts
@@ -690,6 +690,7 @@ describe('yupSchemas – composed clusterValidationSchema', () => {
           cidr_block: '192.168.1.0/24',
           name: 'my-subnet',
           subnet_id: 'sub-1',
+          public: true,
           availability_zone: 'us-east-1a',
         },
       ];
@@ -772,6 +773,7 @@ describe('yupSchemas – composed clusterValidationSchema', () => {
           cidr_block: '172.30.0.0/24',
           name: 'svc-subnet',
           subnet_id: 'sub-2',
+          public: true,
           availability_zone: 'us-east-1a',
         },
       ];
@@ -866,6 +868,7 @@ describe('yupSchemas – composed clusterValidationSchema', () => {
           cidr_block: '10.128.0.0/24',
           name: 'pod-subnet',
           subnet_id: 'sub-3',
+          public: true,
           availability_zone: 'us-east-1a',
         },
       ];

--- a/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizard.spec.tsx
@@ -103,6 +103,7 @@ const minimalWizardsStepsData: { basicSetupStep: BasicSetupStepProps } = {
             subnet_id: 'subnet-1',
             name: 'subnet-a',
             availability_zone: 'us-east-1a',
+            public: true,
             cidr_block: '10.0.0.0/24',
           },
         ],

--- a/src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx
+++ b/src/components/Wizards/RosaWizard/RosaWizardIntegrationContract.stories.tsx
@@ -62,11 +62,13 @@ const vpcList: VPC[] = [
       {
         subnet_id: 'subnet-private-a',
         name: 'example-subnet-private1-us-east-1a',
+        public: false,
         availability_zone: 'us-east-1a',
       },
       {
         subnet_id: 'subnet-public-a',
         name: 'example-subnet-public1-us-east-1a',
+        public: true,
         availability_zone: 'us-east-1a',
       },
     ],

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.fixtures.ts
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/MachinePoolsSubstep/MachinePoolsSubstep.fixtures.ts
@@ -19,21 +19,25 @@ export const mockSubnets: Subnet[] = [
   {
     subnet_id: 'subnet-private-1',
     name: 'my-vpc-private-us-east-1a',
+    public: false,
     availability_zone: 'us-east-1a',
   },
   {
     subnet_id: 'subnet-private-2',
     name: 'my-vpc-private-us-east-1b',
+    public: false,
     availability_zone: 'us-east-1b',
   },
   {
     subnet_id: 'subnet-public-1',
     name: 'my-vpc-public-us-east-1a',
+    public: true,
     availability_zone: 'us-east-1a',
   },
   {
     subnet_id: 'subnet-public-2',
     name: 'my-vpc-public-us-east-1b',
+    public: true,
     availability_zone: 'us-east-1b',
   },
 ];
@@ -53,11 +57,13 @@ export const mockVpcList: Resource<VPC[]> = {
         {
           subnet_id: 'subnet-staging-private',
           name: 'staging-private-subnet',
+          public: false,
           availability_zone: 'us-west-2a',
         },
         {
           subnet_id: 'subnet-staging-public',
           name: 'staging-public-subnet',
+          public: true,
           availability_zone: 'us-west-2a',
         },
       ],

--- a/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.story.tsx
+++ b/src/components/Wizards/RosaWizard/Steps/BasicSetupStep/NetworkingAndSubnetsSubStep/NetworkingAndSubnetsSubStep.story.tsx
@@ -22,22 +22,26 @@ const mockResource = <TData,>(data: TData): Resource<TData> => ({
 export const mockSubnets: Subnet[] = [
   {
     subnet_id: 'subnet-private-1',
+    public: false,
     name: 'my-vpc-private-us-east-1a',
     availability_zone: 'us-east-1a',
   },
   {
     subnet_id: 'subnet-private-2',
+    public: false,
     name: 'my-vpc-private-us-east-1b',
     availability_zone: 'us-east-1b',
   },
   {
     subnet_id: 'subnet-public-1',
     name: 'my-vpc-public-us-east-1a',
+    public: true,
     availability_zone: 'us-east-1a',
   },
   {
     subnet_id: 'subnet-public-2',
     name: 'my-vpc-public-us-east-1b',
+    public: true,
     availability_zone: 'us-east-1b',
   },
 ];
@@ -55,11 +59,13 @@ export const mockVpcList: VPC[] = [
       {
         subnet_id: 'subnet-staging-private',
         name: 'staging-private-subnet',
+        public: false,
         availability_zone: 'us-west-2a',
       },
       {
         subnet_id: 'subnet-staging-public',
         name: 'staging-public-subnet',
+        public: true,
         availability_zone: 'us-west-2a',
       },
     ],

--- a/src/components/Wizards/RosaWizard/rosaWizardTestMocks.ts
+++ b/src/components/Wizards/RosaWizard/rosaWizardTestMocks.ts
@@ -81,6 +81,7 @@ const mockVpcs: VPC[] = [
       {
         subnet_id: 'subnet-0cd89766e94deb008',
         name: 'test-1-subnet-public1-us-east-1b',
+        public: true,
         availability_zone: 'us-east-1b',
       },
     ],

--- a/src/components/Wizards/types.ts
+++ b/src/components/Wizards/types.ts
@@ -74,12 +74,14 @@ export type Role = {
 export type Subnet = {
   subnet_id: string;
   name: string;
+  public: boolean;
   availability_zone: string;
 };
 
 export type CIDRSubnet = {
   cidr_block: string;
   name: string;
+  public: boolean;
   subnet_id: string;
   availability_zone: string;
 };

--- a/src/examples/rosaWizardIntegration.example.tsx
+++ b/src/examples/rosaWizardIntegration.example.tsx
@@ -61,6 +61,7 @@ const exampleVpcList: VPC[] = [
       {
         subnet_id: 'subnet-private-a',
         name: 'example-subnet-private1-us-east-1a',
+        public: false,
         availability_zone: 'us-east-1a',
       },
     ],


### PR DESCRIPTION
## Description

Add public subnet filtering and selection to the ROSA HCP Networking step.

- Extended `buildMachinePoolsReviewSelectOptions` in `helpers.ts` to return `publicSubnet` options (filtered from VPC subnets whose name contains "public").
- Wired a `WizSelect` for `cluster_privacy_public_subnet_id` inside the Public radio option in `Networking.tsx`, populated from the selected VPC's public subnets via `resolveSelectedVpc` + `buildMachinePoolsReviewSelectOptions`.
- Added reset logic: the public subnet field is cleared when the user switches to Private (`useClearFieldWhenHidden`) and when the selected VPC changes (ref-based `useEffect`).
- Added 8 Playwright CT tests covering public subnet select visibility, option filtering, selection, empty states, and radio toggle behavior.
- Updated test fixtures to use lowercase subnet names matching the case-sensitive `subnetsFilter`.

**Jira issue #** [FCN-439](https://redhat.atlassian.net/browse/FCN-439)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Navigate to the ROSA HCP Wizard → Networking step
2. With a VPC selected, verify the "Public subnet name" select appears inside the Public radio and lists only public subnets from that VPC
3. Select a public subnet, switch to Private radio, then back to Public — confirm the previously selected subnet is cleared
4. Change the selected VPC and confirm the public subnet selection resets

**Test Environment:**
- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)

**Unit Tests:**
- [x] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A

### Before

### After


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

The `MachinePoolsReviewSelectOptions` type in `helpers.ts` gained a new `publicSubnet` field. Existing consumers that destructure only `vpc`, `subnet`, and `securityGroup` are unaffected.


## Reviewer Guidelines

### Focus Areas
- `Networking.tsx` — the `useClearFieldWhenHidden` and VPC-change `useEffect` reset logic
- `helpers.ts` — `publicSubnet` addition to `buildMachinePoolsReviewSelectOptions`
- `Networking.spec.tsx` — new "public subnet select" test suite (8 tests)
- `Networking.fixtures.ts` — lowercase subnet names to match `subnetsFilter`

### Questions for Reviewers
-

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-439]: https://redhat.atlassian.net/browse/FCN-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ