### PR TITLE
FCN-238 refactor drawer

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/AssociateAWSAccountInfo.css
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/AssociateAWSAccountInfo.css
@@ -1,0 +1,11 @@
+.associate-aws-account-info .pf-v6-c-expandable-section__toggle {
+  margin: 0;
+  font-family: var(--pf-t--global--font--family--heading);
+  font-size: var(--pf-t--global--font--size--heading--xs);
+  font-weight: var(--pf-t--global--font--weight--heading--default);
+  line-height: var(--pf-t--global--font--line-height--heading);
+}
+
+.associate-aws-account-info .pf-v6-c-expandable-section__toggle .pf-v6-c-button.pf-m-link {
+  font: inherit;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/AssociateAWSAccountInfo.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/AssociateAWSAccountInfo.tsx
@@ -1,5 +1,7 @@
-import { ExpandableSection, Title } from '@patternfly/react-core';
+import { ExpandableSection } from '@patternfly/react-core';
 import React from 'react';
+
+import './AssociateAWSAccountInfo.css';
 
 type AssociateAWSAccountInfoProps = {
   title: string;
@@ -14,20 +16,16 @@ export const AssociateAWSAccountInfo = (props: AssociateAWSAccountInfoProps) => 
     setIsExpanded(isExpanded);
   };
   return (
-    <>
-      <ExpandableSection
-        onToggle={(event: React.MouseEvent<Element, MouseEvent>, isExpanded: boolean) =>
-          onToggle(event, isExpanded)
-        }
-        isExpanded={isExpanded}
-        toggleContent={
-          <Title headingLevel="h3" size="md">
-            {title}
-          </Title>
-        }
-      >
-        {props.children}
-      </ExpandableSection>
-    </>
+    <ExpandableSection
+      className="associate-aws-account-info"
+      toggleWrapper="h3"
+      toggleText={title}
+      onToggle={(event: React.MouseEvent<Element, MouseEvent>, isExpanded: boolean) =>
+        onToggle(event, isExpanded)
+      }
+      isExpanded={isExpanded}
+    >
+      {props.children}
+    </ExpandableSection>
   );
 };

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/DetailsStepDrawer.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/DetailsStepDrawer.tsx
@@ -18,7 +18,7 @@ import { OCMRole } from './OCMRole';
 import { AccountRoles } from './AccountRoles';
 import { useRosaHcpWizardStrings } from '../../stringsProvider/RosaHcpWizardStringsContext';
 import { UserRole } from './UserRole';
-import { AssociateAWSAccountInfo } from '../AssociateAWSAccountInfo';
+import { AssociateAWSAccountInfo } from './AssociateAWSAccountInfo';
 
 type StepDrawerProps = {
   isDrawerExpanded: boolean;
@@ -31,7 +31,7 @@ export const DetailsStepDrawer = (props: StepDrawerProps) => {
   const { isDrawerExpanded, onWizardExpand, setIsDrawerExpanded } = props;
   const d = useRosaHcpWizardStrings().associateAwsDrawer;
   return (
-    <Drawer isInline isExpanded={isDrawerExpanded} onExpand={onWizardExpand}>
+    <Drawer isExpanded={isDrawerExpanded} onExpand={onWizardExpand}>
       <DrawerContent
         panelContent={
           <DrawerPanelContent isResizable={true} defaultSize="40%">

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/OCMRole.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/OCMRole.tsx
@@ -1,15 +1,17 @@
 import { Alert, AlertVariant, Content, ContentVariants, Title } from '@patternfly/react-core';
 import { useRosaHcpWizardStrings } from '../../stringsProvider/RosaHcpWizardStringsContext';
 import { CopyInstruction } from '../CopyInstruction';
-import { TabGroup } from '../TabGroup';
+import { TabGroup } from './TabGroup';
 import PopoverHintWithTitle from '../PopoverHintWithTitle';
+import ExternalLink from '../ExternalLink';
+import links from '../../constants/links';
 
 export const OCMRole = () => {
   const { ocmRole: o, associateAwsDrawer: a } = useRosaHcpWizardStrings();
-
+  const u = useRosaHcpWizardStrings().userRole;
   return (
     <>
-      <Title headingLevel="h3" className="pf-v6-u-mb-md" size="md">
+      <Title headingLevel="h4" className="pf-v6-u-mb-md" size="md">
         {o.checkLinkedTitle}
       </Title>
 
@@ -23,10 +25,20 @@ export const OCMRole = () => {
         className="pf-v6-u-mb-lg"
       />
 
-      <Title headingLevel="h3" size="md">
+      <Title headingLevel="h4" size="md">
         {o.unlinkedTitle}
       </Title>
-
+      <PopoverHintWithTitle
+        title={u.whyLinkTitle}
+        bodyContent={
+          <>
+            {u.whyLinkBodyPrefix}{' '}
+            <ExternalLink href={links.ROSA_AWS_ACCOUNT_ASSOCIATION}>
+              {u.reviewPermissionsLink}
+            </ExternalLink>
+          </>
+        }
+      />
       <TabGroup
         tabs={[
           {

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/TabGroup.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/TabGroup.tsx
@@ -26,7 +26,7 @@ export const TabGroup: React.FunctionComponent<ToggleGroupTabsProps> = ({ tabs }
   };
 
   return (
-    <Stack hasGutter>
+    <Stack hasGutter className="pf-v6-u-mt-md">
       <StackItem>
         <ToggleGroup>
           {tabs.map((tab) => (

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/UserRole.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/DetailsStepDrawer/UserRole.tsx
@@ -1,10 +1,7 @@
-import { Alert, AlertVariant, Content, ContentVariants, Title } from '@patternfly/react-core';
+import { Alert, AlertVariant, Title } from '@patternfly/react-core';
 import { useRosaHcpWizardStrings } from '../../stringsProvider/RosaHcpWizardStringsContext';
 import { CopyInstruction } from '../CopyInstruction';
-import PopoverHintWithTitle from '../PopoverHintWithTitle';
-import ExternalLink from '../ExternalLink';
-import links from '../../constants/links';
-import { TabGroup } from '../TabGroup';
+import { TabGroup } from './TabGroup';
 import PopoverHint from '../PopoverHint';
 
 export const UserRole = () => {
@@ -12,7 +9,7 @@ export const UserRole = () => {
 
   return (
     <>
-      <Title headingLevel="h3" className="pf-v6-u-mb-md" size="md">
+      <Title headingLevel="h4" className="pf-v6-u-mb-md" size="md">
         {u.checkLinkedTitle}
       </Title>
 
@@ -32,19 +29,9 @@ export const UserRole = () => {
         className="pf-v6-u-mb-lg"
       />
 
-      <Content component={ContentVariants.h3}>{u.unlinkedTitle}</Content>
-
-      <PopoverHintWithTitle
-        title={u.whyLinkTitle}
-        bodyContent={
-          <>
-            {u.whyLinkBodyPrefix}{' '}
-            <ExternalLink href={links.ROSA_AWS_ACCOUNT_ASSOCIATION}>
-              {u.reviewPermissionsLink}
-            </ExternalLink>
-          </>
-        }
-      />
+      <Title headingLevel="h4" size="md">
+        {u.unlinkedTitle}
+      </Title>
 
       <TabGroup
         tabs={[


### PR DESCRIPTION
## Description

Refactors the ROSA HCP wizard **Associate AWS account** drawer to align layout and heading hierarchy.

Changes include:

- **Drawer layout:** Remove `isInline` from the drawer so opening the panel no longer shifts or compresses the main wizard content.  This prevents weird and strange layout issues with the GUI wizard.
- **Co-located drawer components:** Move `AssociateAWSAccountInfo` and `TabGroup` into `DetailsStepDrawer/` alongside the role instruction components that consume them.
- **Expandable step sections:** Replace custom `Title`-wrapped toggle content with PatternFly `ExpandableSection` (`toggleText`, `toggleWrapper="h3"`) and add CSS so step headings use design-token heading styles.
- **Heading hierarchy:** Demote in-section titles in `OCMRole` and `UserRole` from `h3` to `h4` so step titles (`h3`) and section titles (`h4`) nest correctly.
- **Content placement:** Move the “Why link?” popover hint from the User role step to the OCM role step where it applies.
- **Spacing:** Add top margin to `TabGroup` toggle content for clearer separation from section headings.

Verified that CLI copy commands and existing tab flows are correct as compared with designs and OCM.

**Jira issue #** [FCN-238](https://redhat.atlassian.net/browse/FCN-238)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Open the ROSA HCP wizard and expand the **Associate AWS account** drawer from the Details step.
2. Confirm the main wizard layout is stable when the drawer opens (no inline compression or unexpected reflow).
3. Verify the three expandable steps (OCM role, User role, Account roles) use consistent heading styling and expand/collapse correctly; step 1 is expanded by default.
4. In **OCM role**, confirm the “Why link?” popover appears and links to AWS account association docs; toggle **Create new** / **Link existing** tabs and verify copy commands.
5. In **User role**, confirm section headings and tabbed create/link commands render without the OCM-only popover; verify copy commands.
6. Compare drawer spacing and heading levels against design expectations.

**Test Environment:**
- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A — visual/layout changes; before/after screenshots recommended during review.

### Before
<!-- Drawer used isInline; step toggles used Title in toggleContent; heading levels mixed h3/h4 -->

### After
<!-- Drawer overlay layout; PatternFly ExpandableSection step headings; h3/h4 hierarchy -->


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Interactive elements are keyboard accessible
- [x] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes



## Reviewer Guidelines

### Focus Areas


### Questions for Reviewers
-

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-238]: https://redhat.atlassian.net/browse/FCN-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ