### PR TITLE
FCN-356 add publish workflow and finalize dashboard package metadata

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,15 @@ jobs:
             exit 1
           fi
 
+      - name: Verify release tag matches dashboard package version
+        run: |
+          expected="nxtcm-dashboard-v$(node -p "require('./packages/nxtcm-dashboard/package.json').version")"
+          actual="${{ github.event.release.tag_name }}"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Release tag $actual does not match expected $expected"
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -43,13 +52,19 @@ jobs:
           fi
 
       - name: Run dashboard lint
-        run: npx eslint --config .eslintrc.json 'packages/nxtcm-dashboard/src/**/*.{ts,tsx}'
+        run: npm run lint -w packages/nxtcm-dashboard
 
       - name: Run dashboard type-check
         run: npm run type-check -w packages/nxtcm-dashboard
 
       - name: Run dashboard unit tests
         run: npm run test -w packages/nxtcm-dashboard
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run dashboard component tests
+        run: npm run test:ct -w packages/nxtcm-dashboard
 
       - name: Build dashboard package
         run: npm run build -w packages/nxtcm-dashboard
@@ -78,15 +93,6 @@ jobs:
 
       - name: Build dashboard package
         run: npm run build -w packages/nxtcm-dashboard
-
-      - name: Verify release tag matches dashboard package version
-        run: |
-          expected="v$(node -p "require('./packages/nxtcm-dashboard/package.json').version")"
-          actual="${{ github.event.release.tag_name }}"
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::Release tag $actual does not match dashboard package version $expected"
-            exit 1
-          fi
 
       - name: Publish dashboard package
         run: npm publish -w packages/nxtcm-dashboard --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,5 +69,14 @@ jobs:
       - name: Build dashboard package
         run: npm run build -w packages/nxtcm-dashboard
 
+      - name: Verify release tag matches dashboard package version
+        run: |
+          expected="v$(node -p "require('./packages/nxtcm-dashboard/package.json').version")"
+          actual="${{ github.event.release.tag_name }}"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::Release tag $actual does not match dashboard package version $expected"
+            exit 1
+          fi
+
       - name: Publish dashboard package
         run: npm publish -w packages/nxtcm-dashboard --provenance --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Verify release tag is reachable from main
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" refs/remotes/origin/main; then
+            echo "::error::Release tag $GITHUB_REF_NAME ($GITHUB_SHA) is not reachable from main"
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   quality-gates:
     name: Dashboard Quality Gates
+    if: github.event.release.target_commitish == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -23,6 +24,13 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Check lockfile for git-based dependencies
+        run: |
+          if grep -qE '"resolved":\s*"(git\+|git:|github:)' package-lock.json; then
+            echo "::error::git-based dependency found in lockfile (supply chain risk)"
+            exit 1
+          fi
 
       - name: Run dashboard lint
         run: npx eslint --config .eslintrc.json 'packages/nxtcm-dashboard/src/**/*.{ts,tsx}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
     if: github.repository == 'RedHatInsights/nxtcm-components'
     runs-on: ubuntu-latest
     needs: quality-gates
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,11 +26,12 @@ jobs:
           fi
 
       - name: Verify release tag matches dashboard package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           expected="nxtcm-dashboard-v$(node -p "require('./packages/nxtcm-dashboard/package.json').version")"
-          actual="${{ github.event.release.tag_name }}"
-          if [ "$actual" != "$expected" ]; then
-            echo "::error::Release tag $actual does not match expected $expected"
+          if [ "$RELEASE_TAG" != "$expected" ]; then
+            echo "::error::Release tag $RELEASE_TAG does not match expected $expected"
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,64 @@
+name: Publish Dashboard
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  quality-gates:
+    name: Dashboard Quality Gates
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run dashboard lint
+        run: npx eslint --config .eslintrc.json 'packages/nxtcm-dashboard/src/**/*.{ts,tsx}'
+
+      - name: Run dashboard type-check
+        run: npm run type-check -w packages/nxtcm-dashboard
+
+      - name: Run dashboard unit tests
+        run: npm run test -w packages/nxtcm-dashboard
+
+      - name: Build dashboard package
+        run: npm run build -w packages/nxtcm-dashboard
+
+  publish:
+    name: Publish to npm
+    if: github.repository == 'RedHatInsights/nxtcm-components'
+    runs-on: ubuntu-latest
+    needs: quality-gates
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dashboard package
+        run: npm run build -w packages/nxtcm-dashboard
+
+      - name: Publish dashboard package
+        run: npm publish -w packages/nxtcm-dashboard --provenance --access public

--- a/packages/nxtcm-dashboard/README.md
+++ b/packages/nxtcm-dashboard/README.md
@@ -1,3 +1,54 @@
 # @redhat-cloud-services/nxtcm-dashboard
 
-PatternFly dashboard widget components for ACM and OCM console home views
+PatternFly dashboard widget components for ACM and OCM console home views.
+
+## Installation
+
+```bash
+npm install @redhat-cloud-services/nxtcm-dashboard
+```
+
+## Peer dependencies
+
+This package expects these dependencies to be provided by the consuming application:
+
+- `react`
+- `react-dom`
+- `@patternfly/react-core`
+- `@patternfly/react-icons`
+- `@patternfly/react-table`
+- `@patternfly/react-charts`
+- `@patternfly/widgetized-dashboard`
+
+## Usage
+
+```tsx
+import { TotalClusters, AdvisorSeverity } from '@redhat-cloud-services/nxtcm-dashboard';
+
+export const DashboardSummary = () => (
+  <>
+    <TotalClusters data={{ total: 67 }} />
+    <AdvisorSeverity severity={{ critical: 3, important: 8, moderate: 12, low: 20 }} />
+  </>
+);
+```
+
+## Component catalog
+
+- `Dashboard` - configurable widgetized dashboard layout wrapper
+- `TotalClusters` - total managed cluster count card
+- `ClusterProviders` - provider distribution donut card
+- `ClustersWithIssues` - clusters with issues table card
+- `ResourceUtilization` - utilization donut card
+- `ExpiredTrials` - expired trials table card
+- `Telemetry` - connected vs disconnected status card
+- `UpdateStatus` - up to date vs update available card
+- `AdvisorSeverity` - advisor counts by severity card
+- `AdvisorCategories` - advisor counts by category donut card
+- `CostManagement` - total and per-cluster cost card
+- `CVECard` - CVE counts by severity card
+- `ClusterRecommendations` - recommendation summary card
+- `Subscriptions` - subscription status and counts card
+- `UpgradeRisks` - upgrade risk severity card
+- `LoadingPanel` - generic loading state panel
+- `NotificationsPanel` - notifications table card

--- a/packages/nxtcm-dashboard/README.md
+++ b/packages/nxtcm-dashboard/README.md
@@ -23,6 +23,7 @@ This package expects these dependencies to be provided by the consuming applicat
 ## Usage
 
 ```tsx
+import '@redhat-cloud-services/nxtcm-dashboard/dist/index.css';
 import { TotalClusters, AdvisorSeverity } from '@redhat-cloud-services/nxtcm-dashboard';
 
 export const DashboardSummary = () => (

--- a/packages/nxtcm-dashboard/package.json
+++ b/packages/nxtcm-dashboard/package.json
@@ -4,9 +4,14 @@
   "description": "PatternFly dashboard widget components for ACM and OCM console home views",
   "author": "Red Hat",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RedHatInsights/nxtcm-components.git",
+    "directory": "packages/nxtcm-dashboard"
+  },
   "main": "dist/index.umd.js",
   "module": "dist/index.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "files": [
     "dist",
     "README.md",
@@ -26,7 +31,7 @@
   "scripts": {
     "prepack": "cp ../../LICENSE LICENSE",
     "postpack": "rm -f LICENSE",
-    "build": "tsc && NXTCM_LIB_NAME=NXTCM-DASHBOARD vite build --config ../../vite.config.ts",
+    "build": "rm -rf dist && tsc && NXTCM_LIB_NAME=NXTCM-DASHBOARD vite build --config ../../vite.config.ts",
     "type-check": "tsc --noEmit",
     "lint": "eslint --config ../../.eslintrc.json 'src/**/*.{ts,tsx}'",
     "lint:fix": "eslint --config ../../.eslintrc.json 'src/**/*.{ts,tsx}' --fix",
@@ -35,5 +40,20 @@
     "test": "jest --config ../../jest.config.js packages/nxtcm-dashboard --passWithNoTests",
     "test:ct": "playwright test -c ../../playwright-ct.config.ts packages/nxtcm-dashboard",
     "allthethings": "npm run prettier:fix && npm run lint:fix && npm run type-check && npm run test && npm run test:ct"
+  },
+  "peerDependencies": {
+    "@patternfly/react-charts": "^8.4.0",
+    "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-icons": "^6.3.1",
+    "@patternfly/react-table": "^6.0.0",
+    "@patternfly/widgetized-dashboard": "^1.0.0-prerelease.6",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "sideEffects": [
+    "*.css"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Description

Add the npm publish workflow and finalize package metadata for `@redhat-cloud-services/nxtcm-dashboard` so it's ready for first release.

**Security governance gate implemented:** the publish job uses a `npm-publish` GitHub Environment with required reviewers, so no single maintainer can independently trigger a release. This matches the team decision from the Slack thread (Jun 5) where Roberto confirmed the release PR / approval path is preferred.

**Tag convention:** `nxtcm-dashboard-v<version>` (e.g. `nxtcm-dashboard-v6.0.0`). Namespaced from the start so future wizard releases won't collide.

**Jira issue #** [FCN-356](https://redhat.atlassian.net/browse/FCN-356)

**Backport of** N/A


## Type of Change

- [x] New feature/enhancement (non-breaking change which adds functionality)
- [x] Infrastructure/build change
- [x] Documentation update


## What's in this PR

### publish.yml (new)
- Triggered on GitHub Release (`release: published`)
- **Quality gates job:** ancestry check, version tag match (`nxtcm-dashboard-v*`), git dep check, lint, type-check, unit tests, Playwright CT tests, build
- **Publish job:** OIDC auth (`id-token: write`), `--provenance`, `environment: npm-publish` gate, `github.repository` fork guard

### package.json changes
- Fixed `types` path (`dist/index.d.ts` not `dist/src/index.d.ts`)
- Added `rm -rf dist` to build script (prevent stale artifacts)
- Added `repository.directory` for npm page linking
- Added `peerDependencies` (7 runtime deps)
- Added `sideEffects: ["*.css"]` (prevent CSS tree-shaking)
- Added `publishConfig: { access: "public" }`

### README.md expanded
- Installation, CSS import note, peer deps, usage example, component catalog


## Testing

### Local checks (all pass)
- `npm run lint -w packages/nxtcm-dashboard` — pass
- `npm run type-check -w packages/nxtcm-dashboard` — pass
- `npm run test -w packages/nxtcm-dashboard` — pass
- `npm run test:ct -w packages/nxtcm-dashboard` — 297 passed, 1 skipped
- `npm run build -w packages/nxtcm-dashboard` — 63 modules, 357ms
- `npm pack --dry-run` — 83 files, 154.5 kB, no test/story/scss artifacts

### Fork workflow test
Workflow tested on fork — all quality gates pass, publish correctly skipped due to `github.repository` guard:
https://github.com/vishsanghishetty/nxtcm-components/actions/runs/28049315722

**Test Environment:**
- [x] Tested locally
- [x] Tested in CI (fork)


## Screenshots/Recordings

N/A — infrastructure/config change, no UI modifications.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors
- [x] Code formatting is correct

### Documentation
- [x] I have updated the README if necessary

### Dependencies
- [x] Any dependent changes have been merged and published (FCN-99 is closed)


## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No


## Additional Notes

**Governance implementation:** The publish job references a `npm-publish` GitHub Environment. A repo admin needs to create this environment in Settings → Environments and add required reviewers. Until that's done, the environment gets auto-created with no protection rules on first workflow run.

**OIDC trusted publishing:** Uses `id-token: write` for npm authentication via OIDC exchange — no long-lived `NODE_AUTH_TOKEN` secret needed. The npm org admin (Karel) will bind OIDC trusted publishing to this repo/workflow after this PR merges.

**Direct push to main disabled:** Roberto already applied this (Jun 5). Ruleset migration tracked separately in FCN-505.

**Follow-up ticket:** FCN-560 — CI check to enforce consistent PF peer dep versions across workspaces.


## Reviewer Guidelines

### Focus Areas
- `publish.yml` workflow structure, security layers, and execution order
- Tag convention (`nxtcm-dashboard-v*`) for future multi-package releases
- `peerDependencies` completeness in dashboard package.json
- README content accuracy

### Admin follow-up needed after merge
1. Roberto: create `npm-publish` environment in repo Settings → add required reviewers
2. Karel: bind OIDC trusted publishing to this repo/workflow on npm
3. First release: create GitHub Release with tag `nxtcm-dashboard-v6.0.0`

[FCN-356]: https://redhat.atlassian.net/browse/FCN-356