### PR TITLE
FCN-487 Networking values not going back to default

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.spec-helpers.tsx
@@ -21,6 +21,10 @@ import { clusterValidationSchema } from '../../../yupSchemas';
 import type { ValidationSchemaContext } from '../../../yupSchemas/types';
 import { defaultRosaHcpWizardValidatorStrings } from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
 import { withRosaCt } from '../../../components/WizFields/wizFieldCtSpecHelpers';
+import {
+  makeDefaultRosaHcpCtWizardData,
+  WizardFieldMetaChangeEffectsCtHarness,
+} from '../../../test/rosaHcpWizardCtSpecHelpers';
 
 /** Defaults aligned with {@link ROSAHCPWizardBody} so the composed Yup schema resolves consistently in CT. */
 const DEFAULT_ROSA_HCP_CT_FORM_VALUES: Partial<ROSAHCPCluster> = {
@@ -54,6 +58,8 @@ export type NetworkingMountProps = {
   subnets?: SubnetsResource;
   defaultValues?: Partial<ROSAHCPCluster>;
 };
+
+const CT_WIZARD_DATA = makeDefaultRosaHcpCtWizardData();
 
 export const NetworkingMount: React.FC<NetworkingMountProps> = ({
   vpcList,
@@ -94,6 +100,7 @@ export const NetworkingMount: React.FC<NetworkingMountProps> = ({
   return withRosaCt(
     <FormProvider {...methods}>
       <Form>
+        <WizardFieldMetaChangeEffectsCtHarness wizardData={CT_WIZARD_DATA} />
         <Networking vpcList={vpcListProps} subnets={subnetsProps} />
       </Form>
     </FormProvider>

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Networking/Networking.spec.tsx
@@ -1,10 +1,36 @@
 import { expect, test } from '@playwright/experimental-ct-react';
+import type { Locator } from '@playwright/test';
 import { checkAccessibility } from '../../../test-helpers';
 import { defaultRosaHcpWizardStrings } from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
 import { ClusterNetwork } from '../../../types';
 import { NetworkingMount } from './Networking.spec-helpers';
 
 const n = defaultRosaHcpWizardStrings.networking;
+
+type NetworkingCtRoot = {
+  getByText(text: string | RegExp, options?: { exact?: boolean }): Locator;
+  getByRole(role: 'checkbox' | 'textbox', options: { name: string | RegExp }): Locator;
+};
+
+type AdvancedCidrFields = {
+  useDefaultsCheckbox: Locator;
+  machineInput: Locator;
+  serviceInput: Locator;
+  podInput: Locator;
+  hostInput: Locator;
+};
+
+async function openAdvancedCidrFields(component: NetworkingCtRoot): Promise<AdvancedCidrFields> {
+  await component.getByText(n.advancedToggle).click();
+
+  return {
+    useDefaultsCheckbox: component.getByRole('checkbox', { name: n.useDefaultsLabel }),
+    machineInput: component.getByRole('textbox', { name: n.machineCidrLabel }),
+    serviceInput: component.getByRole('textbox', { name: n.serviceCidrLabel }),
+    podInput: component.getByRole('textbox', { name: n.podCidrLabel }),
+    hostInput: component.getByRole('textbox', { name: n.hostPrefixLabel }),
+  };
+}
 
 test.describe('Networking (ROSA HCP)', () => {
   test('should pass accessibility tests', async ({ mount }) => {
@@ -163,6 +189,28 @@ test.describe('Networking (ROSA HCP)', () => {
       await expect(component.getByRole('textbox', { name: n.hostPrefixLabel })).toBeEnabled();
     });
 
+    test('should restore default CIDR values when "Use default values" is re-checked', async ({
+      mount,
+    }) => {
+      const component = await mount(<NetworkingMount />);
+      const { useDefaultsCheckbox, machineInput, serviceInput, podInput, hostInput } =
+        await openAdvancedCidrFields(component);
+
+      await useDefaultsCheckbox.uncheck();
+      await machineInput.fill('10.1.0.0/16');
+      await serviceInput.fill('172.31.0.0/16');
+      await podInput.fill('10.129.0.0/14');
+      await hostInput.fill('/24');
+
+      await useDefaultsCheckbox.check();
+
+      await expect(machineInput).toHaveValue('10.0.0.0/16');
+      await expect(serviceInput).toHaveValue('172.30.0.0/16');
+      await expect(podInput).toHaveValue('10.128.0.0/14');
+      await expect(hostInput).toHaveValue('/23');
+      await expect(machineInput).toBeDisabled();
+    });
+
     test('should show default value for Machine CIDR', async ({ mount }) => {
       const component = await mount(<NetworkingMount />);
 
@@ -260,6 +308,32 @@ test.describe('Networking (ROSA HCP)', () => {
       await machineInput.fill('10.1.0.0/16');
 
       await expect(machineInput).toHaveValue('10.1.0.0/16');
+    });
+
+    test('should clear CIDR validation errors when "Use default values" is re-checked', async ({
+      mount,
+    }) => {
+      const component = await mount(<NetworkingMount />);
+      const { useDefaultsCheckbox, machineInput, serviceInput, podInput, hostInput } =
+        await openAdvancedCidrFields(component);
+
+      await useDefaultsCheckbox.uncheck();
+      await machineInput.fill('invalid-cidr');
+      await machineInput.blur();
+      await serviceInput.fill('not-a-cidr');
+      await serviceInput.blur();
+      await podInput.fill('bad-value');
+      await podInput.blur();
+      await hostInput.fill('abc');
+      await hostInput.blur();
+
+      await expect(component.getByText(/isn.t valid CIDR notation/)).toHaveCount(3);
+      await expect(component.getByText(/isn.t a valid subnet mask/)).toHaveCount(1);
+
+      await useDefaultsCheckbox.check();
+
+      await expect(component.getByText(/isn.t valid CIDR notation/)).toHaveCount(0);
+      await expect(component.getByText(/isn.t a valid subnet mask/)).toHaveCount(0);
     });
   });
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.test.ts
@@ -9,6 +9,7 @@ import fixtures from '../ROSAHCPWizard.fixtures';
 import { getWizardFieldSyncsForSourceField } from '../yupSchemas';
 
 const autoscalingSyncRules = getWizardFieldSyncsForSourceField('autoscaling');
+const cidrDefaultSyncRules = getWizardFieldSyncsForSourceField('cidr_default');
 
 jest.mock('./resetFieldsToDefaultValues', () => ({
   resetFieldsToDefaultValues: jest.fn(),
@@ -148,6 +149,48 @@ describe('applyWizardFieldMetaChangeEffects', () => {
       {},
       { http_proxy_url: '' }
     );
+  });
+
+  it('syncs CIDR defaults when cidr_default is re-checked', () => {
+    const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+
+    applyWizardFieldMetaChangeEffects({
+      sourceField: 'cidr_default',
+      formValues: { cidr_default: true },
+      previousValue: false,
+      currentValue: true,
+      wizardData: makeWizardData(),
+      setValue,
+    });
+
+    expect(syncFieldsOnSourceChangeMock).toHaveBeenCalledWith(
+      setValue,
+      cidrDefaultSyncRules,
+      true,
+      undefined
+    );
+    expect(resetFieldsToDefaultValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reset CIDR fields when cidr_default is unchecked', () => {
+    const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+
+    applyWizardFieldMetaChangeEffects({
+      sourceField: 'cidr_default',
+      formValues: { cidr_default: false },
+      previousValue: true,
+      currentValue: false,
+      wizardData: makeWizardData(),
+      setValue,
+    });
+
+    expect(syncFieldsOnSourceChangeMock).toHaveBeenCalledWith(
+      setValue,
+      cidrDefaultSyncRules,
+      false,
+      undefined
+    );
+    expect(resetFieldsToDefaultValuesMock).not.toHaveBeenCalled();
   });
 
   it('syncs autoscaling dependent fields when autoscaling toggles', () => {

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.test.ts
@@ -6,13 +6,24 @@ import {
   getWizardFieldSyncsForSourceField,
   maxReplicasSchema,
   minReplicasSchema,
+  networkHostPrefixSchema,
+  networkMachineCidrSchema,
+  networkPodCidrSchema,
+  networkServiceCidrSchema,
   nodesComputeSchema,
 } from '../yupSchemas';
 
 const autoscalingSyncRules = getWizardFieldSyncsForSourceField('autoscaling');
+const cidrDefaultSyncRules = getWizardFieldSyncsForSourceField('cidr_default');
+const defaultMachineCidr = networkMachineCidrSchema.getDefault() as string;
+const defaultServiceCidr = networkServiceCidrSchema.getDefault() as string;
+const defaultPodCidr = networkPodCidrSchema.getDefault() as string;
+const defaultHostPrefix = networkHostPrefixSchema.getDefault() as string;
 const defaultMinReplicas = minReplicasSchema.getDefault() as number;
 const defaultMaxReplicas = maxReplicasSchema.getDefault() as number;
 const defaultNodesCompute = nodesComputeSchema.getDefault() as number;
+const clearFieldOpts = { shouldDirty: true, shouldTouch: false, shouldValidate: false };
+const setDefaultsWithValidateOpts = { shouldDirty: true, shouldTouch: false, shouldValidate: true };
 
 describe('syncFieldsOnSourceChange', () => {
   it('sets replica defaults and clears compute count when autoscaling is enabled', () => {
@@ -20,9 +31,17 @@ describe('syncFieldsOnSourceChange', () => {
 
     syncFieldsOnSourceChange(setValue, autoscalingSyncRules, true);
 
-    expect(setValue).toHaveBeenCalledWith('nodes_compute', undefined, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('min_replicas', defaultMinReplicas, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('max_replicas', defaultMaxReplicas, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('nodes_compute', undefined, clearFieldOpts);
+    expect(setValue).toHaveBeenCalledWith(
+      'min_replicas',
+      defaultMinReplicas,
+      setDefaultsWithValidateOpts
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      'max_replicas',
+      defaultMaxReplicas,
+      setDefaultsWithValidateOpts
+    );
   });
 
   it('restores compute count and clears replicas when autoscaling is disabled', () => {
@@ -30,9 +49,13 @@ describe('syncFieldsOnSourceChange', () => {
 
     syncFieldsOnSourceChange(setValue, autoscalingSyncRules, false);
 
-    expect(setValue).toHaveBeenCalledWith('min_replicas', undefined, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('max_replicas', undefined, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('nodes_compute', defaultNodesCompute, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('min_replicas', undefined, clearFieldOpts);
+    expect(setValue).toHaveBeenCalledWith('max_replicas', undefined, clearFieldOpts);
+    expect(setValue).toHaveBeenCalledWith(
+      'nodes_compute',
+      defaultNodesCompute,
+      setDefaultsWithValidateOpts
+    );
   });
 
   it('clears inactive fields without applying setDefaults when clearOnly is set', () => {
@@ -40,7 +63,7 @@ describe('syncFieldsOnSourceChange', () => {
 
     syncFieldsOnSourceChange(setValue, autoscalingSyncRules, true, { clearOnly: true });
 
-    expect(setValue).toHaveBeenCalledWith('nodes_compute', undefined, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('nodes_compute', undefined, clearFieldOpts);
     expect(setValue).not.toHaveBeenCalledWith(
       'min_replicas',
       expect.anything(),
@@ -50,6 +73,33 @@ describe('syncFieldsOnSourceChange', () => {
       'max_replicas',
       expect.anything(),
       expect.any(Object)
+    );
+  });
+
+  it('applies shouldValidate when writing synced defaults for every sync branch', () => {
+    const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+
+    syncFieldsOnSourceChange(setValue, cidrDefaultSyncRules, true);
+
+    expect(setValue).toHaveBeenCalledWith(
+      'network_machine_cidr',
+      defaultMachineCidr,
+      setDefaultsWithValidateOpts
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      'network_service_cidr',
+      defaultServiceCidr,
+      setDefaultsWithValidateOpts
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      'network_pod_cidr',
+      defaultPodCidr,
+      setDefaultsWithValidateOpts
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      'network_host_prefix',
+      defaultHostPrefix,
+      setDefaultsWithValidateOpts
     );
   });
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.ts
@@ -3,6 +3,7 @@ import type { FieldPathValue, UseFormSetValue } from 'react-hook-form';
 
 import {
   buildFormSetValueOptions,
+  DEFAULT_FORM_SET_VALUE_OPTS_WITH_VALIDATE,
   type FormSetValueOptions,
 } from '../utilities/formSetValueOptions';
 import type { ROSAHCPCluster } from '../types';
@@ -41,8 +42,13 @@ export function syncFieldsOnSourceChange(
     return;
   }
 
+  const setDefaultsOpts: Required<FormSetValueOptions> = {
+    ...setOpts,
+    shouldValidate: DEFAULT_FORM_SET_VALUE_OPTS_WITH_VALIDATE.shouldValidate,
+  };
+
   for (const name of branch.setDefaults ?? []) {
     const value = getWizardFieldSchemaDefault(name);
-    setValue(name, value as FieldPathValue<Partial<ROSAHCPCluster>, typeof name>, setOpts);
+    setValue(name, value as FieldPathValue<Partial<ROSAHCPCluster>, typeof name>, setDefaultsOpts);
   }
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/networkingFields.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/networkingFields.ts
@@ -65,6 +65,17 @@ export const cidrDefaultSchema = yup
     fieldType: 'checkbox',
     advanced: true,
     hideInReview: true,
+    syncsFieldsOnChange: [
+      {
+        when: true,
+        setDefaults: [
+          'network_machine_cidr',
+          'network_service_cidr',
+          'network_pod_cidr',
+          'network_host_prefix',
+        ],
+      },
+    ],
   } satisfies WizardFieldMeta);
 
 export const networkMachineCidrSchema = yup

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.test.ts
@@ -95,9 +95,24 @@ describe('wizardFieldMetaChangeRegistry', () => {
       ]);
     });
 
+    it('lists cidr_default dependent sync rules from Yup meta', () => {
+      expect(getWizardFieldSyncsForSourceField('cidr_default')).toEqual([
+        {
+          when: true,
+          setDefaults: [
+            'network_machine_cidr',
+            'network_service_cidr',
+            'network_pod_cidr',
+            'network_host_prefix',
+          ],
+        },
+      ]);
+    });
+
     it('returns an entry per source field with sync metadata', () => {
       const entries = listWizardFieldSyncEntries();
       expect(entries.some((entry) => entry.sourceField === 'autoscaling')).toBe(true);
+      expect(entries.some((entry) => entry.sourceField === 'cidr_default')).toBe(true);
       expect(entries.every((entry) => entry.syncs.length > 0)).toBe(true);
     });
   });


### PR DESCRIPTION
## Description

Fixes networking advanced CIDR fields not restoring their default values when the user re-checks **Use default values** on the ROSA HCP wizard Networking step.

When `cidr_default` is toggled back on, dependent fields (`network_machine_cidr`, `network_service_cidr`, `network_pod_cidr`, `network_host_prefix`) now sync from Yup defaults via the existing field-meta change registry. `syncFieldsOnSourceChange` also applies `shouldValidate: true` when writing synced defaults so invalid custom CIDRs and validation errors are cleared.

**Jira issue #** [FCN-487](https://redhat.atlassian.net/browse/FCN-487)

**Backport of** #


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Open the ROSA HCP wizard Networking step (Storybook or host app).
2. Expand **Advanced networking configuration** and uncheck **Use default values**.
3. Change Machine, Service, Pod CIDR, and Host prefix to custom (including invalid) values.
4. Re-check **Use default values** and confirm fields reset to defaults (`10.0.0.0/16`, `172.30.0.0/16`, `10.128.0.0/14`, `/23`) and are disabled again.
5. Repeat with invalid CIDRs and confirm validation errors clear when defaults are restored.

**Test Environment:**
- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [x] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A

### Before

Re-checking **Use default values** left custom CIDR values and validation errors in place.

### After

Re-checking **Use default values** restores Yup defaults and clears validation state.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes


Suggested PR title: `[FCN-487] fix(networking): restore CIDR defaults on re-check`


## Reviewer Guidelines

### Focus Areas


### Questions for Reviewers

-

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-487]: https://redhat.atlassian.net/browse/FCN-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FCN-487]: https://redhat.atlassian.net/browse/FCN-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ