### PR TITLE
[Rehor Bot] fix(rosa): replace staging API URL with production

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/components/OIDCConfigHint.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/OIDCConfigHint.tsx
@@ -9,8 +9,7 @@ export const OIDCConfigHint = () => {
     <>
       <Content component={ContentVariants.p}>{oidcHint.instructions}</Content>
       <CopyInstruction variant={ClipboardCopyVariant.expansion} className="pf-v6-u-text-wrap">
-        rosa login --use-auth-code --url https://api.stage.openshift.com
-        {/* TODO: This should be at least production */}
+        rosa login --use-auth-code --url https://api.openshift.com
       </CopyInstruction>
       <CopyInstruction>rosa create oidc-config</CopyInstruction>
     </>

--- a/src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx
+++ b/src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx
@@ -9,8 +9,7 @@ export const OIDCConfigHint = () => {
     <>
       <Content component={ContentVariants.p}>{oidcHint.instructions}</Content>
       <CopyInstruction variant={ClipboardCopyVariant.expansion} className="pf-v6-u-text-wrap">
-        rosa login --use-auth-code --url https://api.stage.openshift.com
-        {/* TODO: This should be at least production */}
+        rosa login --use-auth-code --url https://api.openshift.com
       </CopyInstruction>
       <CopyInstruction>rosa create oidc-config</CopyInstruction>
     </>


### PR DESCRIPTION
## Description

Replace the staging API URL (`api.stage.openshift.com`) with the production URL (`api.openshift.com`) in the ROSA login command shown in the OIDCConfigHint component. Also removes the resolved TODO comment that noted this should use production.

Both instances of OIDCConfigHint are updated:
- `packages/nxtcm-rosa-hcp-wizard/src/components/OIDCConfigHint.tsx`
- `src/components/Wizards/RosaWizard/common/OIDCConfigHint.tsx`

**Jira issue #** FCN-425

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

### Manual Testing

**Test Steps:**
1. Open the ROSA HCP wizard to the OIDC config step
2. Verify the login command shows `https://api.openshift.com` instead of `https://api.stage.openshift.com`
3. Verify the TODO comment is no longer present in the source

**Test Environment:**
- [x] Tested locally

### Automated Testing

**Unit Tests:**
- [x] All unit tests pass (npm run test)

## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Dependencies
- [x] Any dependent changes have been merged and published

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No

🤖 Generated with [Claude Code](https://claude.com/claude-code)