### PR TITLE
[FCN-552] feat(RosaWizard): enable composed VPC refetch args in fieldMetaChangeEffects

### DIFF
--- a/e2e-app/e2e.tsx
+++ b/e2e-app/e2e.tsx
@@ -180,6 +180,7 @@ const mockWizardData: ROSAHCPWizardData = {
     ],
     error: null,
     isFetching: false,
+    fetch: async () => {},
   },
   subnets: {
     data: [],

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.helpers.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.helpers.ts
@@ -236,7 +236,7 @@ export function createMockRosaHcpWizardDataWithFetchLogging(
     },
     vpcList: {
       ...base.vpcList,
-      fetch: storyFetchWithLogging('vpcList'),
+      fetch: storyFetchWithLogging<[args: import('./types').VPCRefetchArgs]>('vpcList'),
     },
     subnets: {
       ...base.subnets,

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizard.stories.tsx
@@ -52,7 +52,7 @@ const mockWizardData: ROSAHCPWizardData = {
     ...fixtures.mockFetchResource<OIDCConfig[], [awsAccount: string]>(fixtures.mockOicdConfig),
     fetch: async () => {},
   },
-  vpcList: fixtures.mockResource(fixtures.mockVPCs),
+  vpcList: { ...fixtures.mockResource(fixtures.mockVPCs), fetch: async () => {} },
   subnets: fixtures.mockResource(getMockStoryPrivateSubnets()),
   securityGroups: fixtures.mockResource(fixtures.mockSecurityGroups),
   clusterNameValidation: fixtures.mockValidationResource(),

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Details/Details.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Details/Details.spec.tsx
@@ -358,6 +358,8 @@ test.describe('Details (ROSA HCP)', () => {
         <DetailsMount
           vpcList={vpcList}
           defaultValues={{
+            associated_aws_id: 'aws-prod-123456789012',
+            installer_role_arn: 'arn:aws:iam::123456789012:role/Installer',
             region: 'us-east-1',
             selected_vpc: rosaHcpWizardFixtures.mockVPCs[0].id,
           }}

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePools.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/MachinePools/MachinePools.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Content, ContentVariants, Grid, GridItem, Stack, StackItem } from '@patternfly/react-core';
 import { useFormContext, useWatch } from 'react-hook-form';
-import type { ROSAHCPCluster, ROSAHCPWizardData } from '../../../types';
+import type { ROSAHCPCluster, ROSAHCPWizardData, VPCRefetchArgs } from '../../../types';
 import {
   buildMachinePoolsReviewSelectOptions,
   canSelectImds,
@@ -31,6 +31,8 @@ export const MachinePools = (props: MachinePoolsProps) => {
   const clusterVersion = useWatch({ control, name: 'cluster_version' }) ?? '';
   const selectedVpcRaw = useWatch({ control, name: 'selected_vpc' });
   const autoscaling = useWatch({ control, name: 'autoscaling' });
+  const awsAccountId = useWatch({ control, name: 'associated_aws_id' });
+  const installerRoleArn = useWatch({ control, name: 'installer_role_arn' });
   const maxRootDiskSize = getWorkerNodeVolumeSizeMaxGiB(clusterVersion);
   const wrongVersionForIMDS = !canSelectImds(clusterVersion);
   const maxAutoscalingNodes = getAutoscalingMaxNodes(clusterVersion);
@@ -47,9 +49,14 @@ export const MachinePools = (props: MachinePoolsProps) => {
 
   const { vpc: vpcOptions, subnet: subnetOptions } = machinePoolsSelectOptions;
 
-  const onRefreshVpc = vpcList.fetch
+  const vpcRefetchArgs: VPCRefetchArgs | undefined =
+    awsAccountId && installerRoleArn && region
+      ? { account_id: awsAccountId, role_arn: installerRoleArn, region }
+      : undefined;
+
+  const onRefreshVpc = vpcRefetchArgs
     ? () => {
-        void vpcList.fetch?.();
+        void vpcList.fetch(vpcRefetchArgs);
       }
     : undefined;
   const onRefreshMachineTypes =

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/RolesAndPolicies/RolesAndPolicies.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/RolesAndPolicies/RolesAndPolicies.tsx
@@ -98,9 +98,7 @@ export const RolesAndPolicies = (props: RolesAndPoliciesStepProps) => {
             <Stack>
               <StackItem>
                 <WizSelect<ROSAHCPCluster>
-                  onRefresh={() =>
-                    void (awsInfrastructureAccount && roles.fetch(awsInfrastructureAccount))
-                  }
+                  onRefresh={() => void oidcConfig.fetch(awsInfrastructureAccount)}
                   apiError={oidcConfig.error}
                   isLoading={oidcConfig.isFetching}
                   schema={clusterValidationSchema}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/PopoverHintWithTitle.css
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/PopoverHintWithTitle.css
@@ -15,3 +15,9 @@
     padding: 0;
     color: inherit !important
 }
+
+.pf-v6-c-content--pre:has(.pf-v6-c-clipboard-copy) {
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 100%;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
@@ -145,6 +145,7 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
       placeholder={placeholder}
       helperText={helperText}
       labelHelp={labelHelp}
+      isScrollable
       labelHelpTitle={labelHelpTitle}
       isRequired={isRequired}
       value={value}

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.test.ts
@@ -87,7 +87,11 @@ describe('applyWizardFieldMetaChangeEffects', () => {
 
     applyWizardFieldMetaChangeEffects({
       sourceField: 'region',
-      formValues: { region: 'us-east-1' },
+      formValues: {
+        region: 'us-east-1',
+        associated_aws_id: 'aws-123',
+        installer_role_arn: 'arn:aws:iam::role/installer',
+      },
       previousValue: undefined,
       currentValue: 'us-east-1',
       wizardData: makeWizardData({ vpcListFetch, machineTypesFetch }),
@@ -95,9 +99,35 @@ describe('applyWizardFieldMetaChangeEffects', () => {
     });
 
     expect(vpcListFetch).toHaveBeenCalledTimes(1);
-    expect(vpcListFetch).toHaveBeenCalledWith();
+    expect(vpcListFetch).toHaveBeenCalledWith({
+      account_id: 'aws-123',
+      role_arn: 'arn:aws:iam::role/installer',
+      region: 'us-east-1',
+    });
     expect(machineTypesFetch).toHaveBeenCalledWith('us-east-1');
     expect(resetFieldsToDefaultValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('skips composed vpcList refetch when a required field is empty', () => {
+    const vpcListFetch = jest.fn();
+    const machineTypesFetch = jest.fn();
+    const setValue = jest.fn() as jest.MockedFunction<UseFormSetValue<Partial<ROSAHCPCluster>>>;
+
+    applyWizardFieldMetaChangeEffects({
+      sourceField: 'region',
+      formValues: {
+        region: 'us-east-1',
+        associated_aws_id: '',
+        installer_role_arn: 'arn:aws:iam::role/installer',
+      },
+      previousValue: undefined,
+      currentValue: 'us-east-1',
+      wizardData: makeWizardData({ vpcListFetch, machineTypesFetch }),
+      setValue,
+    });
+
+    expect(vpcListFetch).not.toHaveBeenCalled();
+    expect(machineTypesFetch).toHaveBeenCalledWith('us-east-1');
   });
 
   it('resets dependents and refetches when a tracked field changes', () => {
@@ -107,7 +137,11 @@ describe('applyWizardFieldMetaChangeEffects', () => {
 
     applyWizardFieldMetaChangeEffects({
       sourceField: 'region',
-      formValues: { region: 'us-west-2' },
+      formValues: {
+        region: 'us-west-2',
+        associated_aws_id: 'aws-123',
+        installer_role_arn: 'arn:aws:iam::role/installer',
+      },
       previousValue: 'us-east-1',
       currentValue: 'us-west-2',
       wizardData: makeWizardData({ vpcListFetch, machineTypesFetch }),
@@ -115,7 +149,11 @@ describe('applyWizardFieldMetaChangeEffects', () => {
     });
 
     expect(vpcListFetch).toHaveBeenCalledTimes(1);
-    expect(vpcListFetch).toHaveBeenCalledWith();
+    expect(vpcListFetch).toHaveBeenCalledWith({
+      account_id: 'aws-123',
+      role_arn: 'arn:aws:iam::role/installer',
+      region: 'us-west-2',
+    });
     expect(machineTypesFetch).toHaveBeenCalledWith('us-west-2');
     expect(resetFieldsToDefaultValuesMock).toHaveBeenCalledWith(
       setValue,
@@ -126,7 +164,11 @@ describe('applyWizardFieldMetaChangeEffects', () => {
         'cluster_privacy_public_subnet_id',
       ],
       {},
-      { region: 'us-west-2' }
+      {
+        region: 'us-west-2',
+        associated_aws_id: 'aws-123',
+        installer_role_arn: 'arn:aws:iam::role/installer',
+      }
     );
   });
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.ts
@@ -23,18 +23,53 @@ export type ApplyWizardFieldMetaChangeEffectsArgs = {
   setValue: UseFormSetValue<Partial<ROSAHCPCluster>>;
 };
 
+/**
+ * Builds a `Record<string, string>` from multiple form field values.
+ * Returns `null` when any referenced field is empty/missing so the refetch is skipped.
+ */
+export function buildComposedRefetchArg(
+  argsFromFields: Readonly<Record<string, WizardFormFieldName>>,
+  formValues: Partial<ROSAHCPCluster>
+): Record<string, string> | null {
+  const result: Record<string, string> = {};
+  for (const [key, fieldName] of Object.entries(argsFromFields)) {
+    const value = formValues[fieldName];
+    if (!hasRefetchableStringValue(value)) {
+      return null;
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
 function refetchWizardResource(
   wizardData: ROSAHCPWizardData,
   refetch: WizardResourceRefetchOnChange,
   formValues: Partial<ROSAHCPCluster>
 ): void {
-  const resource = wizardData[refetch.resource];
-  const fetch = resource.fetch;
+  const resourceKey = refetch.resource;
+  if (!resourceKey) {
+    return;
+  }
+  const resource = wizardData[resourceKey as keyof ROSAHCPWizardData];
+  if (resource == null || typeof resource !== 'object' || !('fetch' in resource)) {
+    return;
+  }
+  const fetch = (resource as { fetch?: (...args: unknown[]) => Promise<void> }).fetch;
   if (!fetch) {
     return;
   }
 
-  if (refetch.argFromField) {
+  if ('argsFromFields' in refetch) {
+    const composed = buildComposedRefetchArg(refetch.argsFromFields, formValues);
+    if (!composed) {
+      return;
+    }
+    void (fetch as (arg: Record<string, string>) => Promise<void>)(composed);
+    return;
+  }
+
+  if ('argFromField' in refetch && refetch.argFromField) {
     const arg = formValues[refetch.argFromField];
     if (!hasRefetchableStringValue(arg)) {
       return;

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/index.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/index.ts
@@ -1,4 +1,7 @@
-export { applyWizardFieldMetaChangeEffects } from './applyWizardFieldMetaChangeEffects';
+export {
+  applyWizardFieldMetaChangeEffects,
+  buildComposedRefetchArg,
+} from './applyWizardFieldMetaChangeEffects';
 export type { ApplyWizardFieldMetaChangeEffectsArgs } from './applyWizardFieldMetaChangeEffects';
 export { resetFieldsToDefaultValues } from './resetFieldsToDefaultValues';
 export type { ResetFieldsToDefaultValuesOptions } from './resetFieldsToDefaultValues';

--- a/packages/nxtcm-rosa-hcp-wizard/src/types.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/types.ts
@@ -164,7 +164,17 @@ export type AwsBillingAccountsResource = Resource<AWSBillingAccounts[]>;
 export type OidcConfigResource = Resource<OIDCConfig[], [awsAccount: string]> & {
   fetch: (awsAccount: string) => Promise<void>;
 };
-export type VpcListResource = Resource<VPC[]>;
+
+/** Flat args the host app receives when the wizard triggers a VPC refetch. */
+export type VPCRefetchArgs = {
+  account_id: string;
+  role_arn: string;
+  region: string;
+};
+
+export type VpcListResource = Resource<VPC[], [args: VPCRefetchArgs]> & {
+  fetch: (args: VPCRefetchArgs) => Promise<void>;
+};
 export type SubnetsResource = Resource<Subnet[]>;
 export type SecurityGroupsResource = Resource<SecurityGroup[]>;
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/detailsFields.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/detailsFields.ts
@@ -112,7 +112,14 @@ export const regionSchema = yup
       'cluster_privacy_public_subnet_id',
     ],
     refetchesResourcesOnChange: [
-      { resource: 'vpcList' },
+      {
+        resource: 'vpcList',
+        argsFromFields: {
+          account_id: 'associated_aws_id',
+          role_arn: 'installer_role_arn',
+          region: 'region',
+        },
+      },
       { resource: 'machineTypes', argFromField: 'region' },
     ],
   } satisfies WizardFieldMeta);

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/rolesAndPoliciesFields.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/rolesAndPoliciesFields.ts
@@ -17,6 +17,16 @@ export const installerRoleArnSchema = yup
     stepId: STEP_IDS.ROLES_AND_POLICIES,
     fieldType: 'select',
     optionsWizardDataResource: 'roles',
+    refetchesResourcesOnChange: [
+      {
+        resource: 'vpcList',
+        argsFromFields: {
+          account_id: 'associated_aws_id',
+          role_arn: 'installer_role_arn',
+          region: 'region',
+        },
+      },
+    ],
     reconcileValueWithOptions: true,
     derivedFieldsSyncOnChange: 'installerRoleDependentRoles',
   } satisfies WizardFieldMeta);

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/types.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/types.ts
@@ -39,9 +39,24 @@ type WizardResourceRefetchOnChangeForResource<K extends WizardDataResourceKey> =
         : never
     : never;
 
+/** Single-arg or no-arg refetch derived from the resource's fetch signature. */
+export type WizardResourceSimpleRefetchOnChange =
+  WizardResourceRefetchOnChangeForResource<WizardDataResourceKey>;
+
+/**
+ * Composed-arg refetch: builds a `Record<string, string>` from multiple form field values
+ * and passes it to the resource's `fetch`. All referenced fields must have non-empty string
+ * values for the refetch to fire.
+ */
+export type WizardResourceComposedRefetchOnChange = {
+  readonly resource: WizardDataResourceKey;
+  readonly argsFromFields: Readonly<Record<string, WizardFormFieldName>>;
+};
+
 /** Describes a {@link ROSAHCPWizardData} resource reload when a form field changes. */
 export type WizardResourceRefetchOnChange =
-  WizardResourceRefetchOnChangeForResource<WizardDataResourceKey>;
+  | WizardResourceSimpleRefetchOnChange
+  | WizardResourceComposedRefetchOnChange;
 
 /**
  * When a source field changes to `when`, apply `setDefaults` and/or `clear` on dependent fields.

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.test.ts
@@ -66,7 +66,14 @@ describe('wizardFieldMetaChangeRegistry', () => {
     it('lists region refetches from Yup meta', () => {
       expect(getWizardResourceRefetchesForSourceField('region')).toEqual(
         expect.arrayContaining([
-          { resource: 'vpcList' },
+          {
+            resource: 'vpcList',
+            argsFromFields: {
+              account_id: 'associated_aws_id',
+              role_arn: 'installer_role_arn',
+              region: 'region',
+            },
+          },
           { resource: 'machineTypes', argFromField: 'region' },
         ])
       );

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/yupSchemas.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/yupSchemas.test.ts
@@ -1374,7 +1374,14 @@ BnRlc3RjYTBcMA0GCSqGSIb3DQEBAQUAAwIAATANBgkqhkiG9w0BAQsFAAMCAQA=
       expect(meta!.fieldType).toBe('select');
       expect(meta!.noEditAfterSubmit).toBe(true);
       expect(meta!.refetchesResourcesOnChange).toEqual([
-        { resource: 'vpcList' },
+        {
+          resource: 'vpcList',
+          argsFromFields: {
+            account_id: 'associated_aws_id',
+            role_arn: 'installer_role_arn',
+            region: 'region',
+          },
+        },
         { resource: 'machineTypes', argFromField: 'region' },
       ]);
     });


### PR DESCRIPTION
## Description

Extends the wizard's declarative `fieldMetaChangeEffects` system to support resource fetches that require multiple form field values as composed arguments. Previously, `refetchesResourcesOnChange` only supported single-string or no-argument fetches. This change enables the VPC list resource (`vpcList`) to be automatically refetched with the correct `account_id`, `role_arn`, and `region` whenever any of those fields change — removing the need for host apps to manually wire individual state setters.

### What changed

- **New `VPCRefetchArgs` type** — flat type with `account_id`, `role_arn`, `region`; `VpcListResource.fetch` now requires it.
- **New `argsFromFields` metadata variant** — `WizardResourceComposedRefetchOnChange` maps multiple form field values into a single fetch argument object.
- **Runtime handler** — `buildComposedRefetchArg()` reads all referenced form fields and builds the composed arg. If any field is empty the refetch is skipped.
- **Schema declarations** — `regionSchema` and `installerRoleArnSchema` both declare `argsFromFields` for `vpcList`, so the fetch triggers from whichever field is set last.
- **`MachinePools.tsx`** — manual Refresh button now passes composed `VPCRefetchArgs`.
- **All tests and mocks updated** to match the new type and behaviour.

**Jira issue #** [FCN-552](https://redhat.atlassian.net/browse/FCN-552)

**Backport of** #


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Select an AWS infrastructure account in the Details step
2. Select a region — VPC refetch should be skipped (installer role not yet selected)
3. Select an installer role in the Roles & Policies step — VPC list should auto-fetch
4. Navigate to Machine Pools — VPC dropdown should show fetched VPCs
5. Click the Refresh button on the VPC dropdown — should trigger a new fetch with composed args

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)

**Unit Tests:**
- [x] Unit tests added/updated
- [x] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A — no visual UI changes; behaviour change is in fetch triggering logic.

### Before

VPC refetch was configured as a no-arg fetch `{ resource: 'vpcList' }` on region change. Host app had to manually manage and pass individual state setters (`setAwsAccountId`, `setInstallerRoleArn`, `setRegion`) to synchronise VPC fetching.

### After

VPC refetch uses `argsFromFields` to declaratively compose `{ account_id, role_arn, region }` from form state and pass it to the host app's `vpcList.fetch()` callback. The fetch is also triggered when `installer_role_arn` changes (not just `region`), ensuring VPCs are loaded before the Machine Pools step.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [x] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] Yes
- [ ] No

`VpcListResource.fetch` now requires a `VPCRefetchArgs` argument (`{ account_id, role_arn, region }`). Host apps that previously provided a no-arg or untyped `fetch` callback for `vpcList` must update their implementation to accept and use this object.

**Migration:**
1. Import `VPCRefetchArgs` from `@redhat-cloud-services/nxtcm-rosa-hcp-wizard`
2. Update `vpcList.fetch` to accept `(args: VPCRefetchArgs) => Promise<void>`
3. Use `args.account_id`, `args.role_arn`, `args.region` to build the API request body
4. Remove manual state setters (`setAwsAccountId`, etc.) from the wrapper component


## Additional Notes

The `argsFromFields` pattern is generic and can be reused for any future resource that needs composed arguments from multiple form fields. The `buildComposedRefetchArg` utility is exported for direct use if needed.


## Reviewer Guidelines

### Focus Areas
- `yupSchemas/types.ts` — new `WizardResourceComposedRefetchOnChange` type and union
- `fieldMetaChangeEffects/applyWizardFieldMetaChangeEffects.ts` — `buildComposedRefetchArg()` and the `argsFromFields` branch in `refetchWizardResource()`
- `yupSchemas/detailsFields.ts` and `yupSchemas/rolesAndPoliciesFields.ts` — both declare `argsFromFields` for `vpcList` so the fetch fires from whichever field is set last
- `types.ts` — `VPCRefetchArgs` shape and `VpcListResource` breaking change

### Questions for Reviewers
- Is the `argsFromFields` naming clear, or would `composedFetchArgs` / `fetchArgsFromFields` be better?

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-552]: https://redhat.atlassian.net/browse/FCN-552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ