### PR TITLE
FCN-162 Set left nav status

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec-helpers.tsx
@@ -2,7 +2,7 @@
  * Playwright CT mount target for footer step-validation tests.
  * Keep a single mount export in this file (see Details.spec-helpers / NumberInput.spec).
  */
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { FormProvider, useForm, type Resolver } from 'react-hook-form';
 import { Wizard, WizardStep } from '@patternfly/react-core';
@@ -27,7 +27,17 @@ import {
 } from '../Steps/BasicSetup/Details/Details.fixtures';
 import { STEP_IDS } from '../constants';
 import { rosaHcpWizardFooter } from './RosaHcpWizardFooter';
-import { RosaHcpWizardValidationProvider } from '../rosaHcpWizardValidationContext';
+import {
+  getRosaHcpFooterCtStartIndex,
+  ROSA_HCP_PENDING_CLUSTER_NAME_UNIQUENESS_CHECK,
+} from './rosaHcpWizardFooter.spec-data';
+import { buildRosaHcpWizardStepLayout } from '../rosaHcpWizardStepLayout';
+import { useRosaHcpWizardStepNavDisabledLookup } from '../useRosaHcpWizardStepNavDisabledLookup';
+import {
+  RosaHcpWizardValidationProvider,
+  useRosaHcpWizardStepStatusLookup,
+  useRosaHcpWizardValidation,
+} from '../rosaHcpWizardValidationContext';
 import fixtures from '../ROSAHCPWizard.fixtures';
 import { clusterValidationSchema } from '../yupSchemas';
 import type { ValidationSchemaContext } from '../yupSchemas/types';
@@ -40,6 +50,7 @@ import { makeVpcListResource } from '../test/rosaHcpWizardCtSpecHelpers';
 import type {
   AwsBillingAccountsResource,
   AwsInfrastructureAccountsResource,
+  CheckClusterNameUniqueness,
   RegionsResource,
   RolesResource,
   VersionsResource,
@@ -73,11 +84,164 @@ const DEFAULT_ROSA_HCP_CT_FORM_VALUES: Partial<ROSAHCPCluster> = {
 
 export type RosaHcpWizardValidationMountProps = {
   defaultValues?: Partial<ROSAHCPCluster>;
+  /** Opens the wizard on this step (defaults to Details). */
+  initialStepId?: string;
+  /** Marks steps as visited for left-nav enablement (defaults to Details only). */
+  initialVisitedStepIds?: readonly string[];
+  /**
+   * CT-only: wires a never-resolving cluster name uniqueness check on Details.
+   * Prefer this boolean over passing `checkClusterNameUniqueness` from tests — Playwright CT
+   * may not forward callback props reliably.
+   */
+  clusterNameUniquenessPending?: boolean;
 };
+
+type RosaHcpWizardValidationWizardProps = {
+  sl: (typeof defaultRosaHcpWizardStrings)['wizard']['stepLabels'];
+  startIndex: number;
+  initialStepId: string;
+  versionsProps: VersionsResource;
+  awsInfra: AwsInfrastructureAccountsResource;
+  awsBilling: AwsBillingAccountsResource;
+  regionsProps: RegionsResource;
+  rolesProps: RolesResource;
+  oidcProps: {
+    data: typeof fixtures.mockOicdConfig;
+    error: null;
+    isFetching: boolean;
+    fetch: () => Promise<void>;
+  };
+  vpcListProps: ReturnType<typeof makeVpcListResource>;
+  checkClusterNameUniqueness?: CheckClusterNameUniqueness;
+};
+
+const layoutWithoutProxy = buildRosaHcpWizardStepLayout({ includeClusterWideProxy: false });
+
+const ROSA_HCP_VALIDATION_MOUNT_CHILD_STEP_IDS = {
+  [STEP_IDS.BASIC_SETUP]: [STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES],
+  [STEP_IDS.OPTIONAL_SETUP]: layoutWithoutProxy.childStepIdsByParent[STEP_IDS.OPTIONAL_SETUP],
+} as const;
+
+function RosaHcpWizardValidationWizard({
+  sl,
+  startIndex,
+  initialStepId,
+  versionsProps,
+  awsInfra,
+  awsBilling,
+  regionsProps,
+  rolesProps,
+  oidcProps,
+  vpcListProps,
+  checkClusterNameUniqueness,
+}: RosaHcpWizardValidationWizardProps) {
+  const statusForStep = useRosaHcpWizardStepStatusLookup(ROSA_HCP_VALIDATION_MOUNT_CHILD_STEP_IDS);
+  const isNavDisabledForStep = useRosaHcpWizardStepNavDisabledLookup({
+    includeClusterWideProxy: false,
+    childStepIdsByParent: ROSA_HCP_VALIDATION_MOUNT_CHILD_STEP_IDS,
+  });
+  const { onWizardStepChange } = useRosaHcpWizardValidation();
+
+  useEffect(() => {
+    onWizardStepChange(initialStepId);
+    // CT-only: align validation context with Wizard `startIndex` on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once for the seeded step
+  }, []);
+
+  return (
+    <Wizard
+      height={720}
+      startIndex={startIndex}
+      footer={rosaHcpWizardFooter}
+      onStepChange={(_event, currentStep) => {
+        onWizardStepChange(String(currentStep.id));
+      }}
+    >
+      <WizardStep
+        isExpandable
+        name={sl.basicSetup}
+        id={STEP_IDS.BASIC_SETUP}
+        status={statusForStep(STEP_IDS.BASIC_SETUP)}
+        isDisabled={isNavDisabledForStep(STEP_IDS.BASIC_SETUP)}
+        steps={[
+          <WizardStep
+            key={STEP_IDS.DETAILS}
+            name={sl.details}
+            id={STEP_IDS.DETAILS}
+            status={statusForStep(STEP_IDS.DETAILS)}
+            isDisabled={isNavDisabledForStep(STEP_IDS.DETAILS)}
+          >
+            <Details
+              versions={versionsProps}
+              awsInfrastructureAccounts={awsInfra}
+              awsBillingAccounts={awsBilling}
+              regions={regionsProps}
+              roles={rolesProps}
+              checkClusterNameUniqueness={checkClusterNameUniqueness}
+            />
+          </WizardStep>,
+          <WizardStep
+            key={STEP_IDS.ROLES_AND_POLICIES}
+            name={sl.rolesAndPolicies}
+            id={STEP_IDS.ROLES_AND_POLICIES}
+            status={statusForStep(STEP_IDS.ROLES_AND_POLICIES)}
+            isDisabled={isNavDisabledForStep(STEP_IDS.ROLES_AND_POLICIES)}
+          >
+            <RolesAndPolicies roles={rolesProps} oidcConfig={oidcProps} />
+          </WizardStep>,
+        ]}
+      />
+      <WizardStep
+        isExpandable
+        name={sl.additionalSetup}
+        id={STEP_IDS.OPTIONAL_SETUP}
+        status={statusForStep(STEP_IDS.OPTIONAL_SETUP)}
+        isDisabled={isNavDisabledForStep(STEP_IDS.OPTIONAL_SETUP)}
+        steps={[
+          <WizardStep
+            key={STEP_IDS.ENCRYPTION}
+            name={sl.encryptionOptional}
+            id={STEP_IDS.ENCRYPTION}
+            status={statusForStep(STEP_IDS.ENCRYPTION)}
+            isDisabled={isNavDisabledForStep(STEP_IDS.ENCRYPTION)}
+          >
+            <Encryption />
+          </WizardStep>,
+          <WizardStep
+            key={STEP_IDS.CLUSTER_UPDATES}
+            name={sl.clusterUpdatesOptional}
+            id={STEP_IDS.CLUSTER_UPDATES}
+            status={statusForStep(STEP_IDS.CLUSTER_UPDATES)}
+            isDisabled={isNavDisabledForStep(STEP_IDS.CLUSTER_UPDATES)}
+          >
+            <ClusterUpdates />
+          </WizardStep>,
+        ]}
+      />
+      <WizardStep
+        name={sl.review}
+        id={STEP_IDS.REVIEW}
+        key={STEP_IDS.REVIEW}
+        status={statusForStep(STEP_IDS.REVIEW)}
+        isDisabled={isNavDisabledForStep(STEP_IDS.REVIEW)}
+      >
+        <Review vpcList={vpcListProps} />
+      </WizardStep>
+    </Wizard>
+  );
+}
 
 export const RosaHcpWizardValidationMount: React.FC<RosaHcpWizardValidationMountProps> = ({
   defaultValues = {},
+  initialStepId,
+  initialVisitedStepIds,
+  clusterNameUniquenessPending = false,
 }) => {
+  const checkClusterNameUniqueness = useMemo(
+    () =>
+      clusterNameUniquenessPending ? ROSA_HCP_PENDING_CLUSTER_NAME_UNIQUENESS_CHECK : undefined,
+    [clusterNameUniquenessPending]
+  );
   const validationContext = useMemo<ValidationSchemaContext>(
     () => ({
       msgs: defaultRosaHcpWizardValidatorStrings,
@@ -96,6 +260,7 @@ export const RosaHcpWizardValidationMount: React.FC<RosaHcpWizardValidationMount
   });
 
   const sl = defaultRosaHcpWizardStrings.wizard.stepLabels;
+  const startIndex = getRosaHcpFooterCtStartIndex(initialStepId);
 
   const versionsProps: VersionsResource = {
     data: mockOpenShiftVersionsData,
@@ -143,56 +308,23 @@ export const RosaHcpWizardValidationMount: React.FC<RosaHcpWizardValidationMount
 
   return withRosaCt(
     <FormProvider {...methods}>
-      <RosaHcpWizardValidationProvider>
-        <Wizard height={720} footer={rosaHcpWizardFooter}>
-          <WizardStep
-            isExpandable
-            name={sl.basicSetup}
-            id={STEP_IDS.BASIC_SETUP}
-            steps={[
-              <WizardStep key={STEP_IDS.DETAILS} name={sl.details} id={STEP_IDS.DETAILS}>
-                <Details
-                  versions={versionsProps}
-                  awsInfrastructureAccounts={awsInfra}
-                  awsBillingAccounts={awsBilling}
-                  regions={regionsProps}
-                  roles={rolesProps}
-                />
-              </WizardStep>,
-              <WizardStep
-                key={STEP_IDS.ROLES_AND_POLICIES}
-                name={sl.rolesAndPolicies}
-                id={STEP_IDS.ROLES_AND_POLICIES}
-              >
-                <RolesAndPolicies roles={rolesProps} oidcConfig={oidcProps} />
-              </WizardStep>,
-            ]}
-          />
-          <WizardStep
-            isExpandable
-            name={sl.additionalSetup}
-            id={STEP_IDS.OPTIONAL_SETUP}
-            steps={[
-              <WizardStep
-                key={STEP_IDS.ENCRYPTION}
-                name={sl.encryptionOptional}
-                id={STEP_IDS.ENCRYPTION}
-              >
-                <Encryption />
-              </WizardStep>,
-              <WizardStep
-                key={STEP_IDS.CLUSTER_UPDATES}
-                name={sl.clusterUpdatesOptional}
-                id={STEP_IDS.CLUSTER_UPDATES}
-              >
-                <ClusterUpdates />
-              </WizardStep>,
-            ]}
-          />
-          <WizardStep name={sl.review} id={STEP_IDS.REVIEW} key={STEP_IDS.REVIEW}>
-            <Review vpcList={vpcListProps} />
-          </WizardStep>
-        </Wizard>
+      <RosaHcpWizardValidationProvider
+        initialActiveStepId={initialStepId ?? STEP_IDS.DETAILS}
+        initialVisitedStepIds={initialVisitedStepIds ?? [STEP_IDS.DETAILS]}
+      >
+        <RosaHcpWizardValidationWizard
+          sl={sl}
+          startIndex={startIndex}
+          initialStepId={initialStepId ?? STEP_IDS.DETAILS}
+          versionsProps={versionsProps}
+          awsInfra={awsInfra}
+          awsBilling={awsBilling}
+          regionsProps={regionsProps}
+          rolesProps={rolesProps}
+          oidcProps={oidcProps}
+          vpcListProps={vpcListProps}
+          checkClusterNameUniqueness={checkClusterNameUniqueness}
+        />
       </RosaHcpWizardValidationProvider>
     </FormProvider>
   );

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
@@ -5,7 +5,13 @@ import {
   defaultRosaHcpWizardValidatorStrings,
 } from '../stringsProvider/rosaHcpWizardStrings.defaults';
 import { RosaHcpWizardValidationMount } from './RosaHcpWizardFooter.spec-helpers';
+import {
+  ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION,
+  ROSA_HCP_FOOTER_CT_VISITED_THROUGH_REVIEW,
+  ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ROLES,
+} from './rosaHcpWizardFooter.spec-data';
 import fixtures from '../ROSAHCPWizard.fixtures';
+import { STEP_IDS } from '../constants';
 import { mockRoles } from '../Steps/BasicSetup/Details/Details.fixtures';
 import {
   VALID_DETAILS_FORM_VALUES,
@@ -28,6 +34,95 @@ const encryption = defaultRosaHcpWizardStrings.encryption;
 /** PatternFly danger Alert exposes the title as a heading (e.g. "Danger alert: …"). */
 const validationAlertHeading = { name: new RegExp(FIX_VALIDATION_ALERT) };
 
+/** PatternFly prepends screen-reader ", error" before the step label in nav button names. */
+const wizardNavStepErrorButtonName = (stepLabel: string): RegExp =>
+  new RegExp(`, error ${stepLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
+
+test.describe('RosaHcpWizardFooter — left nav enablement', () => {
+  test('disables forward unvisited steps while on Details', async ({ mount }) => {
+    const component = await mount(<RosaHcpWizardValidationMount />);
+
+    await expect(
+      component.getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
+    ).toBeDisabled();
+    await expect(
+      component.getByRole('button', { name: w.stepLabels.review, exact: true })
+    ).toBeDisabled();
+  });
+
+  test('keeps previous steps enabled when on a later step', async ({ mount }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_DETAILS_FORM_VALUES} />
+    );
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
+
+    await expect(
+      component.getByRole('button', { name: w.stepLabels.details, exact: true })
+    ).toBeEnabled();
+  });
+
+  test('blocks forward nav to Additional setup when an earlier step has validation errors', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        initialStepId={STEP_IDS.ROLES_AND_POLICIES}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION}
+      />
+    );
+
+    await expect(component.getByText(w.stepLabels.additionalSetup)).toBeDisabled();
+  });
+
+  test('disables forward visited steps when the active step has empty required fields', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_DETAILS_FORM_VALUES} />
+    );
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
+
+    await component.getByRole('button', { name: w.stepLabels.details, exact: true }).click();
+    await component.getByRole('textbox', { name: /Cluster name/i }).fill('');
+
+    await expect(
+      component.getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
+    ).toBeDisabled();
+  });
+
+  test('disables forward visited steps while cluster name async validation is in progress', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        defaultValues={VALID_DETAILS_FORM_VALUES}
+        clusterNameUniquenessPending
+      />
+    );
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
+
+    await component.getByRole('button', { name: w.stepLabels.details, exact: true }).click();
+
+    const nameInput = component.getByRole('textbox', { name: /Cluster name/i });
+    await nameInput.fill('renamed-cluster');
+    await nameInput.blur();
+
+    await expect
+      .poll(async () =>
+        component
+          .getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
+          .isDisabled()
+      )
+      .toBe(true);
+  });
+});
+
 test.describe('RosaHcpWizardFooter — step validation on Next', () => {
   test('disables Back on the Details step', async ({ mount }) => {
     const component = await mount(<RosaHcpWizardValidationMount />);
@@ -47,6 +142,57 @@ test.describe('RosaHcpWizardFooter — step validation on Next', () => {
       'aria-invalid',
       'true'
     );
+  });
+
+  test('sets the Details nav step status to error when Next fails validation', async ({
+    mount,
+  }) => {
+    const component = await mount(<RosaHcpWizardValidationMount />);
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+
+    await expect(
+      component.getByRole('button', { name: wizardNavStepErrorButtonName(w.stepLabels.details) })
+    ).toBeVisible();
+  });
+
+  test('sets the Basic setup parent nav step status to error when a child step fails validation', async ({
+    mount,
+  }) => {
+    const component = await mount(<RosaHcpWizardValidationMount />);
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+
+    await expect(
+      component.getByRole('button', { name: wizardNavStepErrorButtonName(w.stepLabels.basicSetup) })
+    ).toBeVisible();
+  });
+
+  test('clears the Details nav step error status when the step becomes valid', async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        defaultValues={{
+          ...VALID_DETAILS_FORM_VALUES,
+          name: '',
+        }}
+      />
+    );
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+    await expect(
+      component.getByRole('button', { name: wizardNavStepErrorButtonName(w.stepLabels.details) })
+    ).toBeVisible();
+
+    await component.getByRole('textbox', { name: /Cluster name/i }).fill('mycluster');
+
+    await expect(
+      component.getByRole('button', { name: wizardNavStepErrorButtonName(w.stepLabels.details) })
+    ).not.toBeVisible();
+    await expect(
+      component.getByRole('button', { name: wizardNavStepErrorButtonName(w.stepLabels.basicSetup) })
+    ).not.toBeVisible();
   });
 
   test('hides the validation alert after Details fields on the step become valid', async ({
@@ -86,23 +232,24 @@ test.describe('RosaHcpWizardFooter — step validation on Next', () => {
     );
   });
 
-  test('does not show the validation alert on another step after Details Next failed and the user navigates away', async ({
+  test('does not show the validation alert on Details after Roles Next failed and the user navigates back', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        defaultValues={VALID_DETAILS_FORM_VALUES}
+        initialStepId={STEP_IDS.ROLES_AND_POLICIES}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ROLES}
+      />
+    );
 
+    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
     await component.getByRole('button', { name: FOOTER_NEXT }).click();
     await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
 
-    await component
-      .getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
-      .click();
+    await component.getByRole('button', { name: w.stepLabels.details, exact: true }).click();
 
-    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
     await expect(component.getByRole('heading', validationAlertHeading)).not.toBeVisible();
-    await expect(component.locator('#installer_role_arn-form-group')).not.toContainText(
-      REQUIRED_FIELD_MESSAGE
-    );
   });
 });
 
@@ -113,12 +260,12 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   });
 
   test('shows Skip to review on an Additional setup step', async ({ mount }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
-
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        initialStepId={STEP_IDS.ENCRYPTION}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION}
+      />
+    );
 
     await expect(component.getByText(encryption.sectionLabel, { exact: true })).toBeVisible();
     await expect(component.getByRole('button', { name: SKIP_TO_REVIEW })).toBeVisible();
@@ -127,12 +274,13 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   test('shows the validation alert and stays on the step when Skip to review is pressed with invalid fields', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        initialStepId={STEP_IDS.ENCRYPTION}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION}
+      />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
     await component.getByRole('checkbox', { name: encryption.etcdLabel }).check();
     await component.getByRole('button', { name: SKIP_TO_REVIEW }).click();
 
@@ -144,12 +292,13 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   test('keeps Next and Skip to review enabled after field blur validation on Encryption', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        initialStepId={STEP_IDS.ENCRYPTION}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION}
+      />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
     await component.getByRole('radio', { name: encryption.customKms }).check();
     await component.getByRole('textbox', { name: encryption.keyArnLabel }).focus();
     await component.getByRole('textbox', { name: encryption.keyArnLabel }).blur();
@@ -163,12 +312,14 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
     mount,
   }) => {
     test.setTimeout(30_000);
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        defaultValues={VALID_DETAILS_FORM_VALUES}
+        initialStepId={STEP_IDS.ENCRYPTION}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION}
+      />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
     await component.getByRole('radio', { name: encryption.customKms }).check();
     const keyArn = component.getByRole('textbox', { name: encryption.keyArnLabel });
     await keyArn.focus();
@@ -200,12 +351,13 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   test('navigates to Review when Skip to review is pressed with a valid current step', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        initialStepId={STEP_IDS.ENCRYPTION}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION}
+      />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
     await component.getByRole('button', { name: SKIP_TO_REVIEW }).click();
 
     await expect(component.getByText(review.sectionLabel, { exact: true })).toBeVisible();
@@ -214,7 +366,7 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
 });
 
 test.describe('RosaHcpWizardFooter — Review Submit validation alert', () => {
-  test('hides the validation alert on Review after a failed Submit when the form becomes valid', async ({
+  test('shows the validation alert on Review after a failed Submit with an invalid cluster name', async ({
     mount,
   }) => {
     const component = await mount(
@@ -223,20 +375,14 @@ test.describe('RosaHcpWizardFooter — Review Submit validation alert', () => {
           ...VALID_REVIEW_SUBMIT_FORM_VALUES,
           name: '',
         }}
+        initialStepId={STEP_IDS.REVIEW}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_REVIEW}
       />
     );
 
-    await component.getByRole('button', { name: w.stepLabels.review, exact: true }).click();
     await expect(component.getByText(review.sectionLabel, { exact: true })).toBeVisible();
-
     await component.getByRole('button', { name: FOOTER_SUBMIT }).click();
     await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
-
-    await component.getByRole('button', { name: review.editStep }).first().click();
-    const nameInput = component.getByRole('textbox', { name: /Cluster name/i });
-    await nameInput.fill('mycluster');
-
-    await expect(component.getByRole('heading', validationAlertHeading)).not.toBeVisible();
   });
 });
 
@@ -252,10 +398,11 @@ test.describe('RosaHcpWizardFooter — validation alert after failed Review Subm
           // Match mock installer roleVersion (4.16.0) so the installer option is enabled.
           cluster_version: '4.16.0',
         }}
+        initialStepId={STEP_IDS.REVIEW}
+        initialVisitedStepIds={ROSA_HCP_FOOTER_CT_VISITED_THROUGH_REVIEW}
       />
     );
 
-    await component.getByRole('button', { name: w.stepLabels.review, exact: true }).click();
     await component.getByRole('button', { name: FOOTER_SUBMIT }).click();
     await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx
@@ -15,6 +15,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import type { ROSAHCPCluster } from '../types';
 import { STEP_IDS } from '../constants';
+import { buildOrderedNavigableStepIds, getNextOrderedStepId } from '../rosaHcpWizardNav';
 import { useRosaHcpWizardReviewSections } from '../Steps/Review/ROSAHCPWizardReviewSections';
 import {
   isRosaHcpWizardBackDisabled,
@@ -42,12 +43,17 @@ type RosaHcpWizardFooterProps = Pick<
  */
 export function RosaHcpWizardFooter({
   activeStep,
-  onNext,
+  onNext: _onNext,
   onBack,
   onClose,
   onSubmit,
 }: RosaHcpWizardFooterProps) {
-  const { goToStepById } = useWizardContext();
+  const { steps, goToStepByIndex } = useWizardContext();
+  const clusterWideProxySelected = useWatch({ name: 'configure_proxy' });
+  const orderedStepIds = useMemo(
+    () => buildOrderedNavigableStepIds(!!clusterWideProxySelected),
+    [clusterWideProxySelected]
+  );
   const reviewSections = useRosaHcpWizardReviewSections();
   const { wizard } = useRosaHcpWizardStrings();
   const {
@@ -188,15 +194,29 @@ export function RosaHcpWizardFooter({
     trigger,
   ]);
 
+  const advanceToStepId = useCallback(
+    (stepId: string) => {
+      const step = steps.find((candidate) => String(candidate.id) === stepId);
+      if (step?.index !== undefined) {
+        goToStepByIndex(step.index);
+      }
+    },
+    [goToStepByIndex, steps]
+  );
+
   const handleNext = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
+    (_event: React.MouseEvent<HTMLButtonElement>) => {
       void (async () => {
-        if (await validateActiveStep()) {
-          await onNext(event);
+        if (!(await validateActiveStep())) {
+          return;
+        }
+        const nextStepId = getNextOrderedStepId(activeStepId, orderedStepIds);
+        if (nextStepId !== undefined) {
+          advanceToStepId(nextStepId);
         }
       })();
     },
-    [onNext, validateActiveStep]
+    [activeStepId, advanceToStepId, orderedStepIds, validateActiveStep]
   );
 
   const handleSubmit = useCallback(() => {
@@ -215,10 +235,10 @@ export function RosaHcpWizardFooter({
   const handleSkipToReview = useCallback(() => {
     void (async () => {
       if (await validateActiveStep()) {
-        goToStepById(STEP_IDS.REVIEW);
+        advanceToStepId(STEP_IDS.REVIEW);
       }
     })();
-  }, [goToStepById, validateActiveStep]);
+  }, [advanceToStepId, validateActiveStep]);
 
   return (
     <WizardFooterWrapper>

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.spec-data.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.spec-data.ts
@@ -1,0 +1,47 @@
+import { STEP_IDS } from '../constants';
+import type { CheckClusterNameUniqueness } from '../types';
+
+/** Never resolves — keeps cluster name async validation in flight for footer CT. */
+export const ROSA_HCP_PENDING_CLUSTER_NAME_UNIQUENESS_CHECK: CheckClusterNameUniqueness = () =>
+  new Promise(() => {});
+
+/** Leaf steps visited through Roles in footer CT (includes skipped Machine Pools / Networking). */
+export const ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ROLES: readonly string[] = [
+  STEP_IDS.DETAILS,
+  STEP_IDS.ROLES_AND_POLICIES,
+  STEP_IDS.MACHINE_POOLS,
+  STEP_IDS.NETWORKING,
+];
+
+/** Leaf steps visited through Encryption in footer CT. */
+export const ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION: readonly string[] = [
+  ...ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ROLES,
+  STEP_IDS.ENCRYPTION,
+];
+
+/** Leaf steps visited through Review in footer CT. */
+export const ROSA_HCP_FOOTER_CT_VISITED_THROUGH_REVIEW: readonly string[] = [
+  ...ROSA_HCP_FOOTER_CT_VISITED_THROUGH_ENCRYPTION,
+  STEP_IDS.CLUSTER_UPDATES,
+  STEP_IDS.REVIEW,
+];
+
+/**
+ * PatternFly Wizard flat step index for the footer CT mount tree
+ * (Basic setup parent + 2 subs, Optional parent + 2 subs, Review).
+ */
+const ROSA_HCP_FOOTER_CT_START_INDEX_BY_STEP_ID: Readonly<Record<string, number>> = {
+  [STEP_IDS.DETAILS]: 2,
+  [STEP_IDS.ROLES_AND_POLICIES]: 3,
+  [STEP_IDS.ENCRYPTION]: 5,
+  [STEP_IDS.CLUSTER_UPDATES]: 6,
+  [STEP_IDS.REVIEW]: 7,
+};
+
+/** Resolves `Wizard` `startIndex` for footer CT mid-wizard mounts. */
+export function getRosaHcpFooterCtStartIndex(stepId?: string): number {
+  if (stepId === undefined) {
+    return ROSA_HCP_FOOTER_CT_START_INDEX_BY_STEP_ID[STEP_IDS.DETAILS];
+  }
+  return ROSA_HCP_FOOTER_CT_START_INDEX_BY_STEP_ID[stepId] ?? 2;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.utils.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.utils.test.ts
@@ -3,6 +3,7 @@ import { STEP_IDS } from '../constants';
 import {
   isRosaHcpWizardBackDisabled,
   isRosaHcpWizardSkipToReviewVisible,
+  pathsHaveRevealedValidationIssues,
   pathsHaveValidationIssues,
 } from './rosaHcpWizardFooter.utils';
 
@@ -56,6 +57,55 @@ describe('pathsHaveValidationIssues', () => {
         getFieldState,
         { name: { type: 'required', message: 'Required' } },
         { ignoreResolverErrors: true }
+      )
+    ).toBe(false);
+  });
+});
+
+describe('pathsHaveRevealedValidationIssues', () => {
+  it('returns true only when invalid fields are touched or validation was attempted', () => {
+    const getFieldState = jest.fn((path: string) => ({
+      invalid: path === 'name',
+      isTouched: path === 'name',
+      isDirty: true,
+      isValidating: false,
+      error: path === 'name' ? { type: 'required', message: 'Required' } : undefined,
+    })) as UseFormGetFieldState<FieldValues>;
+
+    expect(pathsHaveRevealedValidationIssues(['name'], getFieldState, {})).toBe(true);
+    expect(
+      pathsHaveRevealedValidationIssues(
+        ['name'],
+        jest.fn(() => ({
+          invalid: true,
+          isTouched: false,
+          isDirty: false,
+          isValidating: false,
+          error: { type: 'required', message: 'Required' },
+        })) as UseFormGetFieldState<FieldValues>,
+        {},
+        {}
+      )
+    ).toBe(false);
+  });
+
+  it('ignores suppressed field paths', () => {
+    const getFieldState = jest.fn(() => ({
+      invalid: true,
+      isTouched: true,
+      isDirty: true,
+      isValidating: false,
+      error: { type: 'required', message: 'Required' },
+    })) as UseFormGetFieldState<FieldValues>;
+
+    expect(
+      pathsHaveRevealedValidationIssues(
+        ['selected_vpc'],
+        getFieldState,
+        {},
+        {
+          suppressedFieldPaths: new Set(['selected_vpc']),
+        }
       )
     ).toBe(false);
   });

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.utils.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.utils.ts
@@ -1,4 +1,6 @@
 import type { FieldErrors, FieldPath, FieldValues, UseFormGetFieldState } from 'react-hook-form';
+
+import type { ROSAHCPCluster } from '../types';
 import { STEP_IDS } from '../constants';
 
 function hasErrorAtPath(errors: FieldErrors, path: string): boolean {
@@ -47,6 +49,65 @@ export function pathsHaveValidationIssues<TFieldValues extends FieldValues>(
     }
     return hasErrorAtPath(errors, path);
   });
+}
+
+export type PathsHaveRevealedValidationIssuesOptions = {
+  validationAttemptedStepIds?: ReadonlySet<string>;
+  fieldPathToStepId?: Readonly<Record<string, string>>;
+  isSubmitted?: boolean;
+  suppressedFieldPaths?: ReadonlySet<string>;
+  formValues?: Partial<ROSAHCPCluster>;
+  isFieldActive?: (path: string, formValues: Partial<ROSAHCPCluster>) => boolean;
+};
+
+/** Whether a field error is user-visible (touched, step validation attempted, or submitted). */
+export function pathHasRevealedValidationIssue<TFieldValues extends FieldValues>(
+  path: string,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  errors: FieldErrors<TFieldValues>,
+  options: PathsHaveRevealedValidationIssuesOptions = {}
+): boolean {
+  if (options.suppressedFieldPaths?.has(path)) {
+    return false;
+  }
+
+  if (
+    options.formValues &&
+    options.isFieldActive &&
+    !options.isFieldActive(path, options.formValues)
+  ) {
+    return false;
+  }
+
+  const fieldPath = path as FieldPath<TFieldValues>;
+  const fieldState = getFieldState(fieldPath);
+  const stepId = options.fieldPathToStepId?.[path];
+  const stepValidationRevealed =
+    stepId !== undefined && (options.validationAttemptedStepIds?.has(stepId) ?? false);
+  const validationRevealed =
+    fieldState.isTouched || stepValidationRevealed || !!options.isSubmitted;
+
+  if (!validationRevealed) {
+    return false;
+  }
+
+  if (fieldState.invalid) {
+    return true;
+  }
+
+  return hasErrorAtPath(errors, path);
+}
+
+/** Like {@link pathsHaveValidationIssues}, but only counts errors the user can see in the form. */
+export function pathsHaveRevealedValidationIssues<TFieldValues extends FieldValues>(
+  fieldPaths: readonly string[],
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  errors: FieldErrors<TFieldValues>,
+  options: PathsHaveRevealedValidationIssuesOptions = {}
+): boolean {
+  return fieldPaths.some((path) =>
+    pathHasRevealedValidationIssue(path, getFieldState, errors, options)
+  );
 }
 
 /** Steps under Additional setup that show Skip to review in the footer. */

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
@@ -13,6 +13,12 @@ import type { YamlEditorHandle } from './Steps/YamlEditor/RosaHcpYamlEditorStep'
 import { createRosaHcpWizardFooter } from './Footer/RosaHcpWizardFooter';
 import { RosaHcpYamlEditorFooter } from './Footer/RosaHcpYamlEditorFooter';
 import { useWizardFieldMetaChangeEffects } from './fieldMetaChangeEffects/useWizardFieldMetaChangeEffects';
+import { buildRosaHcpWizardStepLayout } from './rosaHcpWizardStepLayout';
+import { useRosaHcpWizardStepNavDisabledLookup } from './useRosaHcpWizardStepNavDisabledLookup';
+import {
+  useRosaHcpWizardStepStatusLookup,
+  useRosaHcpWizardValidation,
+} from './rosaHcpWizardValidationContext';
 import { useRosaHcpWizardStrings } from './stringsProvider/RosaHcpWizardStringsContext';
 import { STEP_IDS } from './constants';
 import type { RosaHCPWizardProps } from './types';
@@ -43,16 +49,20 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
 
   const handleCloseYamlEditor = useCallback(() => setIsYamlEditorOpen(false), []);
   const openYamlEditor = useCallback(() => setIsYamlEditorOpen(true), []);
+  const { onWizardStepChange } = useRosaHcpWizardValidation();
 
   const handleWizardStepChange = useCallback<
     NonNullable<React.ComponentProps<typeof Wizard>['onStepChange']>
   >(
     (_event, newStep) => {
+      if (newStep?.id !== undefined) {
+        onWizardStepChange(String(newStep.id));
+      }
       if (isYamlEditorOpen && newStep?.id !== STEP_IDS.REVIEW) {
         setIsYamlEditorOpen(false);
       }
     },
-    [isYamlEditorOpen]
+    [isYamlEditorOpen, onWizardStepChange]
   );
 
   const footer = useMemo(() => createRosaHcpWizardFooter(onSubmit), [onSubmit]);
@@ -60,6 +70,17 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
   useWizardFieldMetaChangeEffects(wizardData);
 
   const clusterWideProxySelected = useWatch({ name: 'configure_proxy' });
+  const childStepIdsByParent = useMemo(
+    () =>
+      buildRosaHcpWizardStepLayout({ includeClusterWideProxy: !!clusterWideProxySelected })
+        .childStepIdsByParent,
+    [clusterWideProxySelected]
+  );
+  const statusForStep = useRosaHcpWizardStepStatusLookup(childStepIdsByParent);
+  const isNavDisabledForStep = useRosaHcpWizardStepNavDisabledLookup({
+    includeClusterWideProxy: !!clusterWideProxySelected,
+    childStepIdsByParent,
+  });
 
   const rosaStrings = useRosaHcpWizardStrings();
   const { wizard, yamlEditor: yamlStrings } = rosaStrings;
@@ -97,18 +118,29 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
         onClose={onCancel}
         onStepChange={handleWizardStepChange}
       >
+        {/* Leaf step order matches {@link ROSA_HCP_LEAF_STEP_DEFS} in rosaHcpWizardStepLayout.ts */}
         <WizardStep
           isExpandable
           name={sl.basicSetup}
           id={STEP_IDS.BASIC_SETUP}
+          status={statusForStep(STEP_IDS.BASIC_SETUP)}
+          isDisabled={isNavDisabledForStep(STEP_IDS.BASIC_SETUP)}
           steps={[
-            <WizardStep name={sl.details} id={STEP_IDS.DETAILS} key={STEP_IDS.DETAILS}>
+            <WizardStep
+              name={sl.details}
+              id={STEP_IDS.DETAILS}
+              key={STEP_IDS.DETAILS}
+              status={statusForStep(STEP_IDS.DETAILS)}
+              isDisabled={isNavDisabledForStep(STEP_IDS.DETAILS)}
+            >
               <Details {...wizardData} />
             </WizardStep>,
             <WizardStep
               name={sl.rolesAndPolicies}
               id={STEP_IDS.ROLES_AND_POLICIES}
               key={STEP_IDS.ROLES_AND_POLICIES}
+              status={statusForStep(STEP_IDS.ROLES_AND_POLICIES)}
+              isDisabled={isNavDisabledForStep(STEP_IDS.ROLES_AND_POLICIES)}
             >
               <RolesAndPolicies {...wizardData} />
             </WizardStep>,
@@ -116,10 +148,18 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
               name={sl.machinePools}
               id={STEP_IDS.MACHINE_POOLS}
               key={STEP_IDS.MACHINE_POOLS}
+              status={statusForStep(STEP_IDS.MACHINE_POOLS)}
+              isDisabled={isNavDisabledForStep(STEP_IDS.MACHINE_POOLS)}
             >
               <MachinePools {...wizardData} />
             </WizardStep>,
-            <WizardStep name={sl.networking} id={STEP_IDS.NETWORKING} key={STEP_IDS.NETWORKING}>
+            <WizardStep
+              name={sl.networking}
+              id={STEP_IDS.NETWORKING}
+              key={STEP_IDS.NETWORKING}
+              status={statusForStep(STEP_IDS.NETWORKING)}
+              isDisabled={isNavDisabledForStep(STEP_IDS.NETWORKING)}
+            >
               <Networking {...wizardData} />
             </WizardStep>,
             ...(clusterWideProxySelected
@@ -128,6 +168,8 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
                     name={sl.clusterWideProxy}
                     id={STEP_IDS.CLUSTER_WIDE_PROXY}
                     key={STEP_IDS.CLUSTER_WIDE_PROXY}
+                    status={statusForStep(STEP_IDS.CLUSTER_WIDE_PROXY)}
+                    isDisabled={isNavDisabledForStep(STEP_IDS.CLUSTER_WIDE_PROXY)}
                   >
                     <ClusterWideProxy />
                   </WizardStep>,
@@ -141,11 +183,15 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
           name={sl.additionalSetup}
           id={STEP_IDS.OPTIONAL_SETUP}
           key={STEP_IDS.OPTIONAL_SETUP}
+          status={statusForStep(STEP_IDS.OPTIONAL_SETUP)}
+          isDisabled={isNavDisabledForStep(STEP_IDS.OPTIONAL_SETUP)}
           steps={[
             <WizardStep
               name={sl.encryptionOptional}
               id={STEP_IDS.ENCRYPTION}
               key={STEP_IDS.ENCRYPTION}
+              status={statusForStep(STEP_IDS.ENCRYPTION)}
+              isDisabled={isNavDisabledForStep(STEP_IDS.ENCRYPTION)}
             >
               <Encryption />
             </WizardStep>,
@@ -153,16 +199,19 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
               name={sl.clusterUpdatesOptional}
               id={STEP_IDS.CLUSTER_UPDATES}
               key={STEP_IDS.CLUSTER_UPDATES}
+              status={statusForStep(STEP_IDS.CLUSTER_UPDATES)}
+              isDisabled={isNavDisabledForStep(STEP_IDS.CLUSTER_UPDATES)}
             >
               <ClusterUpdates />
             </WizardStep>,
           ]}
         />
-
         <WizardStep
           name={sl.review}
           id={STEP_IDS.REVIEW}
           key={STEP_IDS.REVIEW}
+          status={statusForStep(STEP_IDS.REVIEW)}
+          isDisabled={isNavDisabledForStep(STEP_IDS.REVIEW)}
           footer={isYamlEditorOpen ? yamlEditorFooter : undefined}
         >
           {isYamlEditorOpen ? (

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePools.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePools.spec-helpers.tsx
@@ -1,20 +1,31 @@
 /**
  * Playwright CT mount target. Components from *.story.tsx cannot be mounted (see playwright.dev/test-components#test-stories).
  */
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Form } from '@patternfly/react-core';
+import { Form, Wizard, WizardStep } from '@patternfly/react-core';
 import { FormProvider, useForm, type Resolver } from 'react-hook-form';
 
 import type { MachineTypesResource, ROSAHCPCluster, VpcListResource } from '../../../types';
 import { withRosaCt } from '../../../components/WizFields/wizFieldCtSpecHelpers';
+import { STEP_IDS } from '../../../constants';
 import {
   makeDefaultRosaHcpCtWizardData,
   makeMachineTypesResource,
   makeVpcListResource,
   WizardFieldMetaChangeEffectsCtHarness,
 } from '../../../test/rosaHcpWizardCtSpecHelpers';
-import { defaultRosaHcpWizardValidatorStrings } from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
+import { buildRosaHcpWizardStepLayout } from '../../../rosaHcpWizardStepLayout';
+import { useRosaHcpWizardStepNavDisabledLookup } from '../../../useRosaHcpWizardStepNavDisabledLookup';
+import {
+  defaultRosaHcpWizardStrings,
+  defaultRosaHcpWizardValidatorStrings,
+} from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
+import {
+  RosaHcpWizardValidationProvider,
+  useRosaHcpWizardStepStatusLookup,
+  useRosaHcpWizardValidation,
+} from '../../../rosaHcpWizardValidationContext';
 import {
   clusterValidationSchema,
   getClusterValidationSchemaDefaultValues,
@@ -22,18 +33,17 @@ import {
 import type { ValidationSchemaContext } from '../../../yupSchemas/types';
 
 import { MachinePools } from './MachinePools';
+import { Networking } from '../Networking/Networking';
 
-export type MachinePoolsMountProps = {
-  vpcList?: VpcListResource;
-  machineTypes?: MachineTypesResource;
-  defaultValues?: Partial<ROSAHCPCluster>;
-};
+const machinePoolsChildStepIdsByParent = buildRosaHcpWizardStepLayout({
+  includeClusterWideProxy: false,
+}).childStepIdsByParent;
 
-export const MachinePoolsMount: React.FC<MachinePoolsMountProps> = ({
-  vpcList,
-  machineTypes,
-  defaultValues = {},
-}) => {
+const machinePoolsForwardNavChildStepIdsByParent = {
+  [STEP_IDS.BASIC_SETUP]: [STEP_IDS.MACHINE_POOLS, STEP_IDS.NETWORKING],
+} as const;
+
+function useMachinePoolsCtForm(defaultValues: Partial<ROSAHCPCluster> = {}) {
   const validationContext = useMemo<ValidationSchemaContext>(
     () => ({
       msgs: defaultRosaHcpWizardValidatorStrings,
@@ -46,7 +56,7 @@ export const MachinePoolsMount: React.FC<MachinePoolsMountProps> = ({
 
   const schemaDefaults = getClusterValidationSchemaDefaultValues();
 
-  const methods = useForm<Partial<ROSAHCPCluster>>({
+  return useForm<Partial<ROSAHCPCluster>>({
     defaultValues: {
       ...schemaDefaults,
       region: 'us-east-1',
@@ -57,6 +67,92 @@ export const MachinePoolsMount: React.FC<MachinePoolsMountProps> = ({
     context: validationContext,
     mode: 'onTouched',
   });
+}
+
+function MachinePoolsWizardNavShell({
+  vpcListProps,
+  machineTypesProps,
+  wizardData,
+  includeNetworkingStep = false,
+  childStepIdsByParent = machinePoolsChildStepIdsByParent,
+  startIndex = 1,
+}: {
+  vpcListProps: ReturnType<typeof makeVpcListResource>;
+  machineTypesProps: ReturnType<typeof makeMachineTypesResource>;
+  wizardData: ReturnType<typeof makeDefaultRosaHcpCtWizardData>;
+  includeNetworkingStep?: boolean;
+  childStepIdsByParent?: typeof machinePoolsChildStepIdsByParent;
+  startIndex?: number;
+}) {
+  const sl = defaultRosaHcpWizardStrings.wizard.stepLabels;
+  const statusForStep = useRosaHcpWizardStepStatusLookup(childStepIdsByParent);
+  const isNavDisabledForStep = useRosaHcpWizardStepNavDisabledLookup({
+    includeClusterWideProxy: false,
+    childStepIdsByParent,
+  });
+  const { onWizardStepChange } = useRosaHcpWizardValidation();
+
+  useEffect(() => {
+    onWizardStepChange(STEP_IDS.MACHINE_POOLS);
+  }, [onWizardStepChange]);
+
+  const machinePoolsStep = (
+    <WizardStep
+      key={STEP_IDS.MACHINE_POOLS}
+      name={sl.machinePools}
+      id={STEP_IDS.MACHINE_POOLS}
+      status={statusForStep(STEP_IDS.MACHINE_POOLS)}
+      isDisabled={isNavDisabledForStep(STEP_IDS.MACHINE_POOLS)}
+    >
+      <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
+      <MachinePools vpcList={vpcListProps} machineTypes={machineTypesProps} />
+    </WizardStep>
+  );
+
+  const networkingStep = includeNetworkingStep ? (
+    <WizardStep
+      key={STEP_IDS.NETWORKING}
+      name={sl.networking}
+      id={STEP_IDS.NETWORKING}
+      status={statusForStep(STEP_IDS.NETWORKING)}
+      isDisabled={isNavDisabledForStep(STEP_IDS.NETWORKING)}
+    >
+      <Networking vpcList={vpcListProps} subnets={wizardData.subnets} />
+    </WizardStep>
+  ) : null;
+
+  return (
+    <Wizard
+      height={720}
+      startIndex={startIndex}
+      onStepChange={(_event, currentStep) => {
+        onWizardStepChange(String(currentStep.id));
+      }}
+    >
+      <WizardStep
+        isExpandable
+        name={sl.basicSetup}
+        id={STEP_IDS.BASIC_SETUP}
+        status={statusForStep(STEP_IDS.BASIC_SETUP)}
+        isDisabled={isNavDisabledForStep(STEP_IDS.BASIC_SETUP)}
+        steps={[machinePoolsStep, ...(networkingStep ? [networkingStep] : [])]}
+      />
+    </Wizard>
+  );
+}
+
+export type MachinePoolsMountProps = {
+  vpcList?: VpcListResource;
+  machineTypes?: MachineTypesResource;
+  defaultValues?: Partial<ROSAHCPCluster>;
+};
+
+export const MachinePoolsMount: React.FC<MachinePoolsMountProps> = ({
+  vpcList,
+  machineTypes,
+  defaultValues = {},
+}) => {
+  const methods = useMachinePoolsCtForm(defaultValues);
 
   const vpcListProps = makeVpcListResource(vpcList);
   const machineTypesProps = makeMachineTypesResource(machineTypes);
@@ -76,6 +172,80 @@ export const MachinePoolsMount: React.FC<MachinePoolsMountProps> = ({
         <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
         <MachinePools vpcList={vpcListProps} machineTypes={machineTypesProps} />
       </Form>
+    </FormProvider>
+  );
+};
+
+/** Wizard left nav + Machine pools step for nav status CT tests. */
+export const MachinePoolsWizardNavMount: React.FC<MachinePoolsMountProps> = ({
+  vpcList,
+  machineTypes,
+  defaultValues = {},
+}) => {
+  const methods = useMachinePoolsCtForm(defaultValues);
+  const vpcListProps = makeVpcListResource(vpcList);
+  const machineTypesProps = makeMachineTypesResource(machineTypes);
+  const wizardData = useMemo(
+    () =>
+      makeDefaultRosaHcpCtWizardData({
+        machineTypes: machineTypesProps,
+        vpcList: vpcListProps,
+      }),
+    [machineTypesProps, vpcListProps]
+  );
+
+  return withRosaCt(
+    <FormProvider {...methods}>
+      <RosaHcpWizardValidationProvider
+        initialActiveStepId={STEP_IDS.MACHINE_POOLS}
+        initialVisitedStepIds={[STEP_IDS.MACHINE_POOLS]}
+      >
+        <Form>
+          <MachinePoolsWizardNavShell
+            vpcListProps={vpcListProps}
+            machineTypesProps={machineTypesProps}
+            wizardData={wizardData}
+          />
+        </Form>
+      </RosaHcpWizardValidationProvider>
+    </FormProvider>
+  );
+};
+
+/** Wizard left nav with Machine pools + Networking for reset-source forward nav CT tests. */
+export const MachinePoolsForwardNavMount: React.FC<MachinePoolsMountProps> = ({
+  vpcList,
+  machineTypes,
+  defaultValues = {},
+}) => {
+  const methods = useMachinePoolsCtForm(defaultValues);
+  const vpcListProps = makeVpcListResource(vpcList);
+  const machineTypesProps = makeMachineTypesResource(machineTypes);
+  const wizardData = useMemo(
+    () =>
+      makeDefaultRosaHcpCtWizardData({
+        machineTypes: machineTypesProps,
+        vpcList: vpcListProps,
+      }),
+    [machineTypesProps, vpcListProps]
+  );
+
+  return withRosaCt(
+    <FormProvider {...methods}>
+      <RosaHcpWizardValidationProvider
+        initialActiveStepId={STEP_IDS.MACHINE_POOLS}
+        initialVisitedStepIds={[STEP_IDS.MACHINE_POOLS, STEP_IDS.NETWORKING]}
+      >
+        <Form>
+          <MachinePoolsWizardNavShell
+            vpcListProps={vpcListProps}
+            machineTypesProps={machineTypesProps}
+            wizardData={wizardData}
+            includeNetworkingStep
+            childStepIdsByParent={machinePoolsForwardNavChildStepIdsByParent}
+          />
+        </Form>
+      </RosaHcpWizardValidationProvider>
     </FormProvider>
   );
 };

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePools.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePools.spec.tsx
@@ -1,18 +1,29 @@
 import { expect, type MountResult, test } from '@playwright/experimental-ct-react';
 import type { Page } from '@playwright/test';
 import { checkAccessibility } from '../../../test-helpers';
-import { defaultRosaHcpWizardStrings } from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
+import {
+  defaultRosaHcpWizardStrings,
+  defaultRosaHcpWizardValidatorStrings,
+} from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
 import rosaHcpWizardFixtures from '../../../ROSAHCPWizard.fixtures';
 import {
   makeMachineTypesResource,
   makeVpcListResource,
 } from '../../../test/rosaHcpWizardCtSpecHelpers';
 import { maxReplicasSchema, minReplicasSchema, nodesComputeSchema } from '../../../yupSchemas';
-import { MachinePoolsMount } from './MachinePools.spec-helpers';
+import {
+  MachinePoolsMount,
+  MachinePoolsForwardNavMount,
+  MachinePoolsWizardNavMount,
+} from './MachinePools.spec-helpers';
 
 const mp = defaultRosaHcpWizardStrings.machinePools;
 const a = defaultRosaHcpWizardStrings.autoscaling;
 const sg = defaultRosaHcpWizardStrings.securityGroups;
+const w = defaultRosaHcpWizardStrings.wizard;
+
+const wizardNavStepErrorButtonName = (stepLabel: string): RegExp =>
+  new RegExp(`, error ${stepLabel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
 
 const [fixtureVpc1, fixtureVpc2] = rosaHcpWizardFixtures.mockVPCs;
 const fixtureVpc1PrivateSubnet = fixtureVpc1.aws_subnets.find((subnet) =>
@@ -142,6 +153,152 @@ test.describe('MachinePools (ROSA HCP)', () => {
     await expect(
       component.getByRole('spinbutton', { name: a.computeCountLabel, exact: true })
     ).not.toBeVisible();
+  });
+
+  test('should clear machine pools nav error when autoscaling is disabled', async ({ mount }) => {
+    const component = await mount(<MachinePoolsWizardNavMount />);
+    const autoscalingCheckbox = component.getByRole('checkbox', {
+      name: a.enableLabel,
+      exact: true,
+    });
+
+    await autoscalingCheckbox.click();
+
+    for (let click = 0; click < 3; click += 1) {
+      await component.getByRole('button', { name: 'Minus' }).nth(1).click();
+    }
+
+    await expect(
+      component.getByRole('button', {
+        name: wizardNavStepErrorButtonName(w.stepLabels.machinePools),
+      })
+    ).toBeVisible();
+
+    await autoscalingCheckbox.click();
+
+    await expect(
+      component.getByRole('button', {
+        name: wizardNavStepErrorButtonName(w.stepLabels.machinePools),
+      })
+    ).not.toBeVisible();
+  });
+
+  test('should show machine pools nav error when max is less than min', async ({ mount }) => {
+    const component = await mount(<MachinePoolsWizardNavMount />);
+
+    await component.getByRole('checkbox', { name: a.enableLabel, exact: true }).click();
+
+    for (let click = 0; click < 3; click += 1) {
+      await component.getByRole('button', { name: 'Minus' }).nth(1).click();
+    }
+
+    await expect(
+      component.getByRole('button', {
+        name: wizardNavStepErrorButtonName(w.stepLabels.machinePools),
+      })
+    ).toBeVisible();
+    await expect(
+      component.getByRole('button', {
+        name: wizardNavStepErrorButtonName(w.stepLabels.basicSetup),
+      })
+    ).toBeVisible();
+  });
+
+  test('should hide machine pools nav error while the VPC select menu is open', async ({
+    mount,
+  }) => {
+    const component = await mount(<MachinePoolsWizardNavMount />);
+    const vpcToggle = component.getByRole('button', { name: vpcSelectMenuName, exact: true });
+    const machinePoolsNavError = component.getByRole('button', {
+      name: wizardNavStepErrorButtonName(w.stepLabels.machinePools),
+    });
+    const sectionTitle = component
+      .locator('#machine-pools-section')
+      .getByText(mp.sectionLabel, { exact: true });
+
+    await vpcToggle.click();
+    await sectionTitle.click();
+
+    await expect(machinePoolsNavError).toBeVisible();
+
+    await vpcToggle.click();
+    await expect(machinePoolsNavError).not.toBeVisible();
+
+    await sectionTitle.click();
+    await expect(machinePoolsNavError).toBeVisible();
+  });
+
+  test('should disable forward visited steps after the VPC reset-source field changes', async ({
+    mount,
+    page,
+  }) => {
+    const component = await mount(
+      <MachinePoolsForwardNavMount
+        defaultValues={{
+          selected_vpc: fixtureVpc1.id,
+          machine_pools_subnets: [{ machine_pool_subnet: fixtureVpc1PrivateSubnet.subnet_id }],
+        }}
+      />
+    );
+
+    const networkingNav = component.getByRole('button', {
+      name: w.stepLabels.networking,
+      exact: true,
+    });
+    await expect(networkingNav).toBeEnabled();
+
+    await selectVpc(component, page, fixtureVpc2.name, fixtureVpc1.name);
+
+    await expect(networkingNav).toBeDisabled();
+  });
+
+  test('should show max less than min validation when max is decremented with the minus button', async ({
+    mount,
+  }) => {
+    const component = await mount(<MachinePoolsMount />);
+    const maxReplicasError = defaultRosaHcpWizardValidatorStrings.replicas.maxLessThanMin;
+
+    await component.getByRole('checkbox', { name: a.enableLabel, exact: true }).click();
+
+    const maxInput = component.getByRole('spinbutton', { name: a.maxLabel, exact: true });
+    await expect(maxInput).toHaveValue(defaultMaxReplicas);
+
+    for (let click = 0; click < 3; click += 1) {
+      await component.getByRole('button', { name: 'Minus' }).nth(1).click();
+    }
+
+    await expect(maxInput).toHaveValue('1');
+    await expect(component.getByText(maxReplicasError, { exact: true })).toBeVisible();
+  });
+
+  test('should clear replica validation when autoscaling is toggled off and back on', async ({
+    mount,
+  }) => {
+    const component = await mount(<MachinePoolsMount />);
+    const maxReplicasError = defaultRosaHcpWizardValidatorStrings.replicas.maxLessThanMin;
+    const autoscalingCheckbox = component.getByRole('checkbox', {
+      name: a.enableLabel,
+      exact: true,
+    });
+
+    await autoscalingCheckbox.click();
+
+    for (let click = 0; click < 3; click += 1) {
+      await component.getByRole('button', { name: 'Minus' }).nth(1).click();
+    }
+
+    await expect(component.getByText(maxReplicasError, { exact: true })).toBeVisible();
+
+    await autoscalingCheckbox.click();
+    await autoscalingCheckbox.click();
+
+    await expect(component.getByRole('spinbutton', { name: a.minLabel, exact: true })).toHaveValue(
+      defaultMinReplicas
+    );
+    await expect(component.getByRole('spinbutton', { name: a.maxLabel, exact: true })).toHaveValue(
+      defaultMaxReplicas
+    );
+    await expect(component.getByText(maxReplicasError, { exact: true })).not.toBeVisible();
   });
 
   test('should set replica defaults when autoscaling is enabled and restore compute count when disabled', async ({

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePoolsAutoscalingReplicas.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePoolsAutoscalingReplicas.tsx
@@ -8,6 +8,10 @@ import { clusterValidationSchema, minReplicasSchema } from '../../../yupSchemas'
 
 const minReplicasUiMin = minReplicasSchema.getDefault() as number;
 
+const autoscalingReplicaFieldPaths = ['min_replicas', 'max_replicas'] as const satisfies Readonly<
+  (keyof ROSAHCPCluster)[]
+>;
+
 function AutoscalingReplicasLabelHelp({ helpText }: { helpText: string }) {
   const a = useRosaHcpWizardStrings().autoscaling;
   return (
@@ -35,6 +39,7 @@ export const MachinePoolsAutoscalingReplicas = (props: MachinePoolsAutoscalingRe
           schema={clusterValidationSchema}
           min={minReplicasUiMin}
           max={maxAutoscalingNodes}
+          revalidateFieldPaths={autoscalingReplicaFieldPaths}
           labelHelp={<AutoscalingReplicasLabelHelp helpText={a.minHelp} />}
         />
       </FlexItem>
@@ -44,6 +49,7 @@ export const MachinePoolsAutoscalingReplicas = (props: MachinePoolsAutoscalingRe
           schema={clusterValidationSchema}
           min={1}
           max={maxAutoscalingNodes}
+          revalidateFieldPaths={autoscalingReplicaFieldPaths}
           labelHelp={<AutoscalingReplicasLabelHelp helpText={a.maxHelp} />}
         />
       </FlexItem>

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.spec-helpers.tsx
@@ -4,6 +4,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import type { ROSAHCPCluster, VpcListResource } from '../../types';
 import { STEP_IDS } from '../../constants';
 import { makeVpcListResource } from '../../test/rosaHcpWizardCtSpecHelpers';
+import { RosaHcpWizardValidationProvider } from '../../rosaHcpWizardValidationContext';
 import { RosaHcpWizardStringsProvider } from '../../stringsProvider/RosaHcpWizardStringsContext';
 import { getClusterValidationSchemaDefaultValues } from '../../yupSchemas';
 import { Review } from './Review';
@@ -26,11 +27,16 @@ export function ReviewHarness({ formOverrides = {}, vpcList }: ReviewHarnessProp
   return (
     <RosaHcpWizardStringsProvider>
       <FormProvider {...methods}>
-        <Wizard height={720}>
-          <WizardStep name="Review" id={STEP_IDS.REVIEW} key="review">
-            <Review vpcList={vpcListProps} />
-          </WizardStep>
-        </Wizard>
+        <RosaHcpWizardValidationProvider
+          initialActiveStepId={STEP_IDS.REVIEW}
+          initialVisitedStepIds={[STEP_IDS.REVIEW]}
+        >
+          <Wizard height={720}>
+            <WizardStep name="Review" id={STEP_IDS.REVIEW} key="review">
+              <Review vpcList={vpcListProps} />
+            </WizardStep>
+          </Wizard>
+        </RosaHcpWizardValidationProvider>
       </FormProvider>
     </RosaHcpWizardStringsProvider>
   );

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../utilities/helpers';
 import { Section } from '../../components/Section';
 import { STEP_IDS } from '../../constants';
+import { useRosaHcpWizardValidation } from '../../rosaHcpWizardValidationContext';
 import { useRosaHcpWizardReviewSections } from './ROSAHCPWizardReviewSections';
 import type { RosaHcpWizardStrings } from '../../stringsProvider/rosaHcpWizardStrings';
 import { getRosaHcpWizardStringByLabelKey } from '../../stringsProvider/getRosaHcpWizardStringByLabelKey';
@@ -69,6 +70,7 @@ export type ReviewProps = Pick<ROSAHCPWizardData, 'vpcList'> & {
 
 export const Review = ({ vpcList, onOpenYamlEditor }: ReviewProps) => {
   const { goToStepById } = useWizardContext();
+  const { onWizardStepChange } = useRosaHcpWizardValidation();
   const watchedFormValues = useWatch();
   const defaultWizardFormValues = getClusterValidationSchemaDefaultValues();
   const formValues = {
@@ -163,7 +165,14 @@ export const Review = ({ vpcList, onOpenYamlEditor }: ReviewProps) => {
                   </ReviewExpandSection>
                 </SplitItem>
                 <SplitItem>
-                  <Button isInline variant="link" onClick={() => goToStepById?.(section.id)}>
+                  <Button
+                    isInline
+                    variant="link"
+                    onClick={() => {
+                      goToStepById?.(section.id);
+                      onWizardStepChange(section.id);
+                    }}
+                  >
                     {review.editStep}
                   </Button>
                 </SplitItem>

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/rosaHcpWizardReviewSections.data.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/rosaHcpWizardReviewSections.data.ts
@@ -1,13 +1,13 @@
 /**
  * Review-step sections and per-step field paths (no React). Shared by Review and Next validation.
- * Field paths are derived from Yup `.meta({ stepId })` via {@link getFieldPathsByStepId}
- * in {@link wizardFieldMetaChangeRegistry}.
+ * Leaf step ids and review metadata come from {@link buildRosaHcpWizardStepLayout}; field paths
+ * come from Yup `.meta({ stepId })` via {@link getFieldPathsByStepId}.
  *
  * Named `.data.ts` so imports of `ROSAHCPWizardReviewSections` resolve to the React hook module
  * on case-insensitive filesystems (macOS).
  */
 
-import { STEP_IDS } from '../../constants';
+import { buildRosaHcpWizardStepLayout } from '../../rosaHcpWizardStepLayout';
 import { getFieldPathsByStepId } from '../../yupSchemas/wizardFieldMetaChangeRegistry';
 
 export interface RosaHcpWizardReviewSection {
@@ -29,49 +29,25 @@ export type RosaHcpWizardReviewStepLabels = {
   clusterUpdatesOptional: string;
 };
 
+export type BuildRosaHcpWizardReviewSectionsOptions = {
+  includeClusterWideProxy?: boolean;
+};
+
 export function buildRosaHcpWizardReviewSections(
-  stepLabels: RosaHcpWizardReviewStepLabels
+  stepLabels: RosaHcpWizardReviewStepLabels,
+  options: BuildRosaHcpWizardReviewSectionsOptions = {}
 ): RosaHcpWizardReviewSection[] {
   const fieldPathsByStepId = getFieldPathsByStepId();
+  const { leafSteps } = buildRosaHcpWizardStepLayout({
+    includeClusterWideProxy: options.includeClusterWideProxy ?? true,
+  });
 
-  return [
-    {
-      id: STEP_IDS.DETAILS,
-      label: stepLabels.details,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.DETAILS] ?? [],
-    },
-    {
-      id: STEP_IDS.ROLES_AND_POLICIES,
-      label: stepLabels.rolesAndPolicies,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.ROLES_AND_POLICIES] ?? [],
-    },
-    {
-      id: STEP_IDS.MACHINE_POOLS,
-      label: stepLabels.machinePools,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.MACHINE_POOLS] ?? [],
-    },
-    {
-      id: STEP_IDS.NETWORKING,
-      label: stepLabels.networking,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.NETWORKING] ?? [],
-    },
-    {
-      id: STEP_IDS.CLUSTER_WIDE_PROXY,
-      label: stepLabels.clusterWideProxy,
-      hideIfUnchanged: true,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.CLUSTER_WIDE_PROXY] ?? [],
-    },
-    {
-      id: STEP_IDS.ENCRYPTION,
-      label: stepLabels.encryptionOptional,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.ENCRYPTION] ?? [],
-    },
-    {
-      id: STEP_IDS.CLUSTER_UPDATES,
-      label: stepLabels.clusterUpdatesOptional,
-      fieldPaths: fieldPathsByStepId[STEP_IDS.CLUSTER_UPDATES] ?? [],
-    },
-  ];
+  return leafSteps.map((step) => ({
+    id: step.id,
+    label: stepLabels[step.labelKey],
+    ...(step.hideInReviewIfUnchanged ? { hideIfUnchanged: true } : {}),
+    fieldPaths: fieldPathsByStepId[step.id] ?? [],
+  }));
 }
 
 /** Field paths for a wizard step, used when validating on Next. */

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/MultiSelect/MultiSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/MultiSelect/MultiSelect.tsx
@@ -4,9 +4,7 @@ import {
   type MouseEvent,
   type ReactNode,
   useCallback,
-  useEffect,
   useMemo,
-  useState,
 } from 'react';
 import {
   Badge,
@@ -41,6 +39,8 @@ import {
   type OptionType,
 } from '../Select/SelectTypes';
 import { useMultiSelectDerived } from './useMultiSelectDerived';
+import { useSelectMenuOpen } from '../Select/useSelectMenuOpen';
+import { useSelectMenuToggleBlur } from '../Select/useSelectMenuToggleBlur';
 
 /** Stable fallback when `value` is null/undefined so hook deps stay referentially stable. */
 const EMPTY_MULTISELECT_VALUE: never[] = [];
@@ -78,7 +78,7 @@ export interface MultiSelectProps<T = unknown> {
   noResultsText?: string;
   isSuccess?: boolean;
   successMessage?: ReactNode | string;
-  /** Fires when the dropdown menu opens or closes (after internal `open` updates). */
+  /** Fires when the dropdown menu opens or closes. Close is deferred until after selection. */
   onMenuOpenChange?: (isOpen: boolean) => void;
   /** Optional max height for the dropdown list. */
   maxMenuHeight?: string;
@@ -143,11 +143,8 @@ export function MultiSelect<T = unknown>(props: MultiSelectProps<T>) {
     keyPath,
   });
 
-  const [open, setOpen] = useState(false);
-
-  useEffect(() => {
-    onMenuOpenChange?.(open);
-  }, [open, onMenuOpenChange]);
+  const { open, handleOpenChange } = useSelectMenuOpen(onMenuOpenChange);
+  const handleToggleBlur = useSelectMenuToggleBlur(open, onBlur);
 
   const selectedMenuIds = useMemo(() => {
     const ids: string[] = [];
@@ -190,7 +187,10 @@ export function MultiSelect<T = unknown>(props: MultiSelectProps<T>) {
     <Badge screenReaderText={badgeScreenReaderText}>{value.length}</Badge>
   ) : undefined;
 
-  const handleToggle = useCallback(() => setOpen((o) => !o), []);
+  const handleToggle = useCallback(
+    () => handleOpenChange((current) => !current),
+    [handleOpenChange]
+  );
 
   const onPfSelect = useCallback(
     (_event: MouseEvent<Element> | undefined, val: unknown) => {
@@ -316,7 +316,7 @@ export function MultiSelect<T = unknown>(props: MultiSelectProps<T>) {
     <MenuToggle
       ref={toggleRef}
       onClick={handleToggle}
-      onBlur={onBlur}
+      onBlur={handleToggleBlur}
       isExpanded={open}
       isDisabled={!!disabled}
       isFullWidth
@@ -338,7 +338,7 @@ export function MultiSelect<T = unknown>(props: MultiSelectProps<T>) {
           isOpen={open}
           selected={selectedMenuIds}
           onSelect={onPfSelect}
-          onOpenChange={setOpen}
+          onOpenChange={handleOpenChange}
           shouldFocusToggleOnSelect={false}
           toggle={plainToggle}
           maxMenuHeight={maxMenuHeight}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/Select.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/Select.tsx
@@ -32,6 +32,8 @@ import { toDisplayString } from './SelectOptions';
 import { extractOptionValue, type Option, type OptionGroup, type OptionType } from './SelectTypes';
 import { getStatus, isSyntheticOptionId, lowercaseFirst } from './selectFieldUtils';
 import { useSelectDerived } from './useSelectDerived';
+import { useSelectMenuOpen } from './useSelectMenuOpen';
+import { useSelectMenuToggleBlur } from './useSelectMenuToggleBlur';
 import { HelperText, helperTextId } from '../HelperText';
 import { LabelHelp } from '../LabelHelp';
 
@@ -73,7 +75,7 @@ export interface SelectProps<T = unknown> {
   noResultsText?: string;
   isSuccess?: boolean;
   successMessage?: ReactNode | string;
-  /** Fires when the dropdown menu opens or closes (after internal `open` updates). */
+  /** Fires when the dropdown menu opens or closes. Close is deferred until after selection. */
   onMenuOpenChange?: (isOpen: boolean) => void;
   /** Optional max height for the dropdown list (passed to PatternFly `Select`). */
   maxMenuHeight?: string;
@@ -117,13 +119,10 @@ export function Select<T = unknown>(props: SelectProps<T>) {
     throw new Error('Select: use either `options` or `optionGroups`, not both.');
   }
 
-  const [open, setOpen] = useState(false);
+  const { open, handleOpenChange } = useSelectMenuOpen(onMenuOpenChange);
   const [typeaheadQuery, setTypeaheadQuery] = useState('');
   const textInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    onMenuOpenChange?.(open);
-  }, [open, onMenuOpenChange]);
+  const handleToggleBlur = useSelectMenuToggleBlur(open, onBlur);
 
   const {
     normalizedFlat,
@@ -164,16 +163,16 @@ export function Select<T = unknown>(props: SelectProps<T>) {
         if (isTypeAhead) {
           onChange(undefined as T | string | number | undefined);
         }
-        setOpen(false);
+        handleOpenChange(false);
         return;
       }
       const opt = flatForLookup.find((o) => o.id === optionId);
       if (opt) {
         onChange(opt.value as T | string | number | undefined);
       }
-      setOpen(false);
+      handleOpenChange(false);
     },
-    [flatForLookup, isTypeAhead, onChange]
+    [flatForLookup, handleOpenChange, isTypeAhead, onChange]
   );
 
   const onPfSelect = useCallback(
@@ -297,7 +296,7 @@ export function Select<T = unknown>(props: SelectProps<T>) {
     [onChange]
   );
 
-  const toggleOpen = useCallback(() => setOpen((o) => !o), []);
+  const toggleOpen = useCallback(() => handleOpenChange((current) => !current), [handleOpenChange]);
 
   const describedBy = helperTextId({
     id,
@@ -314,7 +313,7 @@ export function Select<T = unknown>(props: SelectProps<T>) {
     <MenuToggle
       ref={toggleRef}
       onClick={toggleOpen}
-      onBlur={onBlur}
+      onBlur={handleToggleBlur}
       isExpanded={open}
       isDisabled={!!disabled}
       isFullWidth
@@ -331,7 +330,7 @@ export function Select<T = unknown>(props: SelectProps<T>) {
       variant="typeahead"
       ref={toggleRef}
       onClick={toggleOpen}
-      onBlur={onBlur}
+      onBlur={handleToggleBlur}
       isExpanded={open}
       isDisabled={!!disabled}
       isFullWidth
@@ -382,7 +381,7 @@ export function Select<T = unknown>(props: SelectProps<T>) {
           isOpen={open}
           selected={selectedForMenu}
           onSelect={onPfSelect}
-          onOpenChange={setOpen}
+          onOpenChange={handleOpenChange}
           toggle={isTypeAhead ? typeaheadToggle : plainToggle}
           variant={isTypeAhead ? 'typeahead' : undefined}
           shouldFocusToggleOnSelect={!isTypeAhead}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/useSelectMenuOpen.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/useSelectMenuOpen.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Controlled open state for PatternFly {@link Select} wrappers.
+ *
+ * Notifies {@link onMenuOpenChange} synchronously when the menu opens so parent error
+ * suppression stays aligned with the toggle. Defers close notification to the next task
+ * so {@link onSelect} / RHF {@link onChange} can run first (PF may close on pointerdown
+ * before the value updates).
+ */
+export function useSelectMenuOpen(onMenuOpenChange?: (isOpen: boolean) => void): {
+  open: boolean;
+  handleOpenChange: (nextOpen: boolean | ((prev: boolean) => boolean)) => void;
+} {
+  const openRef = useRef(false);
+  const [open, setOpen] = useState(false);
+  const closeNotifyTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const clearCloseNotifyTimer = useCallback(() => {
+    if (closeNotifyTimerRef.current !== undefined) {
+      clearTimeout(closeNotifyTimerRef.current);
+      closeNotifyTimerRef.current = undefined;
+    }
+  }, []);
+
+  const notifyMenuOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        clearCloseNotifyTimer();
+        onMenuOpenChange?.(true);
+        return;
+      }
+      clearCloseNotifyTimer();
+      closeNotifyTimerRef.current = setTimeout(() => {
+        closeNotifyTimerRef.current = undefined;
+        onMenuOpenChange?.(false);
+      }, 0);
+    },
+    [clearCloseNotifyTimer, onMenuOpenChange]
+  );
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean | ((prev: boolean) => boolean)) => {
+      const prev = openRef.current;
+      const resolved = typeof nextOpen === 'function' ? nextOpen(prev) : nextOpen;
+      if (resolved === prev) {
+        return;
+      }
+      openRef.current = resolved;
+      setOpen(resolved);
+      notifyMenuOpenChange(resolved);
+    },
+    [notifyMenuOpenChange]
+  );
+
+  useEffect(() => () => clearCloseNotifyTimer(), [clearCloseNotifyTimer]);
+
+  return { open, handleOpenChange };
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/useSelectMenuToggleBlur.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/useSelectMenuToggleBlur.ts
@@ -1,0 +1,26 @@
+import { type FocusEventHandler, useCallback, useRef } from 'react';
+
+/**
+ * Skips RHF {@link onBlur} while the select menu stays open after a toggle blur. Focus often
+ * leaves the toggle for the portaled listbox during option selection; marking touched in that
+ * window flashes errors before {@link onChange} runs. The open check is deferred so an outside
+ * click that closes the menu in the same gesture still reaches RHF blur.
+ */
+export function useSelectMenuToggleBlur(
+  open: boolean,
+  onBlur?: FocusEventHandler<HTMLElement>
+): FocusEventHandler<HTMLElement> {
+  const openRef = useRef(open);
+  openRef.current = open;
+
+  return useCallback(
+    (event) => {
+      setTimeout(() => {
+        if (!openRef.current) {
+          onBlur?.(event);
+        }
+      }, 0);
+    },
+    [onBlur]
+  );
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizMultiSelect/WizMultiSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizMultiSelect/WizMultiSelect.tsx
@@ -4,6 +4,7 @@ import { requiredFromYup } from '../../../utilities/yupFieldRequired';
 import { FieldWithAPIErrorAlert } from '../../FieldWithAPIErrorAlert';
 import { MultiSelect, type MultiSelectProps } from '../../Fields/MultiSelect';
 import { useWizFieldPresentation } from '../wizFieldPresentation';
+import { useWizardFieldNavErrorSuppression } from '../../../rosaHcpWizardValidationContext';
 import { useWizRhfControl, wizFieldShowsError, type WizRhfBoundFieldProps } from '../wizFieldRhf';
 
 type WizMultiSelectControlledKeys = 'value' | 'onChange' | 'onBlur' | 'errorMessage' | 'isError';
@@ -93,6 +94,7 @@ export function WizMultiSelect<TFieldValues extends FieldValues = FieldValues, T
   } = useController({ name, control });
 
   const showError = wizFieldShowsError(invalid, isTouched, isSubmitted);
+  useWizardFieldNavErrorSuppression(String(name), isMenuOpen);
 
   const raw = field.value;
   const value = Array.isArray(raw) ? (raw as TOption[]) : [];

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizNumberInput/WizNumberInput.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizNumberInput/WizNumberInput.tsx
@@ -1,5 +1,13 @@
 import type { SyntheticEvent } from 'react';
-import { type FieldValues, useController } from 'react-hook-form';
+import {
+  type FieldPath,
+  type FieldPathValue,
+  type FieldValues,
+  type UseFormReturn,
+  useController,
+  useFormContext,
+} from 'react-hook-form';
+
 import { requiredFromYup } from '../../../utilities/yupFieldRequired';
 import { NumberInput, type NumberInputProps } from '../../Fields/NumberInput';
 import { useWizFieldPresentation } from '../wizFieldPresentation';
@@ -33,7 +41,11 @@ type WizNumberInputSpreadProps = Omit<
   >;
 
 export type WizNumberInputProps<TFieldValues extends FieldValues = FieldValues> =
-  WizNumberInputSpreadProps & WizRhfBoundFieldProps<TFieldValues>;
+  WizNumberInputSpreadProps &
+    WizRhfBoundFieldProps<TFieldValues> & {
+      /** Re-run validation on these paths after each value change (cross-field Yup rules). */
+      revalidateFieldPaths?: readonly FieldPath<TFieldValues>[];
+    };
 
 /**
  * Prefer wrapping the form with `FormProvider` so you can omit `control`.
@@ -56,10 +68,12 @@ export function WizNumberInput<TFieldValues extends FieldValues = FieldValues>(
     labelHelp: labelHelpProp,
     labelHelpTitle: labelHelpTitleProp,
     placeholder: placeholderProp,
+    revalidateFieldPaths,
     ...rest
   } = props;
 
   const control = useWizRhfControl<TFieldValues>('WizNumberInput', controlProp);
+  const formContext = useFormContext<TFieldValues>() as UseFormReturn<TFieldValues> | null;
   const { id, label, helperText, labelHelp, labelHelpTitle, placeholder } = useWizFieldPresentation(
     {
       name,
@@ -91,6 +105,20 @@ export function WizNumberInput<TFieldValues extends FieldValues = FieldValues>(
     typeof field.value === 'number' && !Number.isNaN(field.value) ? field.value : undefined;
 
   const onChange = (_event: SyntheticEvent, next: number | undefined) => {
+    const nextValue = next as FieldPathValue<TFieldValues, typeof name>;
+
+    if (formContext?.setValue) {
+      formContext.setValue(name, nextValue, {
+        shouldDirty: true,
+        shouldTouch: true,
+        shouldValidate: true,
+      });
+      if (revalidateFieldPaths?.length) {
+        void formContext.trigger(revalidateFieldPaths);
+      }
+      return;
+    }
+
     field.onChange(next);
   };
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
@@ -10,7 +10,10 @@ import {
 import { FieldWithAPIErrorAlert } from '../../FieldWithAPIErrorAlert';
 import { Select, type SelectProps } from '../../Fields/Select';
 import { useWizFieldPresentation } from '../wizFieldPresentation';
-import { useWizStepValidationRevealed } from '../../../rosaHcpWizardValidationContext';
+import {
+  useWizardFieldNavErrorSuppression,
+  useWizStepValidationRevealed,
+} from '../../../rosaHcpWizardValidationContext';
 import { useWizRhfControl, wizFieldShowsError, type WizRhfBoundFieldProps } from '../wizFieldRhf';
 
 type WizSelectControlledKeys = 'value' | 'onChange' | 'onBlur' | 'errorMessage' | 'isError';
@@ -104,6 +107,7 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
 
   const stepValidationRevealed = useWizStepValidationRevealed(String(name));
   const showError = wizFieldShowsError(invalid, isTouched, isSubmitted || stepValidationRevealed);
+  useWizardFieldNavErrorSuppression(String(name), isMenuOpen);
   useReconcileWizSelectValueWithOptions({
     name,
     schema,

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.test.ts
@@ -166,6 +166,7 @@ describe('applyWizardFieldMetaChangeEffects', () => {
       setValue,
       autoscalingSyncRules,
       true,
+      undefined,
       undefined
     );
     expect(resetFieldsToDefaultValuesMock).not.toHaveBeenCalled();
@@ -190,7 +191,8 @@ describe('applyWizardFieldMetaChangeEffects', () => {
       {
         clearOnly: true,
         shouldDirty: false,
-      }
+      },
+      undefined
     );
     expect(resetFieldsToDefaultValuesMock).not.toHaveBeenCalled();
   });
@@ -211,7 +213,8 @@ describe('applyWizardFieldMetaChangeEffects', () => {
       setValue,
       autoscalingSyncRules,
       false,
-      { clearOnly: true, shouldDirty: false }
+      { clearOnly: true, shouldDirty: false },
+      undefined
     );
   });
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.ts
@@ -1,4 +1,4 @@
-import type { UseFormSetValue } from 'react-hook-form';
+import type { UseFormClearErrors, UseFormSetValue } from 'react-hook-form';
 
 import { hasDerivedSyncSourceValue, hasRefetchableStringValue } from './wizardFieldDerivedSyncs';
 import { resetFieldsToDefaultValues } from './resetFieldsToDefaultValues';
@@ -21,6 +21,7 @@ export type ApplyWizardFieldMetaChangeEffectsArgs = {
   currentValue: unknown;
   wizardData: ROSAHCPWizardData;
   setValue: UseFormSetValue<Partial<ROSAHCPCluster>>;
+  clearErrors?: UseFormClearErrors<Partial<ROSAHCPCluster>>;
 };
 
 function refetchWizardResource(
@@ -54,6 +55,7 @@ export function applyWizardFieldMetaChangeEffects({
   currentValue,
   wizardData,
   setValue,
+  clearErrors,
 }: ApplyWizardFieldMetaChangeEffectsArgs): void {
   const isInitialChange = previousValue === undefined;
   if (!isInitialChange && wizardFormFieldValuesEqual(previousValue, currentValue)) {
@@ -83,7 +85,8 @@ export function applyWizardFieldMetaChangeEffects({
       setValue,
       syncs,
       currentValue,
-      isInitialChange ? { clearOnly: true, shouldDirty: false } : undefined
+      isInitialChange ? { clearOnly: true, shouldDirty: false } : undefined,
+      clearErrors
     );
   }
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.test.ts
@@ -17,22 +17,50 @@ const defaultNodesCompute = nodesComputeSchema.getDefault() as number;
 describe('syncFieldsOnSourceChange', () => {
   it('sets replica defaults and clears compute count when autoscaling is enabled', () => {
     const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+    const clearErrors = jest.fn();
 
-    syncFieldsOnSourceChange(setValue, autoscalingSyncRules, true);
+    syncFieldsOnSourceChange(setValue, autoscalingSyncRules, true, {}, clearErrors);
 
-    expect(setValue).toHaveBeenCalledWith('nodes_compute', undefined, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('min_replicas', defaultMinReplicas, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('max_replicas', defaultMaxReplicas, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('nodes_compute', undefined, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: true,
+    });
+    expect(setValue).toHaveBeenCalledWith('min_replicas', defaultMinReplicas, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: true,
+    });
+    expect(setValue).toHaveBeenCalledWith('max_replicas', defaultMaxReplicas, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: true,
+    });
+    expect(clearErrors).toHaveBeenCalledWith(['nodes_compute', 'min_replicas', 'max_replicas']);
   });
 
   it('restores compute count and clears replicas when autoscaling is disabled', () => {
     const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+    const clearErrors = jest.fn();
 
-    syncFieldsOnSourceChange(setValue, autoscalingSyncRules, false);
+    syncFieldsOnSourceChange(setValue, autoscalingSyncRules, false, {}, clearErrors);
 
-    expect(setValue).toHaveBeenCalledWith('min_replicas', undefined, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('max_replicas', undefined, expect.any(Object));
-    expect(setValue).toHaveBeenCalledWith('nodes_compute', defaultNodesCompute, expect.any(Object));
+    expect(setValue).toHaveBeenCalledWith('min_replicas', undefined, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: true,
+    });
+    expect(setValue).toHaveBeenCalledWith('max_replicas', undefined, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: true,
+    });
+    expect(setValue).toHaveBeenCalledWith('nodes_compute', defaultNodesCompute, {
+      shouldDirty: true,
+      shouldTouch: false,
+      shouldValidate: true,
+    });
+    expect(clearErrors).toHaveBeenCalledWith(['min_replicas', 'max_replicas', 'nodes_compute']);
   });
 
   it('clears inactive fields without applying setDefaults when clearOnly is set', () => {

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/syncFieldsOnSourceChange.ts
@@ -1,8 +1,15 @@
 import * as yup from 'yup';
-import type { FieldPathValue, UseFormSetValue } from 'react-hook-form';
+import type {
+  FieldPath,
+  FieldPathValue,
+  UseFormClearErrors,
+  UseFormSetValue,
+} from 'react-hook-form';
 
 import {
   buildFormSetValueOptions,
+  DEFAULT_FORM_SET_VALUE_OPTS,
+  DEFAULT_FORM_SET_VALUE_OPTS_WITH_VALIDATE,
   type FormSetValueOptions,
 } from '../utilities/formSetValueOptions';
 import type { ROSAHCPCluster } from '../types';
@@ -24,25 +31,38 @@ export function syncFieldsOnSourceChange(
   setValue: UseFormSetValue<Partial<ROSAHCPCluster>>,
   syncRules: readonly WizardFieldSyncOnChange[],
   currentValue: unknown,
-  options: SyncFieldsOnSourceChangeOptions = {}
+  options: SyncFieldsOnSourceChangeOptions = {},
+  clearErrors?: UseFormClearErrors<Partial<ROSAHCPCluster>>
 ): void {
   const branch = syncRules.find((rule) => rule.when === currentValue);
   if (!branch) {
     return;
   }
 
-  const setOpts = buildFormSetValueOptions(options);
+  const { clearOnly, ...setValueOptions } = options;
+  const setOpts = buildFormSetValueOptions(
+    setValueOptions,
+    clearOnly ? DEFAULT_FORM_SET_VALUE_OPTS : DEFAULT_FORM_SET_VALUE_OPTS_WITH_VALIDATE
+  );
+
+  const syncedFieldNames: WizardFormFieldName[] = [];
 
   for (const name of branch.clear ?? []) {
+    syncedFieldNames.push(name);
     setValue(name, undefined as FieldPathValue<Partial<ROSAHCPCluster>, typeof name>, setOpts);
   }
 
-  if (options.clearOnly) {
+  if (clearOnly) {
     return;
   }
 
   for (const name of branch.setDefaults ?? []) {
+    syncedFieldNames.push(name);
     const value = getWizardFieldSchemaDefault(name);
     setValue(name, value as FieldPathValue<Partial<ROSAHCPCluster>, typeof name>, setOpts);
+  }
+
+  if (clearErrors && syncedFieldNames.length > 0) {
+    clearErrors(syncedFieldNames as FieldPath<Partial<ROSAHCPCluster>>[]);
   }
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
@@ -41,7 +41,7 @@ function buildFormValuesForMetaEffects(
  * re-run effects; resets skip `setValue` when the form already matches schema defaults.
  */
 export function useWizardFieldMetaChangeEffects(wizardData: ROSAHCPWizardData): void {
-  const { setValue, getValues, control } = useFormContext<Partial<ROSAHCPCluster>>();
+  const { setValue, getValues, control, clearErrors } = useFormContext<Partial<ROSAHCPCluster>>();
   const sourceFields = useMemo(() => listWizardFieldMetaChangeSourceFields(), []);
   const derivedSyncEntries = useMemo(() => listWizardFieldDerivedSyncEntries(), []);
   const watchedValues = useWatch({
@@ -72,12 +72,13 @@ export function useWizardFieldMetaChangeEffects(wizardData: ROSAHCPWizardData): 
         currentValue,
         wizardData: wizardDataRef.current,
         setValue,
+        clearErrors,
       });
       previousByFieldRef.current[field] = currentValue;
     }
 
     hasInitializedRef.current = true;
-  }, [getValues, setValue, sourceFields, watchedValues]);
+  }, [clearErrors, getValues, setValue, sourceFields, watchedValues]);
 
   useEffect(() => {
     if (!hasInitializedRef.current) {

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useClusterNameUniquenessValidation.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useClusterNameUniquenessValidation.ts
@@ -3,6 +3,7 @@ import { useFormContext, useWatch } from 'react-hook-form';
 
 import { hasRefetchableStringValue } from '../utilities/hasRefetchableStringValue';
 import type { CheckClusterNameUniqueness, ROSAHCPCluster } from '../types';
+import { useRosaHcpWizardFieldAsyncValidationReporter } from '../rosaHcpWizardValidationContext';
 import { useRosaHcpWizardValidators } from '../stringsProvider/RosaHcpWizardStringsContext';
 import { validateClusterNameSync } from '../yupSchemas/helpers';
 
@@ -24,6 +25,7 @@ export function useClusterNameUniquenessValidation({
   checkOnNameBlur: () => Promise<void>;
 } {
   const msgs = useRosaHcpWizardValidators();
+  const reportAsyncValidationInProgress = useRosaHcpWizardFieldAsyncValidationReporter();
   const { control, getValues, setError, clearErrors, getFieldState } =
     useFormContext<Partial<ROSAHCPCluster>>();
   const region = useWatch({ control, name: 'region' });
@@ -84,10 +86,13 @@ export function useClusterNameUniquenessValidation({
 
     const requestId = ++uniquenessRequestIdRef.current;
     let error: string | null | undefined;
+    reportAsyncValidationInProgress?.('name', true);
     try {
       error = await check(name, currentRegion);
     } catch {
       return;
+    } finally {
+      reportAsyncValidationInProgress?.('name', false);
     }
     if (requestId !== uniquenessRequestIdRef.current) {
       return;
@@ -95,7 +100,7 @@ export function useClusterNameUniquenessValidation({
 
     lastCheckedRef.current = { name, region: currentRegion };
     applyUniqueErrorToForm(error ?? null);
-  }, [applyUniqueErrorToForm, getValues, msgs.clusterName]);
+  }, [applyUniqueErrorToForm, getValues, msgs.clusterName, reportAsyncValidationInProgress]);
 
   const scheduleUniquenessCheck = useCallback(() => {
     clearPendingDebounce();

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNav.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNav.test.ts
@@ -1,0 +1,557 @@
+import type { UseFormGetFieldState, UseFormGetValues } from 'react-hook-form';
+
+import { STEP_IDS } from './constants';
+import { buildRosaHcpWizardStepLayout } from './rosaHcpWizardStepLayout';
+import {
+  buildOrderedNavigableStepIds,
+  getNextOrderedStepId,
+  isRosaHcpWizardNavStepDisabled,
+} from './rosaHcpWizardNav';
+
+const ORDERED = buildOrderedNavigableStepIds(false);
+
+const optionalSetupChildStepIdsByParent = buildRosaHcpWizardStepLayout({
+  includeClusterWideProxy: false,
+}).childStepIdsByParent;
+
+describe('getNextOrderedStepId', () => {
+  it('returns the next leaf step id', () => {
+    expect(getNextOrderedStepId(STEP_IDS.DETAILS, ORDERED)).toBe(STEP_IDS.ROLES_AND_POLICIES);
+  });
+
+  it('returns undefined on the last step', () => {
+    expect(getNextOrderedStepId(STEP_IDS.REVIEW, ORDERED)).toBeUndefined();
+  });
+});
+
+describe('isRosaHcpWizardNavStepDisabled', () => {
+  it('disables future unvisited steps', () => {
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.ROLES_AND_POLICIES,
+        activeStepId: STEP_IDS.DETAILS,
+        visitedStepIds: new Set([STEP_IDS.DETAILS]),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+      })
+    ).toBe(true);
+  });
+
+  it('enables previous steps', () => {
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.DETAILS,
+        activeStepId: STEP_IDS.ROLES_AND_POLICIES,
+        visitedStepIds: new Set([STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES]),
+        blockForwardNavigation: true,
+        orderedStepIds: ORDERED,
+      })
+    ).toBe(false);
+  });
+
+  it('disables forward visited steps when forward navigation is blocked', () => {
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.ROLES_AND_POLICIES,
+        activeStepId: STEP_IDS.DETAILS,
+        visitedStepIds: new Set([STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES]),
+        blockForwardNavigation: true,
+        orderedStepIds: ORDERED,
+      })
+    ).toBe(true);
+  });
+
+  it('enables forward visited steps when forward navigation is not blocked', () => {
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.ROLES_AND_POLICIES,
+        activeStepId: STEP_IDS.DETAILS,
+        visitedStepIds: new Set([STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES]),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+      })
+    ).toBe(false);
+  });
+
+  it('disables forward steps that were invalidated after a reset-source edit', () => {
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.MACHINE_POOLS,
+        activeStepId: STEP_IDS.ROLES_AND_POLICIES,
+        visitedStepIds: new Set([STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES]),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+      })
+    ).toBe(true);
+  });
+
+  it('disables forward visited steps after an earlier step has validation errors', () => {
+    const machinePoolsIdx = ORDERED.indexOf(STEP_IDS.MACHINE_POOLS);
+
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.REVIEW,
+        activeStepId: STEP_IDS.ROLES_AND_POLICIES,
+        visitedStepIds: new Set(ORDERED),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+        earliestInvalidStepIdx: machinePoolsIdx,
+      })
+    ).toBe(true);
+  });
+
+  it('allows navigating to the step that has validation errors so the user can fix them', () => {
+    const machinePoolsIdx = ORDERED.indexOf(STEP_IDS.MACHINE_POOLS);
+
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.MACHINE_POOLS,
+        activeStepId: STEP_IDS.ROLES_AND_POLICIES,
+        visitedStepIds: new Set(ORDERED),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+        earliestInvalidStepIdx: machinePoolsIdx,
+      })
+    ).toBe(false);
+  });
+
+  it('disables the Additional setup parent when every child step is blocked', () => {
+    const detailsIdx = ORDERED.indexOf(STEP_IDS.DETAILS);
+
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.OPTIONAL_SETUP,
+        activeStepId: STEP_IDS.ROLES_AND_POLICIES,
+        visitedStepIds: new Set(ORDERED),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+        earliestInvalidStepIdx: detailsIdx,
+        childStepIdsByParent: optionalSetupChildStepIdsByParent,
+      })
+    ).toBe(true);
+  });
+
+  it('enables the Additional setup parent when the invalid child step itself is reachable', () => {
+    const encryptionIdx = ORDERED.indexOf(STEP_IDS.ENCRYPTION);
+
+    expect(
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: STEP_IDS.OPTIONAL_SETUP,
+        activeStepId: STEP_IDS.ROLES_AND_POLICIES,
+        visitedStepIds: new Set(ORDERED),
+        blockForwardNavigation: false,
+        orderedStepIds: ORDERED,
+        earliestInvalidStepIdx: encryptionIdx,
+        childStepIdsByParent: optionalSetupChildStepIdsByParent,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('findEarliestOrderedStepIndexWithValidationIssues', () => {
+  const machinePoolsSection = {
+    id: STEP_IDS.MACHINE_POOLS,
+    fieldPaths: ['min_replicas', 'max_replicas', 'machine_type'],
+  };
+
+  const mockGetFieldState = (
+    impl: Record<string, { invalid?: boolean }>
+  ): UseFormGetFieldState<Record<string, unknown>> =>
+    jest.fn((path: string) => ({
+      invalid: impl[path]?.invalid ?? false,
+      isDirty: false,
+      isTouched: false,
+      isValidating: false,
+      error: undefined,
+    })) as unknown as UseFormGetFieldState<Record<string, unknown>>;
+
+  it('returns the index of the earliest step with field validation errors', async () => {
+    const { findEarliestOrderedStepIndexWithValidationIssues } = await import('./rosaHcpWizardNav');
+
+    expect(
+      findEarliestOrderedStepIndexWithValidationIssues({
+        reviewSections: [machinePoolsSection],
+        orderedStepIds: ORDERED,
+        getFieldState: mockGetFieldState({ max_replicas: { invalid: true } }),
+        errors: {},
+      })
+    ).toBe(ORDERED.indexOf(STEP_IDS.MACHINE_POOLS));
+  });
+
+  it('returns -1 when no step has validation errors', async () => {
+    const { findEarliestOrderedStepIndexWithValidationIssues } = await import('./rosaHcpWizardNav');
+
+    expect(
+      findEarliestOrderedStepIndexWithValidationIssues({
+        reviewSections: [machinePoolsSection],
+        orderedStepIds: ORDERED,
+        getFieldState: mockGetFieldState({}),
+        errors: {},
+      })
+    ).toBe(-1);
+  });
+});
+
+describe('trimVisitedStepIdsAfter', () => {
+  it('removes leaf steps after the active step but keeps parent step ids', async () => {
+    const { trimVisitedStepIdsAfter } = await import('./rosaHcpWizardNav');
+    const visited = new Set([
+      STEP_IDS.DETAILS,
+      STEP_IDS.ROLES_AND_POLICIES,
+      STEP_IDS.MACHINE_POOLS,
+      STEP_IDS.NETWORKING,
+      STEP_IDS.ENCRYPTION,
+      STEP_IDS.REVIEW,
+      STEP_IDS.BASIC_SETUP,
+    ]);
+
+    expect(trimVisitedStepIdsAfter(visited, STEP_IDS.DETAILS, ORDERED)).toEqual(
+      new Set([STEP_IDS.DETAILS, STEP_IDS.BASIC_SETUP])
+    );
+  });
+
+  it('keeps steps up to and including the active step when trimming mid-wizard', async () => {
+    const { trimVisitedStepIdsAfter } = await import('./rosaHcpWizardNav');
+    const visited = new Set([
+      STEP_IDS.DETAILS,
+      STEP_IDS.ROLES_AND_POLICIES,
+      STEP_IDS.MACHINE_POOLS,
+      STEP_IDS.NETWORKING,
+      STEP_IDS.REVIEW,
+    ]);
+
+    expect(trimVisitedStepIdsAfter(visited, STEP_IDS.ROLES_AND_POLICIES, ORDERED)).toEqual(
+      new Set([STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES])
+    );
+  });
+});
+
+describe('rosaHcpWizardBlockForwardNavigation', () => {
+  const detailsBaseline = {
+    name: 'my-cluster',
+    billing_account_id: 'billing-a',
+    region: 'us-east-1',
+    cluster_version: '4.14.0',
+    associated_aws_id: 'aws-1',
+  };
+
+  const mockGetFieldState = (
+    impl: Record<
+      string,
+      { isDirty?: boolean; isTouched?: boolean; invalid?: boolean; isValidating?: boolean }
+    >
+  ): UseFormGetFieldState<Record<string, unknown>> =>
+    jest.fn((path: string) => ({
+      invalid: impl[path]?.invalid ?? false,
+      isDirty: impl[path]?.isDirty ?? false,
+      isTouched: impl[path]?.isTouched ?? false,
+      isValidating: impl[path]?.isValidating ?? false,
+      error: undefined,
+    })) as unknown as UseFormGetFieldState<Record<string, unknown>>;
+
+  it('does not block when the user only changes billing on a revisited details step', async () => {
+    const { rosaHcpWizardBlockForwardNavigation } = await import('./rosaHcpWizardNav');
+    const { clusterValidationSchema } = await import('./yupSchemas');
+    const detailsFieldPaths = Object.keys(detailsBaseline);
+    const getValues = jest.fn((path: string) => {
+      if (path === 'billing_account_id') return 'billing-b';
+      return detailsBaseline[path as keyof typeof detailsBaseline];
+    }) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardBlockForwardNavigation({
+        activeStepFieldPaths: detailsFieldPaths,
+        getValues,
+        getFieldState: mockGetFieldState({
+          billing_account_id: { isDirty: true, isTouched: true },
+        }),
+        errors: {},
+        schema: clusterValidationSchema,
+        describeOptions: undefined,
+        stepDependencyBaseline: detailsBaseline,
+      })
+    ).toBe(false);
+  });
+
+  it('blocks when the user changes a reset-source field on the active step', async () => {
+    const { rosaHcpWizardBlockForwardNavigation } = await import('./rosaHcpWizardNav');
+    const { clusterValidationSchema } = await import('./yupSchemas');
+    const getValues = jest.fn((path: string) =>
+      path === 'region' ? 'us-west-2' : detailsBaseline[path as keyof typeof detailsBaseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardBlockForwardNavigation({
+        activeStepFieldPaths: Object.keys(detailsBaseline),
+        getValues,
+        getFieldState: mockGetFieldState({
+          region: { isDirty: true, isTouched: true },
+        }),
+        errors: {},
+        schema: clusterValidationSchema,
+        describeOptions: undefined,
+        stepDependencyBaseline: detailsBaseline,
+      })
+    ).toBe(true);
+  });
+
+  it('blocks when async cluster name validation is in progress on an engaged field', async () => {
+    const { rosaHcpWizardBlockForwardNavigation } = await import('./rosaHcpWizardNav');
+    const { clusterValidationSchema } = await import('./yupSchemas');
+    const getValues = jest.fn((path: string) =>
+      path === 'name' ? 'new-cluster' : detailsBaseline[path as keyof typeof detailsBaseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardBlockForwardNavigation({
+        activeStepFieldPaths: Object.keys(detailsBaseline),
+        getValues,
+        getFieldState: mockGetFieldState({
+          name: { isDirty: true, isTouched: true, isValidating: true },
+        }),
+        errors: {},
+        schema: clusterValidationSchema,
+        describeOptions: undefined,
+        stepDependencyBaseline: detailsBaseline,
+      })
+    ).toBe(true);
+  });
+});
+
+describe('rosaHcpWizardAsyncValidationInProgress', () => {
+  const detailsBaseline = {
+    name: 'my-cluster',
+    billing_account_id: 'billing-a',
+    region: 'us-east-1',
+  };
+
+  const mockGetFieldState = (
+    impl: Record<string, { isDirty?: boolean; isTouched?: boolean; isValidating?: boolean }>
+  ): UseFormGetFieldState<Record<string, unknown>> =>
+    jest.fn((path: string) => ({
+      invalid: false,
+      isDirty: impl[path]?.isDirty ?? false,
+      isTouched: impl[path]?.isTouched ?? false,
+      isValidating: impl[path]?.isValidating ?? false,
+      error: undefined,
+    })) as unknown as UseFormGetFieldState<Record<string, unknown>>;
+
+  it('returns false when name is validating but not on the active step', async () => {
+    const { rosaHcpWizardAsyncValidationInProgress } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'name' ? 'new-cluster' : detailsBaseline[path as keyof typeof detailsBaseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardAsyncValidationInProgress(
+        ['billing_account_id', 'region'],
+        mockGetFieldState({ name: { isDirty: true, isTouched: true, isValidating: true } }),
+        getValues,
+        detailsBaseline
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when name is validating but the user has not engaged the field since step entry', async () => {
+    const { rosaHcpWizardAsyncValidationInProgress } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn(
+      (path: string) => detailsBaseline[path as keyof typeof detailsBaseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardAsyncValidationInProgress(
+        ['name', 'billing_account_id', 'region'],
+        mockGetFieldState({ name: { isValidating: true } }),
+        getValues,
+        detailsBaseline
+      )
+    ).toBe(false);
+  });
+
+  it('returns true when name is validating and the user engaged the field since step entry', async () => {
+    const { rosaHcpWizardAsyncValidationInProgress } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'name' ? 'new-cluster' : detailsBaseline[path as keyof typeof detailsBaseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardAsyncValidationInProgress(
+        ['name', 'billing_account_id', 'region'],
+        mockGetFieldState({ name: { isDirty: true, isTouched: true, isValidating: true } }),
+        getValues,
+        detailsBaseline
+      )
+    ).toBe(true);
+  });
+
+  it('returns true when async validation is tracked outside RHF isValidating', async () => {
+    const { rosaHcpWizardAsyncValidationInProgress } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'name' ? 'new-cluster' : detailsBaseline[path as keyof typeof detailsBaseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardAsyncValidationInProgress(
+        ['name', 'billing_account_id', 'region'],
+        mockGetFieldState({ name: { isDirty: true, isTouched: true } }),
+        getValues,
+        detailsBaseline,
+        new Set(['name'])
+      )
+    ).toBe(true);
+  });
+});
+
+describe('rosaHcpWizardActiveStepHasValidationIssues', () => {
+  const baseline = {
+    name: 'my-cluster',
+    billing_account_id: 'billing-a',
+    region: 'us-east-1',
+  };
+
+  const mockGetFieldState = (
+    impl: Record<string, { isDirty?: boolean; isTouched?: boolean; invalid?: boolean }>
+  ): UseFormGetFieldState<Record<string, unknown>> =>
+    jest.fn((path: string) => ({
+      invalid: impl[path]?.invalid ?? false,
+      isDirty: impl[path]?.isDirty ?? false,
+      isTouched: impl[path]?.isTouched ?? false,
+      isValidating: false,
+      error: undefined,
+    })) as unknown as UseFormGetFieldState<Record<string, unknown>>;
+
+  it('does not block when an untouched field is invalid but the user only changed billing', async () => {
+    const { rosaHcpWizardActiveStepHasValidationIssues } = await import('./rosaHcpWizardNav');
+    const { clusterValidationSchema } = await import('./yupSchemas');
+    const getValues = jest.fn((path: string) => {
+      if (path === 'billing_account_id') return 'billing-b';
+      if (path === 'name') return 'my-cluster';
+      return baseline[path as keyof typeof baseline];
+    }) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardActiveStepHasValidationIssues(
+        ['name', 'billing_account_id', 'region'],
+        getValues,
+        mockGetFieldState({
+          name: { invalid: true, isDirty: true, isTouched: true },
+          billing_account_id: { isDirty: true, isTouched: true },
+        }),
+        {},
+        clusterValidationSchema,
+        undefined,
+        baseline
+      )
+    ).toBe(false);
+  });
+
+  it('blocks when the user clears a required field they engaged since step entry', async () => {
+    const { rosaHcpWizardActiveStepHasValidationIssues } = await import('./rosaHcpWizardNav');
+    const { clusterValidationSchema } = await import('./yupSchemas');
+    const getValues = jest.fn((path: string) =>
+      path === 'name' ? '' : baseline[path as keyof typeof baseline]
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardActiveStepHasValidationIssues(
+        ['name', 'billing_account_id', 'region'],
+        getValues,
+        mockGetFieldState({ name: { isDirty: true, isTouched: true } }),
+        {},
+        clusterValidationSchema,
+        undefined,
+        baseline
+      )
+    ).toBe(true);
+  });
+});
+
+describe('rosaHcpWizardResetSourceValuesChanged', () => {
+  const mockGetFieldState = (
+    impl: Record<string, { isDirty?: boolean; isTouched?: boolean }>
+  ): UseFormGetFieldState<Record<string, unknown>> =>
+    jest.fn((path: string) => ({
+      invalid: false,
+      isDirty: impl[path]?.isDirty ?? false,
+      isTouched: impl[path]?.isTouched ?? false,
+      isValidating: false,
+      error: undefined,
+    })) as unknown as UseFormGetFieldState<Record<string, unknown>>;
+
+  it('returns false when values match the step-entry baseline', async () => {
+    const { rosaHcpWizardResetSourceValuesChanged } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'region' ? 'us-east-1' : 'cluster'
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardResetSourceValuesChanged(['region', 'name'], getValues, mockGetFieldState({}), {
+        region: 'us-east-1',
+        name: 'cluster',
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when a reset-source value changed programmatically without user engagement', async () => {
+    const { rosaHcpWizardResetSourceValuesChanged } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'region' ? 'us-west-2' : 'cluster'
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardResetSourceValuesChanged(['region', 'name'], getValues, mockGetFieldState({}), {
+        region: 'us-east-1',
+        name: 'cluster',
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when the user changed a field without resetsFieldsToDefaultOnChange meta', async () => {
+    const { rosaHcpWizardResetSourceValuesChanged } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'name' ? 'new-cluster' : 'us-east-1'
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardResetSourceValuesChanged(
+        ['region', 'name'],
+        getValues,
+        mockGetFieldState({ name: { isDirty: true } }),
+        { region: 'us-east-1', name: 'old-cluster' }
+      )
+    ).toBe(false);
+  });
+
+  it('returns true when the user changed a reset-source field since step entry', async () => {
+    const { rosaHcpWizardResetSourceValuesChanged } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'region' ? 'us-west-2' : 'cluster'
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardResetSourceValuesChanged(
+        ['region', 'name'],
+        getValues,
+        mockGetFieldState({ region: { isDirty: true } }),
+        { region: 'us-east-1', name: 'cluster' }
+      )
+    ).toBe(true);
+  });
+
+  it('stays true when a latched reset-source field is restored to its step-entry value', async () => {
+    const { rosaHcpWizardResetSourceValuesChanged } = await import('./rosaHcpWizardNav');
+    const getValues = jest.fn((path: string) =>
+      path === 'region' ? 'us-east-1' : 'cluster'
+    ) as unknown as UseFormGetValues<Record<string, unknown>>;
+
+    expect(
+      rosaHcpWizardResetSourceValuesChanged(
+        ['region', 'name'],
+        getValues,
+        mockGetFieldState({ region: { isDirty: true, isTouched: true } }),
+        { region: 'us-east-1', name: 'cluster' },
+        new Set(['region'])
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNav.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNav.ts
@@ -1,0 +1,362 @@
+import type {
+  FieldErrors,
+  FieldPath,
+  FieldValues,
+  UseFormGetFieldState,
+  UseFormGetValues,
+} from 'react-hook-form';
+import type * as yup from 'yup';
+
+import { wizardFormFieldValuesEqual } from './fieldMetaChangeEffects/wizardFormFieldValuesEqual';
+import { isYupFieldRequired, type YupFieldDescribeOptions } from './utilities/yupFieldRequired';
+
+import { STEP_IDS } from './constants';
+import { buildRosaHcpWizardStepLayout } from './rosaHcpWizardStepLayout';
+import { pathsHaveValidationIssues } from './Footer/rosaHcpWizardFooter.utils';
+import {
+  ROSA_HCP_ASYNC_VALIDATED_FIELD_PATHS,
+  ROSA_HCP_NAV_RESET_SOURCE_FIELDS,
+} from './rosaHcpWizardNavDependencies';
+
+export type RosaHcpWizardNavReviewSection = {
+  id: string;
+  fieldPaths: readonly string[];
+};
+
+/** Leaf wizard steps in nav order (excludes expandable parent steps). */
+export function buildOrderedNavigableStepIds(includeClusterWideProxy: boolean): readonly string[] {
+  return buildRosaHcpWizardStepLayout({ includeClusterWideProxy }).orderedNavigableStepIds;
+}
+
+/** Next leaf step id after `activeStepId`, used by the footer Next control. */
+export function getNextOrderedStepId(
+  activeStepId: string,
+  orderedStepIds: readonly string[]
+): string | undefined {
+  const activeIdx = stepOrderIndex(activeStepId, orderedStepIds);
+  if (activeIdx === -1 || activeIdx >= orderedStepIds.length - 1) {
+    return undefined;
+  }
+  return orderedStepIds[activeIdx + 1];
+}
+
+function stepOrderIndex(stepId: string, orderedStepIds: readonly string[]): number {
+  return orderedStepIds.indexOf(stepId);
+}
+
+function isEmptyFormValue(value: unknown): boolean {
+  if (value === undefined || value === null) {
+    return true;
+  }
+  if (typeof value === 'string') {
+    return value.trim() === '';
+  }
+  if (Array.isArray(value)) {
+    return value.length === 0;
+  }
+  return false;
+}
+
+function formValuesEqual(left: unknown, right: unknown): boolean {
+  return wizardFormFieldValuesEqual(left, right);
+}
+
+/** Snapshot active-step field values when entering a step. */
+export function captureRosaHcpStepFieldValueBaseline<TFieldValues extends FieldValues>(
+  activeStepFieldPaths: readonly string[],
+  getValues: UseFormGetValues<TFieldValues>
+): Record<string, unknown> {
+  const baseline: Record<string, unknown> = {};
+
+  for (const path of activeStepFieldPaths) {
+    baseline[path] = getValues(path as FieldPath<TFieldValues>);
+  }
+
+  return baseline;
+}
+
+/** True when the user edited this field on the active step since entry. */
+export function isRosaHcpWizardFieldEngagedSinceStepEntry<TFieldValues extends FieldValues>(
+  path: string,
+  getValues: UseFormGetValues<TFieldValues>,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  baselineValues: Readonly<Record<string, unknown>> | undefined
+): boolean {
+  if (baselineValues === undefined) {
+    return false;
+  }
+
+  const fieldPath = path as FieldPath<TFieldValues>;
+  if (formValuesEqual(getValues(fieldPath), baselineValues[path])) {
+    return false;
+  }
+
+  const fieldState = getFieldState(fieldPath);
+  return fieldState.isDirty || fieldState.isTouched;
+}
+
+/** True when the user changed a reset-source field on the active step since entry. */
+export function rosaHcpWizardResetSourceValuesChanged<TFieldValues extends FieldValues>(
+  activeStepFieldPaths: readonly string[],
+  getValues: UseFormGetValues<TFieldValues>,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  baselineValues: Readonly<Record<string, unknown>> | undefined,
+  latchedResetSourceFields?: ReadonlySet<string>
+): boolean {
+  const activePaths = new Set(activeStepFieldPaths);
+  return ROSA_HCP_NAV_RESET_SOURCE_FIELDS.some((path) => {
+    if (!activePaths.has(path)) {
+      return false;
+    }
+    if (latchedResetSourceFields?.has(path)) {
+      return true;
+    }
+    return isRosaHcpWizardFieldEngagedSinceStepEntry(
+      path,
+      getValues,
+      getFieldState,
+      baselineValues
+    );
+  });
+}
+
+/** Records reset-source fields the user has edited this visit; stays latched if the value is reverted. */
+export function latchEngagedRosaHcpResetSourceFields<TFieldValues extends FieldValues>(
+  activeStepFieldPaths: readonly string[],
+  getValues: UseFormGetValues<TFieldValues>,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  baselineValues: Readonly<Record<string, unknown>> | undefined,
+  latchedResetSourceFields: Set<string>
+): void {
+  const activePaths = new Set(activeStepFieldPaths);
+  for (const path of ROSA_HCP_NAV_RESET_SOURCE_FIELDS) {
+    if (!activePaths.has(path)) {
+      continue;
+    }
+    if (isRosaHcpWizardFieldEngagedSinceStepEntry(path, getValues, getFieldState, baselineValues)) {
+      latchedResetSourceFields.add(path);
+    }
+  }
+}
+
+/** True when async field validation is running on a field the user engaged since step entry. */
+export function rosaHcpWizardAsyncValidationInProgress<TFieldValues extends FieldValues>(
+  activeStepFieldPaths: readonly string[],
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  getValues: UseFormGetValues<TFieldValues>,
+  baselineValues: Readonly<Record<string, unknown>> | undefined,
+  asyncValidatingFieldPaths?: ReadonlySet<string>
+): boolean {
+  const activePaths = new Set(activeStepFieldPaths);
+  return ROSA_HCP_ASYNC_VALIDATED_FIELD_PATHS.some((path) => {
+    if (!activePaths.has(path)) {
+      return false;
+    }
+    if (
+      !isRosaHcpWizardFieldEngagedSinceStepEntry(path, getValues, getFieldState, baselineValues)
+    ) {
+      return false;
+    }
+    return (
+      getFieldState(path as FieldPath<TFieldValues>).isValidating ||
+      asyncValidatingFieldPaths?.has(path) === true
+    );
+  });
+}
+
+/** Invalid or empty required values on fields the user engaged since step entry. */
+export function rosaHcpWizardActiveStepHasValidationIssues<TFieldValues extends FieldValues>(
+  activeStepFieldPaths: readonly string[],
+  getValues: UseFormGetValues<TFieldValues>,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  errors: FieldErrors<TFieldValues>,
+  schema: yup.AnyObjectSchema,
+  describeOptions: YupFieldDescribeOptions | undefined,
+  baselineValues: Readonly<Record<string, unknown>> | undefined
+): boolean {
+  const engagedFieldPaths = activeStepFieldPaths.filter((path) =>
+    isRosaHcpWizardFieldEngagedSinceStepEntry(path, getValues, getFieldState, baselineValues)
+  );
+
+  if (engagedFieldPaths.length === 0) {
+    return false;
+  }
+
+  if (
+    pathsHaveValidationIssues(engagedFieldPaths, getFieldState, errors, {
+      ignoreResolverErrors: true,
+    })
+  ) {
+    return true;
+  }
+
+  return engagedFieldPaths.some((path) => {
+    if (!isYupFieldRequired(schema, path, describeOptions)) {
+      return false;
+    }
+    return isEmptyFormValue(getValues(path as FieldPath<TFieldValues>));
+  });
+}
+
+export function rosaHcpWizardBlockForwardNavigation<TFieldValues extends FieldValues>(params: {
+  activeStepFieldPaths: readonly string[];
+  getValues: UseFormGetValues<TFieldValues>;
+  getFieldState: UseFormGetFieldState<TFieldValues>;
+  errors: FieldErrors<TFieldValues>;
+  schema: yup.AnyObjectSchema;
+  describeOptions?: YupFieldDescribeOptions;
+  stepDependencyBaseline?: Readonly<Record<string, unknown>>;
+  latchedResetSourceFields?: ReadonlySet<string>;
+  asyncValidatingFieldPaths?: ReadonlySet<string>;
+}): boolean {
+  const {
+    activeStepFieldPaths,
+    getValues,
+    getFieldState,
+    errors,
+    schema,
+    describeOptions,
+    stepDependencyBaseline,
+    latchedResetSourceFields,
+    asyncValidatingFieldPaths,
+  } = params;
+
+  return (
+    rosaHcpWizardResetSourceValuesChanged(
+      activeStepFieldPaths,
+      getValues,
+      getFieldState,
+      stepDependencyBaseline,
+      latchedResetSourceFields
+    ) ||
+    rosaHcpWizardActiveStepHasValidationIssues(
+      activeStepFieldPaths,
+      getValues,
+      getFieldState,
+      errors,
+      schema,
+      describeOptions,
+      stepDependencyBaseline
+    ) ||
+    rosaHcpWizardAsyncValidationInProgress(
+      activeStepFieldPaths,
+      getFieldState,
+      getValues,
+      stepDependencyBaseline,
+      asyncValidatingFieldPaths
+    )
+  );
+}
+
+/** Removes leaf steps after `activeStepId` from the visited set (parent step ids are kept). */
+export function trimVisitedStepIdsAfter(
+  visitedStepIds: ReadonlySet<string>,
+  activeStepId: string,
+  orderedStepIds: readonly string[]
+): Set<string> {
+  const activeIdx = stepOrderIndex(activeStepId, orderedStepIds);
+  if (activeIdx === -1) {
+    return new Set(visitedStepIds);
+  }
+
+  const next = new Set<string>();
+  for (const stepId of visitedStepIds) {
+    const stepIdx = stepOrderIndex(stepId, orderedStepIds);
+    if (stepIdx === -1 || stepIdx <= activeIdx) {
+      next.add(stepId);
+    }
+  }
+  next.add(activeStepId);
+  return next;
+}
+
+/** Index in `orderedStepIds` of the earliest step with a validation error, or -1 when none. */
+export function findEarliestOrderedStepIndexWithValidationIssues<
+  TFieldValues extends FieldValues,
+>(params: {
+  reviewSections: readonly RosaHcpWizardNavReviewSection[];
+  orderedStepIds: readonly string[];
+  getFieldState: UseFormGetFieldState<TFieldValues>;
+  errors: FieldErrors<TFieldValues>;
+}): number {
+  const { reviewSections, orderedStepIds, getFieldState, errors } = params;
+
+  for (let index = 0; index < orderedStepIds.length; index++) {
+    const stepId = orderedStepIds[index];
+    const fieldPaths = reviewSections.find((section) => section.id === stepId)?.fieldPaths ?? [];
+    if (fieldPaths.length === 0) {
+      continue;
+    }
+    if (pathsHaveValidationIssues(fieldPaths, getFieldState, errors)) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+export function isRosaHcpWizardNavStepDisabled(params: {
+  targetStepId: string;
+  activeStepId: string;
+  visitedStepIds: ReadonlySet<string>;
+  blockForwardNavigation: boolean;
+  orderedStepIds: readonly string[];
+  earliestInvalidStepIdx?: number;
+  childStepIdsByParent?: Readonly<Record<string, readonly string[] | undefined>>;
+}): boolean {
+  const {
+    targetStepId,
+    activeStepId,
+    visitedStepIds,
+    blockForwardNavigation,
+    orderedStepIds,
+    earliestInvalidStepIdx = -1,
+    childStepIdsByParent,
+  } = params;
+
+  if (targetStepId === STEP_IDS.BASIC_SETUP) {
+    return false;
+  }
+
+  if (targetStepId === STEP_IDS.OPTIONAL_SETUP) {
+    const childStepIds = childStepIdsByParent?.[STEP_IDS.OPTIONAL_SETUP] ?? [];
+    if (childStepIds.length === 0) {
+      return true;
+    }
+    return childStepIds.every((childId) =>
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: childId,
+        activeStepId,
+        visitedStepIds,
+        blockForwardNavigation,
+        orderedStepIds,
+        earliestInvalidStepIdx,
+      })
+    );
+  }
+
+  const activeIdx = stepOrderIndex(activeStepId, orderedStepIds);
+  const targetIdx = stepOrderIndex(targetStepId, orderedStepIds);
+
+  if (activeIdx === -1 || targetIdx === -1) {
+    return false;
+  }
+
+  if (targetIdx < activeIdx) {
+    return false;
+  }
+
+  if (targetIdx === activeIdx) {
+    return false;
+  }
+
+  if (earliestInvalidStepIdx !== -1 && targetIdx > earliestInvalidStepIdx) {
+    return true;
+  }
+
+  if (!visitedStepIds.has(targetStepId)) {
+    return true;
+  }
+
+  return blockForwardNavigation;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNavDependencies.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNavDependencies.ts
@@ -1,0 +1,11 @@
+import { listWizardFieldResetEntries } from './yupSchemas/wizardFieldMetaChangeRegistry';
+
+/**
+ * Form fields with Yup `resetsFieldsToDefaultOnChange`. Changing one of these on the active step
+ * (with user engagement) blocks forward nav to visited steps.
+ */
+export const ROSA_HCP_NAV_RESET_SOURCE_FIELDS: readonly string[] =
+  listWizardFieldResetEntries().map((entry) => entry.sourceField);
+
+/** Fields that run async Yup tests; forward nav is blocked while validation is in flight. */
+export const ROSA_HCP_ASYNC_VALIDATED_FIELD_PATHS: readonly string[] = ['name'];

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepHierarchy.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepHierarchy.ts
@@ -1,0 +1,66 @@
+import type { FieldErrors, FieldValues, UseFormGetFieldState } from 'react-hook-form';
+
+import type { ROSAHCPCluster } from './types';
+import {
+  pathsHaveRevealedValidationIssues,
+  type PathsHaveRevealedValidationIssuesOptions,
+} from './Footer/rosaHcpWizardFooter.utils';
+import { shouldHideReviewRow } from './Steps/Review/shouldHideReviewRow';
+import { wizardFieldMetaByPath } from './yupSchemas';
+
+import type { RosaHcpWizardChildStepIdsByParent } from './rosaHcpWizardStepLayout';
+
+export type { RosaHcpWizardChildStepIdsByParent } from './rosaHcpWizardStepLayout';
+
+export type RosaHcpWizardStepFieldPathsSource = Readonly<
+  Array<{ id: string; fieldPaths: readonly string[] }>
+>;
+
+/** Whether a field participates in step nav validation for the current form state. */
+export function isWizardFieldActiveForStepValidation(
+  path: string,
+  formValues: Partial<ROSAHCPCluster>
+): boolean {
+  return !shouldHideReviewRow({
+    path,
+    formValues,
+    metaShouldHideInReview: wizardFieldMetaByPath(path)?.hideInReview ?? false,
+  });
+}
+
+function stepIdsToCheckForNavStatus(
+  stepId: string,
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent
+): readonly string[] {
+  const childStepIds = childStepIdsByParent?.[stepId];
+  return childStepIds && childStepIds.length > 0 ? childStepIds : [stepId];
+}
+
+/** Whether the step or any of its nav children has revealed validation errors. */
+export function stepOrChildHasValidationError(
+  stepId: string,
+  validationAttemptedStepIds: ReadonlySet<string>,
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent
+): boolean {
+  return stepIdsToCheckForNavStatus(stepId, childStepIdsByParent).some((id) =>
+    validationAttemptedStepIds.has(id)
+  );
+}
+
+/** Whether the step or any nav child has a user-visible validation error. */
+export function stepOrChildHasFormValidationIssues<TFieldValues extends FieldValues>(
+  stepId: string,
+  reviewSections: RosaHcpWizardStepFieldPathsSource,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  errors: FieldErrors<TFieldValues>,
+  options: PathsHaveRevealedValidationIssuesOptions = {},
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent
+): boolean {
+  return stepIdsToCheckForNavStatus(stepId, childStepIdsByParent).some((id) => {
+    const fieldPaths = reviewSections.find((section) => section.id === id)?.fieldPaths ?? [];
+    return (
+      fieldPaths.length > 0 &&
+      pathsHaveRevealedValidationIssues(fieldPaths, getFieldState, errors, options)
+    );
+  });
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepLayout.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepLayout.test.ts
@@ -1,0 +1,42 @@
+import { STEP_IDS } from './constants';
+import { buildRosaHcpWizardStepLayout, ROSA_HCP_LEAF_STEP_DEFS } from './rosaHcpWizardStepLayout';
+import { getFieldPathsByStepId } from './yupSchemas/wizardFieldMetaChangeRegistry';
+
+describe('buildRosaHcpWizardStepLayout', () => {
+  it('orders basic setup children from ROSA_HCP_LEAF_STEP_DEFS when proxy is excluded', () => {
+    const layout = buildRosaHcpWizardStepLayout({ includeClusterWideProxy: false });
+
+    expect(layout.childStepIdsByParent[STEP_IDS.BASIC_SETUP]).toEqual([
+      STEP_IDS.DETAILS,
+      STEP_IDS.ROLES_AND_POLICIES,
+      STEP_IDS.MACHINE_POOLS,
+      STEP_IDS.NETWORKING,
+    ]);
+    expect(layout.childStepIdsByParent[STEP_IDS.OPTIONAL_SETUP]).toEqual([
+      STEP_IDS.ENCRYPTION,
+      STEP_IDS.CLUSTER_UPDATES,
+    ]);
+    expect(layout.orderedNavigableStepIds.at(-1)).toBe(STEP_IDS.REVIEW);
+    expect(layout.orderedNavigableStepIds).not.toContain(STEP_IDS.CLUSTER_WIDE_PROXY);
+  });
+
+  it('includes cluster-wide proxy when requested', () => {
+    const layout = buildRosaHcpWizardStepLayout({ includeClusterWideProxy: true });
+
+    expect(layout.childStepIdsByParent[STEP_IDS.BASIC_SETUP]).toContain(
+      STEP_IDS.CLUSTER_WIDE_PROXY
+    );
+    expect(layout.orderedNavigableStepIds).toContain(STEP_IDS.CLUSTER_WIDE_PROXY);
+  });
+
+  it('defines a leaf step for every Yup stepId registry bucket except review', () => {
+    const fieldPathsByStepId = getFieldPathsByStepId();
+    const layoutStepIds = new Set(
+      ROSA_HCP_LEAF_STEP_DEFS.map((step) => step.id).filter((id) => id !== STEP_IDS.REVIEW)
+    );
+
+    for (const stepId of Object.keys(fieldPathsByStepId)) {
+      expect(layoutStepIds.has(stepId)).toBe(true);
+    }
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepLayout.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepLayout.ts
@@ -1,0 +1,106 @@
+import { STEP_IDS } from './constants';
+
+/** Keys on {@link RosaHcpWizardReviewStepLabels} — one entry per leaf wizard step. */
+export type RosaHcpWizardLeafStepLabelKey =
+  | 'details'
+  | 'rolesAndPolicies'
+  | 'machinePools'
+  | 'networking'
+  | 'clusterWideProxy'
+  | 'encryptionOptional'
+  | 'clusterUpdatesOptional';
+
+const ROSA_HCP_EXPANDABLE_PARENT_STEP_IDS = [
+  STEP_IDS.BASIC_SETUP,
+  STEP_IDS.OPTIONAL_SETUP,
+] as const;
+
+export type RosaHcpWizardExpandableParentStepId =
+  (typeof ROSA_HCP_EXPANDABLE_PARENT_STEP_IDS)[number];
+
+export type RosaHcpWizardLeafStepDef = {
+  id: string;
+  parentId: RosaHcpWizardExpandableParentStepId;
+  labelKey: RosaHcpWizardLeafStepLabelKey;
+  /** Omitted from nav/review when `includeClusterWideProxy` is false. */
+  requiresClusterWideProxy?: boolean;
+  hideInReviewIfUnchanged?: boolean;
+};
+
+/**
+ * Leaf wizard steps in nav order. Parent grouping and optional proxy gating are derived here;
+ * field paths per step come from Yup `.meta({ stepId })` via {@link getFieldPathsByStepId}.
+ *
+ * Keep {@link ROSAHCPWizardBody} JSX in sync when adding or reordering steps.
+ */
+export const ROSA_HCP_LEAF_STEP_DEFS: readonly RosaHcpWizardLeafStepDef[] = [
+  { id: STEP_IDS.DETAILS, parentId: STEP_IDS.BASIC_SETUP, labelKey: 'details' },
+  { id: STEP_IDS.ROLES_AND_POLICIES, parentId: STEP_IDS.BASIC_SETUP, labelKey: 'rolesAndPolicies' },
+  { id: STEP_IDS.MACHINE_POOLS, parentId: STEP_IDS.BASIC_SETUP, labelKey: 'machinePools' },
+  { id: STEP_IDS.NETWORKING, parentId: STEP_IDS.BASIC_SETUP, labelKey: 'networking' },
+  {
+    id: STEP_IDS.CLUSTER_WIDE_PROXY,
+    parentId: STEP_IDS.BASIC_SETUP,
+    labelKey: 'clusterWideProxy',
+    requiresClusterWideProxy: true,
+    hideInReviewIfUnchanged: true,
+  },
+  { id: STEP_IDS.ENCRYPTION, parentId: STEP_IDS.OPTIONAL_SETUP, labelKey: 'encryptionOptional' },
+  {
+    id: STEP_IDS.CLUSTER_UPDATES,
+    parentId: STEP_IDS.OPTIONAL_SETUP,
+    labelKey: 'clusterUpdatesOptional',
+  },
+];
+
+export type RosaHcpWizardChildStepIdsByParent = Readonly<
+  Record<string, readonly string[] | undefined>
+>;
+
+export type RosaHcpWizardStepLayoutOptions = {
+  includeClusterWideProxy: boolean;
+};
+
+export type RosaHcpWizardStepLayout = {
+  leafSteps: readonly RosaHcpWizardLeafStepDef[];
+  leafStepIds: readonly string[];
+  childStepIdsByParent: RosaHcpWizardChildStepIdsByParent;
+  orderedNavigableStepIds: readonly string[];
+};
+
+function groupChildStepIdsByParent(
+  leafSteps: readonly RosaHcpWizardLeafStepDef[]
+): RosaHcpWizardChildStepIdsByParent {
+  const basicSetup: string[] = [];
+  const optionalSetup: string[] = [];
+
+  for (const step of leafSteps) {
+    if (step.parentId === STEP_IDS.BASIC_SETUP) {
+      basicSetup.push(step.id);
+    } else {
+      optionalSetup.push(step.id);
+    }
+  }
+
+  return {
+    [STEP_IDS.BASIC_SETUP]: basicSetup,
+    [STEP_IDS.OPTIONAL_SETUP]: optionalSetup,
+  };
+}
+
+/** Derives nav child lists and leaf step order from {@link ROSA_HCP_LEAF_STEP_DEFS}. */
+export function buildRosaHcpWizardStepLayout(
+  options: RosaHcpWizardStepLayoutOptions
+): RosaHcpWizardStepLayout {
+  const leafSteps = ROSA_HCP_LEAF_STEP_DEFS.filter(
+    (step) => !step.requiresClusterWideProxy || options.includeClusterWideProxy
+  );
+  const leafStepIds = leafSteps.map((step) => step.id);
+
+  return {
+    leafSteps,
+    leafStepIds,
+    childStepIdsByParent: groupChildStepIdsByParent(leafSteps),
+    orderedNavigableStepIds: [...leafStepIds, STEP_IDS.REVIEW],
+  };
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepStatus.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardStepStatus.test.ts
@@ -1,0 +1,138 @@
+import type { FieldValues, UseFormGetFieldState } from 'react-hook-form';
+
+import { STEP_IDS } from './constants';
+import {
+  stepOrChildHasFormValidationIssues,
+  stepOrChildHasValidationError,
+  isWizardFieldActiveForStepValidation,
+} from './rosaHcpWizardStepHierarchy';
+import { getRosaHcpWizardStepStatus } from './rosaHcpWizardValidationContext';
+
+const childStepIdsByParent = {
+  [STEP_IDS.BASIC_SETUP]: [STEP_IDS.DETAILS, STEP_IDS.ROLES_AND_POLICIES],
+};
+
+describe('getRosaHcpWizardStepStatus', () => {
+  it('returns error when the step has validation errors revealed', () => {
+    expect(getRosaHcpWizardStepStatus(STEP_IDS.DETAILS, new Set([STEP_IDS.DETAILS]))).toBe('error');
+  });
+
+  it('returns default when the step has no revealed validation errors', () => {
+    expect(
+      getRosaHcpWizardStepStatus(STEP_IDS.DETAILS, new Set([STEP_IDS.ROLES_AND_POLICIES]))
+    ).toBe('default');
+    expect(getRosaHcpWizardStepStatus(STEP_IDS.DETAILS, new Set())).toBe('default');
+  });
+
+  it('returns error on a parent step when a child step has validation errors', () => {
+    expect(
+      getRosaHcpWizardStepStatus(
+        STEP_IDS.BASIC_SETUP,
+        new Set([STEP_IDS.DETAILS]),
+        childStepIdsByParent
+      )
+    ).toBe('error');
+  });
+
+  it('returns default on a parent step when no child has validation errors', () => {
+    expect(getRosaHcpWizardStepStatus(STEP_IDS.BASIC_SETUP, new Set(), childStepIdsByParent)).toBe(
+      'default'
+    );
+  });
+
+  it('returns error when the step has live form validation issues', () => {
+    expect(getRosaHcpWizardStepStatus(STEP_IDS.MACHINE_POOLS, new Set(), undefined, true)).toBe(
+      'error'
+    );
+  });
+
+  it('returns default when neither revealed nor live validation issues exist', () => {
+    expect(getRosaHcpWizardStepStatus(STEP_IDS.MACHINE_POOLS, new Set(), undefined, false)).toBe(
+      'default'
+    );
+  });
+});
+
+describe('stepOrChildHasValidationError', () => {
+  it('returns true for a parent when any listed child has errors', () => {
+    expect(
+      stepOrChildHasValidationError(
+        STEP_IDS.BASIC_SETUP,
+        new Set([STEP_IDS.DETAILS]),
+        childStepIdsByParent
+      )
+    ).toBe(true);
+  });
+});
+
+describe('stepOrChildHasFormValidationIssues', () => {
+  const machinePoolsSections = [
+    {
+      id: STEP_IDS.MACHINE_POOLS,
+      fieldPaths: ['min_replicas', 'max_replicas', 'nodes_compute'],
+    },
+  ] as const;
+
+  it('returns true when a visible step field is invalid and touched', () => {
+    const getFieldState = jest.fn((path: string) => ({
+      invalid: path === 'max_replicas',
+      isTouched: path === 'max_replicas',
+      isDirty: true,
+      isValidating: false,
+      error:
+        path === 'max_replicas'
+          ? { type: 'validate', message: 'Max nodes must be greater than or equal to min nodes.' }
+          : undefined,
+    })) as UseFormGetFieldState<FieldValues>;
+
+    expect(
+      stepOrChildHasFormValidationIssues(
+        STEP_IDS.MACHINE_POOLS,
+        machinePoolsSections,
+        getFieldState,
+        {},
+        { formValues: { autoscaling: true }, isFieldActive: isWizardFieldActiveForStepValidation }
+      )
+    ).toBe(true);
+  });
+
+  it('returns false when replica fields are invalid but autoscaling is disabled', () => {
+    const getFieldState = jest.fn((path: string) => ({
+      invalid: path === 'max_replicas' || path === 'min_replicas',
+      isTouched: true,
+      isDirty: true,
+      isValidating: false,
+      error: { type: 'validate', message: 'Max nodes must be greater than or equal to min nodes.' },
+    })) as UseFormGetFieldState<FieldValues>;
+
+    expect(
+      stepOrChildHasFormValidationIssues(
+        STEP_IDS.MACHINE_POOLS,
+        machinePoolsSections,
+        getFieldState,
+        {},
+        { formValues: { autoscaling: false }, isFieldActive: isWizardFieldActiveForStepValidation }
+      )
+    ).toBe(false);
+  });
+
+  it('returns false when invalid fields are untouched and validation was not attempted', () => {
+    const getFieldState = jest.fn(() => ({
+      invalid: true,
+      isTouched: false,
+      isDirty: false,
+      isValidating: false,
+      error: { type: 'required', message: 'Required' },
+    })) as UseFormGetFieldState<FieldValues>;
+
+    expect(
+      stepOrChildHasFormValidationIssues(
+        STEP_IDS.MACHINE_POOLS,
+        machinePoolsSections,
+        getFieldState,
+        { max_replicas: { type: 'required', message: 'Required' } },
+        { formValues: { autoscaling: true }, isFieldActive: isWizardFieldActiveForStepValidation }
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx
@@ -1,23 +1,91 @@
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { type FieldPath, useFormContext, useFormState, useWatch } from 'react-hook-form';
+
+import type { ROSAHCPCluster } from './types';
+import { STEP_IDS } from './constants';
+import { trimVisitedStepIdsAfter } from './rosaHcpWizardNav';
 import { useRosaHcpWizardReviewSections } from './Steps/Review/ROSAHCPWizardReviewSections';
+import {
+  isWizardFieldActiveForStepValidation,
+  stepOrChildHasFormValidationIssues,
+  stepOrChildHasValidationError,
+  type RosaHcpWizardChildStepIdsByParent,
+} from './rosaHcpWizardStepHierarchy';
+
+function visitedStepSetsEqual(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const stepId of left) {
+    if (!right.has(stepId)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export type RosaHcpWizardStepStatus = 'default' | 'error';
 
 type RosaHcpWizardValidationContextValue = {
   fieldPathToStepId: Readonly<Record<string, string>>;
   validationAttemptedStepIds: ReadonlySet<string>;
   validationAlertStepId: string | null;
+  navErrorSuppressedFieldPaths: ReadonlySet<string>;
+  asyncValidatingFieldPaths: ReadonlySet<string>;
+  setFieldNavErrorSuppressed: (fieldPath: string, suppressed: boolean) => void;
+  setFieldAsyncValidationInProgress: (fieldPath: string, inProgress: boolean) => void;
   markValidationAttempted: (stepId: string) => void;
   clearValidationAttempted: (stepId: string) => void;
   setValidationAlertStepId: (
     stepId: string | null | ((prev: string | null) => string | null)
   ) => void;
+  activeStepId: string;
+  visitedStepIds: ReadonlySet<string>;
+  onWizardStepChange: (stepId: string) => void;
+  /** Drop visited status for leaf steps after `activeStepId` (e.g. after a reset-source field edit). */
+  invalidateForwardVisitedSteps: (activeStepId: string, orderedStepIds: readonly string[]) => void;
 };
+
+/** Maps a step to PatternFly nav status from revealed or live field validation. */
+export function getRosaHcpWizardStepStatus(
+  stepId: string,
+  validationAttemptedStepIds: ReadonlySet<string>,
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent,
+  hasFormValidationIssues = false
+): RosaHcpWizardStepStatus {
+  if (
+    stepOrChildHasValidationError(stepId, validationAttemptedStepIds, childStepIdsByParent) ||
+    hasFormValidationIssues
+  ) {
+    return 'error';
+  }
+  return 'default';
+}
 
 const RosaHcpWizardValidationContext = createContext<RosaHcpWizardValidationContextValue | null>(
   null
 );
 
 /** Tracks steps where Next or Skip to review failed so field errors can persist across nav. */
-export function RosaHcpWizardValidationProvider({ children }: { children: ReactNode }) {
+export function RosaHcpWizardValidationProvider({
+  children,
+  initialActiveStepId = STEP_IDS.DETAILS,
+  initialVisitedStepIds = [STEP_IDS.DETAILS],
+}: {
+  children: ReactNode;
+  /** Test-only: seed the active step before nav disable logic runs. */
+  initialActiveStepId?: string;
+  /** Test-only: seed visited steps so forward nav enablement matches a mid-wizard state. */
+  initialVisitedStepIds?: readonly string[];
+}) {
   const reviewSections = useRosaHcpWizardReviewSections();
 
   const fieldPathToStepId = useMemo(() => {
@@ -42,6 +110,26 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
     },
     []
   );
+  const [navErrorSuppressedFieldPaths, setNavErrorSuppressedFieldPathsState] = useState(
+    () => new Set<string>()
+  );
+  const [asyncValidatingFieldPaths, setAsyncValidatingFieldPathsState] = useState(
+    () => new Set<string>()
+  );
+  const [activeStepId, setActiveStepId] = useState(initialActiveStepId);
+  const [visitedStepIds, setVisitedStepIds] = useState(() => new Set(initialVisitedStepIds));
+
+  const onWizardStepChange = useCallback((stepId: string) => {
+    setActiveStepId(stepId);
+    setVisitedStepIds((prev) => {
+      if (prev.has(stepId)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.add(stepId);
+      return next;
+    });
+  }, []);
 
   const markValidationAttempted = useCallback((stepId: string) => {
     setValidationAttemptedStepIds((prev) => {
@@ -65,22 +153,102 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
     });
   }, []);
 
+  const setFieldNavErrorSuppressed = useCallback((fieldPath: string, suppressed: boolean) => {
+    setNavErrorSuppressedFieldPathsState((prev) => {
+      const has = prev.has(fieldPath);
+      if (suppressed === has) {
+        return prev;
+      }
+      const next = new Set(prev);
+      if (suppressed) {
+        next.add(fieldPath);
+      } else {
+        next.delete(fieldPath);
+      }
+      return next;
+    });
+  }, []);
+
+  const setFieldAsyncValidationInProgress = useCallback(
+    (fieldPath: string, inProgress: boolean) => {
+      setAsyncValidatingFieldPathsState((prev) => {
+        const has = prev.has(fieldPath);
+        if (inProgress === has) {
+          return prev;
+        }
+        const next = new Set(prev);
+        if (inProgress) {
+          next.add(fieldPath);
+        } else {
+          next.delete(fieldPath);
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const invalidateForwardVisitedSteps = useCallback(
+    (stepId: string, orderedStepIds: readonly string[]) => {
+      const activeIdx = orderedStepIds.indexOf(stepId);
+
+      setVisitedStepIds((prev) => {
+        const next = trimVisitedStepIdsAfter(prev, stepId, orderedStepIds);
+        return visitedStepSetsEqual(prev, next) ? prev : next;
+      });
+
+      if (activeIdx === -1) {
+        return;
+      }
+
+      setValidationAttemptedStepIds((prev) => {
+        let changed = false;
+        const next = new Set(prev);
+        for (const attemptedStepId of prev) {
+          const stepIdx = orderedStepIds.indexOf(attemptedStepId);
+          if (stepIdx > activeIdx) {
+            next.delete(attemptedStepId);
+            changed = true;
+          }
+        }
+        return changed ? next : prev;
+      });
+    },
+    []
+  );
+
   const value = useMemo(
     () => ({
       fieldPathToStepId,
       validationAttemptedStepIds,
       validationAlertStepId,
+      navErrorSuppressedFieldPaths,
+      asyncValidatingFieldPaths,
+      setFieldNavErrorSuppressed,
+      setFieldAsyncValidationInProgress,
       markValidationAttempted,
       clearValidationAttempted,
       setValidationAlertStepId,
+      activeStepId,
+      visitedStepIds,
+      onWizardStepChange,
+      invalidateForwardVisitedSteps,
     }),
     [
+      activeStepId,
       clearValidationAttempted,
       fieldPathToStepId,
+      asyncValidatingFieldPaths,
+      invalidateForwardVisitedSteps,
       markValidationAttempted,
+      navErrorSuppressedFieldPaths,
+      onWizardStepChange,
+      setFieldAsyncValidationInProgress,
+      setFieldNavErrorSuppressed,
       setValidationAlertStepId,
       validationAlertStepId,
       validationAttemptedStepIds,
+      visitedStepIds,
     ]
   );
 
@@ -99,6 +267,106 @@ export function useRosaHcpWizardValidation(): RosaHcpWizardValidationContextValu
     );
   }
   return context;
+}
+
+export function useRosaHcpWizardStepStatus(
+  stepId: string,
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent
+): RosaHcpWizardStepStatus {
+  const lookup = useRosaHcpWizardStepStatusLookup(childStepIdsByParent);
+  return lookup(stepId);
+}
+
+/** Returns a stable lookup for PatternFly `WizardStep` `status` (must be a direct Wizard child). */
+export function useRosaHcpWizardStepStatusLookup(
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent
+): (stepId: string) => RosaHcpWizardStepStatus {
+  const { validationAttemptedStepIds, fieldPathToStepId, navErrorSuppressedFieldPaths } =
+    useRosaHcpWizardValidation();
+  const reviewSections = useRosaHcpWizardReviewSections();
+  const formContext = useFormContext<Partial<ROSAHCPCluster>>();
+  const watchedFormValues = useWatch<Partial<ROSAHCPCluster>>();
+  const allStepFieldPaths = useMemo(
+    () => reviewSections.flatMap((section) => section.fieldPaths),
+    [reviewSections]
+  );
+  const { errors, isSubmitted } = useFormState<Partial<ROSAHCPCluster>>({
+    control: formContext.control,
+    name:
+      allStepFieldPaths.length > 0
+        ? (allStepFieldPaths as FieldPath<Partial<ROSAHCPCluster>>[])
+        : undefined,
+  });
+
+  const formValues = (watchedFormValues ?? formContext.getValues()) as Partial<ROSAHCPCluster>;
+
+  const revealedValidationOptions = useMemo(
+    () => ({
+      validationAttemptedStepIds,
+      fieldPathToStepId,
+      isSubmitted,
+      suppressedFieldPaths: navErrorSuppressedFieldPaths,
+      formValues,
+      isFieldActive: isWizardFieldActiveForStepValidation,
+    }),
+    [
+      fieldPathToStepId,
+      formValues,
+      isSubmitted,
+      navErrorSuppressedFieldPaths,
+      validationAttemptedStepIds,
+    ]
+  );
+
+  return useCallback(
+    (stepId: string) =>
+      getRosaHcpWizardStepStatus(
+        stepId,
+        validationAttemptedStepIds,
+        childStepIdsByParent,
+        stepOrChildHasFormValidationIssues(
+          stepId,
+          reviewSections,
+          formContext.getFieldState,
+          errors,
+          revealedValidationOptions,
+          childStepIdsByParent
+        )
+      ),
+    [
+      childStepIdsByParent,
+      errors,
+      formContext.getFieldState,
+      revealedValidationOptions,
+      reviewSections,
+      validationAttemptedStepIds,
+    ]
+  );
+}
+
+/** Optional reporter for custom async field checks (e.g. cluster name uniqueness) outside RHF `isValidating`. */
+export function useRosaHcpWizardFieldAsyncValidationReporter():
+  | ((fieldPath: string, inProgress: boolean) => void)
+  | undefined {
+  return useContext(RosaHcpWizardValidationContext)?.setFieldAsyncValidationInProgress;
+}
+
+/** Suppresses left-nav step error indicators while a field hides its inline error (e.g. open select). */
+export function useWizardFieldNavErrorSuppression(fieldPath: string, suppressed: boolean): void {
+  const setFieldNavErrorSuppressed = useContext(
+    RosaHcpWizardValidationContext
+  )?.setFieldNavErrorSuppressed;
+
+  useEffect(() => {
+    if (!setFieldNavErrorSuppressed) {
+      return undefined;
+    }
+
+    setFieldNavErrorSuppressed(fieldPath, suppressed);
+    return () => {
+      setFieldNavErrorSuppressed(fieldPath, false);
+    };
+  }, [fieldPath, setFieldNavErrorSuppressed, suppressed]);
 }
 
 /** True when Next or Skip to review failed validation on the step that owns this field. */

--- a/packages/nxtcm-rosa-hcp-wizard/src/useRosaHcpWizardStepNavDisabledLookup.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/useRosaHcpWizardStepNavDisabledLookup.ts
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { type FieldPath, useFormContext, useFormState, useWatch } from 'react-hook-form';
+
+import type { ROSAHCPCluster } from './types';
+import { buildClusterValidationSchemaContext } from './utilities/buildClusterValidationSchemaContext';
+import { clusterValidationSchema } from './yupSchemas';
+import {
+  buildOrderedNavigableStepIds,
+  captureRosaHcpStepFieldValueBaseline,
+  findEarliestOrderedStepIndexWithValidationIssues,
+  isRosaHcpWizardNavStepDisabled,
+  latchEngagedRosaHcpResetSourceFields,
+  rosaHcpWizardBlockForwardNavigation,
+  rosaHcpWizardResetSourceValuesChanged,
+} from './rosaHcpWizardNav';
+import type { RosaHcpWizardChildStepIdsByParent } from './rosaHcpWizardStepHierarchy';
+import { useRosaHcpWizardReviewSections } from './Steps/Review/ROSAHCPWizardReviewSections';
+import { useRosaHcpWizardValidators } from './stringsProvider/RosaHcpWizardStringsContext';
+import { useRosaHcpWizardValidation } from './rosaHcpWizardValidationContext';
+
+type UseRosaHcpWizardStepNavDisabledLookupOptions = {
+  includeClusterWideProxy: boolean;
+  childStepIdsByParent?: RosaHcpWizardChildStepIdsByParent;
+};
+
+/** PatternFly `WizardStep` `isDisabled` lookup (must be a direct Wizard child). */
+export function useRosaHcpWizardStepNavDisabledLookup({
+  includeClusterWideProxy,
+  childStepIdsByParent,
+}: UseRosaHcpWizardStepNavDisabledLookupOptions): (stepId: string) => boolean {
+  const { activeStepId, visitedStepIds, invalidateForwardVisitedSteps, asyncValidatingFieldPaths } =
+    useRosaHcpWizardValidation();
+  const reviewSections = useRosaHcpWizardReviewSections();
+  const validatorStrings = useRosaHcpWizardValidators();
+  const { control, getValues, getFieldState } = useFormContext<Partial<ROSAHCPCluster>>();
+  const watchedFormValues = useWatch<Partial<ROSAHCPCluster>>();
+  const latchedResetSourceFieldsRef = useRef(new Set<string>());
+  const latchedForActiveStepIdRef = useRef<string | null>(null);
+
+  const orderedStepIds = useMemo(
+    () => buildOrderedNavigableStepIds(includeClusterWideProxy),
+    [includeClusterWideProxy]
+  );
+
+  const activeStepFieldPaths = useMemo(
+    () => reviewSections.find((section) => section.id === activeStepId)?.fieldPaths ?? [],
+    [activeStepId, reviewSections]
+  );
+
+  const allStepFieldPaths = useMemo(
+    () => reviewSections.flatMap((section) => section.fieldPaths),
+    [reviewSections]
+  );
+
+  // Subscribe to validation state for every wizard step, not only the active one.
+  const formState = useFormState<Partial<ROSAHCPCluster>>({
+    control,
+    name:
+      allStepFieldPaths.length > 0
+        ? (allStepFieldPaths as FieldPath<Partial<ROSAHCPCluster>>[])
+        : undefined,
+  });
+  const { errors } = formState;
+
+  const getSubscribedFieldState = useCallback(
+    (path: string) => getFieldState(path as FieldPath<Partial<ROSAHCPCluster>>, formState),
+    [formState, getFieldState]
+  );
+
+  const stepFieldValueBaseline = useMemo(
+    () => captureRosaHcpStepFieldValueBaseline(activeStepFieldPaths, getValues),
+    // Freeze baseline when the user enters a step; omit getValues so edits on the same step are detected.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- activeStepFieldPaths is tied to activeStepId
+    [activeStepId]
+  );
+
+  const yupDescribeOptions = useMemo(
+    () => ({
+      context: buildClusterValidationSchemaContext(
+        (watchedFormValues ?? getValues()) as Partial<ROSAHCPCluster>,
+        validatorStrings
+      ),
+    }),
+    [getValues, validatorStrings, watchedFormValues]
+  );
+
+  // Latch runs in layout effect (not render) so reset-source engagement does not mutate during render.
+  useLayoutEffect(() => {
+    if (latchedForActiveStepIdRef.current !== activeStepId) {
+      latchedResetSourceFieldsRef.current = new Set();
+      latchedForActiveStepIdRef.current = activeStepId;
+    }
+
+    latchEngagedRosaHcpResetSourceFields(
+      activeStepFieldPaths,
+      getValues,
+      getSubscribedFieldState,
+      stepFieldValueBaseline,
+      latchedResetSourceFieldsRef.current
+    );
+  }, [
+    activeStepFieldPaths,
+    activeStepId,
+    getSubscribedFieldState,
+    getValues,
+    stepFieldValueBaseline,
+    watchedFormValues,
+  ]);
+
+  const resetSourceValuesChanged = rosaHcpWizardResetSourceValuesChanged(
+    activeStepFieldPaths,
+    getValues,
+    getSubscribedFieldState,
+    stepFieldValueBaseline,
+    latchedResetSourceFieldsRef.current
+  );
+
+  const blockForwardNavigation = rosaHcpWizardBlockForwardNavigation({
+    activeStepFieldPaths,
+    getValues,
+    getFieldState: getSubscribedFieldState,
+    errors,
+    schema: clusterValidationSchema,
+    describeOptions: yupDescribeOptions,
+    stepDependencyBaseline: stepFieldValueBaseline,
+    latchedResetSourceFields: latchedResetSourceFieldsRef.current,
+    asyncValidatingFieldPaths,
+  });
+
+  const earliestInvalidStepIdx = findEarliestOrderedStepIndexWithValidationIssues({
+    reviewSections,
+    orderedStepIds,
+    getFieldState: getSubscribedFieldState,
+    errors,
+  });
+
+  useEffect(() => {
+    if (!resetSourceValuesChanged) {
+      return;
+    }
+    invalidateForwardVisitedSteps(activeStepId, orderedStepIds);
+  }, [activeStepId, invalidateForwardVisitedSteps, orderedStepIds, resetSourceValuesChanged]);
+
+  return useCallback(
+    (stepId: string) =>
+      isRosaHcpWizardNavStepDisabled({
+        targetStepId: stepId,
+        activeStepId,
+        visitedStepIds,
+        blockForwardNavigation,
+        orderedStepIds,
+        earliestInvalidStepIdx,
+        childStepIdsByParent,
+      }),
+    [
+      activeStepId,
+      blockForwardNavigation,
+      childStepIdsByParent,
+      earliestInvalidStepIdx,
+      orderedStepIds,
+      visitedStepIds,
+    ]
+  );
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/utilities/formSetValueOptions.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/utilities/formSetValueOptions.ts
@@ -19,11 +19,12 @@ export const DEFAULT_FORM_SET_VALUE_OPTS_WITH_VALIDATE: Required<FormSetValueOpt
 };
 
 export function buildFormSetValueOptions(
-  options: FormSetValueOptions = {}
+  options: FormSetValueOptions = {},
+  defaults: Required<FormSetValueOptions> = DEFAULT_FORM_SET_VALUE_OPTS
 ): Required<FormSetValueOptions> {
   return {
-    shouldDirty: options.shouldDirty ?? DEFAULT_FORM_SET_VALUE_OPTS.shouldDirty,
-    shouldTouch: options.shouldTouch ?? DEFAULT_FORM_SET_VALUE_OPTS.shouldTouch,
-    shouldValidate: options.shouldValidate ?? DEFAULT_FORM_SET_VALUE_OPTS.shouldValidate,
+    shouldDirty: options.shouldDirty ?? defaults.shouldDirty,
+    shouldTouch: options.shouldTouch ?? defaults.shouldTouch,
+    shouldValidate: options.shouldValidate ?? defaults.shouldValidate,
   };
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.test.ts
@@ -60,6 +60,14 @@ describe('wizardFieldMetaChangeRegistry', () => {
       expect(entries.some((entry) => entry.sourceField === 'region')).toBe(true);
       expect(entries.every((entry) => entry.targetFields.length > 0)).toBe(true);
     });
+
+    it('lists only fields that declare resetsFieldsToDefaultOnChange as reset source fields', () => {
+      const resetSources = listWizardFieldResetEntries().map((entry) => entry.sourceField);
+      expect(resetSources).toContain('region');
+      expect(resetSources).toContain('associated_aws_id');
+      expect(resetSources).not.toContain('name');
+      expect(resetSources).not.toContain('installer_role_arn');
+    });
   });
 
   describe('refetches', () => {


### PR DESCRIPTION
## Description

Adds left-nav step status and navigation gating to the ROSA HCP wizard so PatternFly `WizardStep` indicators reflect validation state and users cannot skip ahead when the current step has unresolved issues.

- **`status` on wizard steps** — each step (and parent steps with failing children) shows PatternFly `error` status when revealed or live form validation issues exist; otherwise `default`.
- **Nav disabled lookup** — `useRosaHcpWizardStepNavDisabledLookup` disables forward/unvisited steps when the active step has validation errors, dependency-reset source fields changed, or async validation is in progress.
- **Centralized nav utilities** — new `rosaHcpWizardNav.ts`, `rosaHcpWizardStepLayout.ts`, and `rosaHcpWizardStepHierarchy.ts` modules consolidate step ordering, forward-nav blocking, visited-step trimming, and parent/child status roll-up.
- **Validation context** — extended to track active step, visited steps, validation-attempted steps, and async-validating fields used by nav status and disabled logic.
- **Footer integration** — footer Next/back behavior aligned with the new nav rules and step baselines.
- **Field UX fixes** — `Select` / `MultiSelect` menu open and blur handling extracted into hooks to avoid spurious validation while interacting with dropdowns.

**Jira issue #** [FCN-162](https://redhat.atlassian.net/browse/FCN-162)

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Open the ROSA HCP wizard in Storybook and walk through Basic Setup steps with valid data — left nav steps should remain enabled and show default status.
2. Leave required fields empty on a step and click Next — the active step should show error status in the left nav; forward steps should be disabled until issues are resolved.
3. Fix validation errors on the current step — error status should clear and forward navigation should re-enable.
4. Change a field that triggers dependency resets (e.g. VPC/subnet or roles) — forward navigation should block until dependent fields are reconciled.
5. Trigger async validation (e.g. cluster name uniqueness) — forward nav should stay blocked while validation is in progress.
6. Visit later steps, then return to an earlier step and edit a reset-source field — visited steps after the active step should be trimmed and forward nav blocked until resolved.
7. Open Review with validation errors on earlier steps — parent Basic Setup step should show error status when a child step has issues.
8. Exercise Select/MultiSelect fields — opening and closing menus should not cause premature blur validation flicker.

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)

**Unit Tests:**
- [x] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A — left nav status and disabled states are best verified interactively in Storybook.

### Before

Wizard left nav did not reflect per-step validation status; users could navigate forward without resolving active-step issues.

### After

Left nav shows error status on invalid steps (including parent steps with failing children) and disables forward/unvisited steps until the active step is valid.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

This branch (`FCN-162-left-nav`) includes prior merged work from FCN-244 and FCN-502 in its history; this description covers the FCN-162 left-nav status and navigation gating scope only.


## Reviewer Guidelines

### Focus Areas
- `packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardNav.ts` — forward-nav blocking, visited-step trimming, nav disabled rules
- `packages/nxtcm-rosa-hcp-wizard/src/useRosaHcpWizardStepNavDisabledLookup.ts` — hook wiring form state to PatternFly `isDisabled`
- `packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx` — step status lookup (`default` / `error`) and validation tracking
- `packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx` — `status` and `isDisabled` passed to each `WizardStep`
- `packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx` — footer nav integration
- `packages/nxtcm-rosa-hcp-wizard/src/components/Fields/Select/` and `MultiSelect/` — menu open/blur hooks
- Unit tests: `rosaHcpWizardNav.test.ts`, `rosaHcpWizardStepStatus.test.ts`, `rosaHcpWizardStepLayout.test.ts`, footer and MachinePools specs

### Questions for Reviewers
- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-162]: https://redhat.atlassian.net/browse/FCN-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ