### PR TITLE
FCN-538 Prevent storybook measure tool

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx
@@ -134,18 +134,54 @@ function SelectOptionsReconcileOnRefetchWrapper(props: React.ComponentProps<type
   return <ROSAHCPWizard {...props} wizardData={wizardData} />;
 }
 
+/** Stop Storybook focus shortcuts (1/2/3) outside text fields so they don't steal focus from the wizard. */
+function BlockStorybookFocusShortcuts({ children }: Readonly<{ children: React.ReactNode }>) {
+  React.useEffect(() => {
+    const isEditableTarget = (target: EventTarget | null): boolean => {
+      if (!(target instanceof HTMLElement)) {
+        return false;
+      }
+      return (
+        /input|textarea/i.test(target.tagName) || target.getAttribute('contenteditable') !== null
+      );
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (!['1', '2', '3'].includes(event.key)) {
+        return;
+      }
+      const eventTarget = event.composedPath()[0] ?? event.target;
+      if (isEditableTarget(eventTarget)) {
+        return;
+      }
+
+      event.stopPropagation();
+    };
+
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, []);
+
+  return <>{children}</>;
+}
+
 const meta: Meta<typeof ROSAHCPWizard> = {
   title: 'Wizards/RosaHCPWizard',
   component: ROSAHCPWizard,
   decorators: [
     (Story) => (
-      <div style={{ minHeight: '100vh', paddingBottom: '4rem', overflow: 'auto' }}>
-        <Story />
-      </div>
+      <BlockStorybookFocusShortcuts>
+        <div style={{ minHeight: '100vh', paddingBottom: '4rem', overflow: 'auto' }}>
+          <Story />
+        </div>
+      </BlockStorybookFocusShortcuts>
     ),
   ],
   parameters: {
     layout: 'fullscreen',
+    toolbar: {
+      'storybook/measure-addon/tool': { hidden: true },
+    },
     docs: {
       description: {
         component:
@@ -154,6 +190,9 @@ const meta: Meta<typeof ROSAHCPWizard> = {
     },
   },
   tags: ['autodocs'],
+  globals: {
+    measureEnabled: false,
+  },
   argTypes: {
     onSubmit: {
       description: 'Callback function called when the wizard is submitted',


### PR DESCRIPTION
## Description

Prevents Storybook tooling from interfering with the ROSA HCP wizard in Storybook. This was a problem when typing in the YAML editor. It would turn on the measuring tool if you typed "m" and other random tools if you typed "1", "2", or "3".  This interfered with a user's ability to type into the YAML editor.  While it only impacts Storybook - it makes the YAML editor appear broken.

Adds a decorator that blocks Storybook focus shortcuts (`1`, `2`, `3`) outside editable fields so they do not steal focus from wizard controls. Hides the measure addon toolbar control and disables measure mode via story globals and parameters.

**Jira issue #** [FCN-538](https://redhat.atlassian.net/browse/FCN-538)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Open Storybook and navigate to `Wizards/RosaHCPWizard` stories.
2. Go through the wizard to the YAML editor.  Put your cursor in any YAML field.
3. Type `1`, `2`, or `3` — focus should stay on the wizard, not jump to Storybook panels.
5. Type `m` and ensure that the measure tool does not turn on.

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Cypress Tests: E2E tests completed successfully (npm run e2e:run)
      <!-- Provide link to test run if available -->

- [ ] Playwright Tests: E2E tests completed successfully (cd playwright && npm run live)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

N/A — Storybook-only interaction fix; no production UI change.

### Before
<!-- Screenshot or description of the previous behavior -->

Measure tool available in Storybook toolbar; pressing `1`/`2`/`3` could steal focus from wizard controls.

### After
<!-- Screenshot or description of the new behavior -->

Measure tool hidden and disabled; focus shortcuts blocked outside editable fields.


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [x] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->

Changes are scoped to `ROSAHCPWizard.stories.tsx` only; the wizard component itself is unchanged.


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- `packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx` — `BlockStorybookFocusShortcuts` decorator and measure addon configuration (`toolbar`, `globals.measureEnabled`).

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-538]: https://redhat.atlassian.net/browse/FCN-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ