### PR TITLE
FCN-162 - Disable left nav steps 

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec-helpers.tsx
@@ -14,6 +14,9 @@ import {
   type ROSAHCPCluster,
 } from '../types';
 import { Details } from '../Steps/BasicSetup/Details/Details';
+import { MachinePools } from '../Steps/BasicSetup/MachinePools/MachinePools';
+import { Networking } from '../Steps/BasicSetup/Networking/Networking';
+import { mockSubnets } from '../Steps/BasicSetup/Networking/Networking.fixtures';
 import { RolesAndPolicies } from '../Steps/BasicSetup/RolesAndPolicies/RolesAndPolicies';
 import { Encryption } from '../Steps/OptionalSetup/Encryption/Encryption';
 import { ClusterUpdates } from '../Steps/OptionalSetup/ClusterUpdates/ClusterUpdates';
@@ -36,7 +39,12 @@ import {
   defaultRosaHcpWizardValidatorStrings,
 } from '../stringsProvider/rosaHcpWizardStrings.defaults';
 import { withRosaCt } from '../components/WizFields/wizFieldCtSpecHelpers';
-import { makeVpcListResource } from '../test/rosaHcpWizardCtSpecHelpers';
+import {
+  makeDefaultRosaHcpCtWizardData,
+  makeMachineTypesResource,
+  makeVpcListResource,
+  WizardFieldMetaChangeEffectsCtHarness,
+} from '../test/rosaHcpWizardCtSpecHelpers';
 import type {
   AwsBillingAccountsResource,
   AwsInfrastructureAccountsResource,
@@ -97,57 +105,111 @@ export const RosaHcpWizardValidationMount: React.FC<RosaHcpWizardValidationMount
 
   const sl = defaultRosaHcpWizardStrings.wizard.stepLabels;
 
-  const versionsProps: VersionsResource = {
-    data: mockOpenShiftVersionsData,
-    isFetching: false,
-    fetch: async () => {},
-    error: null,
-  };
+  const versionsProps = useMemo<VersionsResource>(
+    () => ({
+      data: mockOpenShiftVersionsData,
+      isFetching: false,
+      fetch: async () => {},
+      error: null,
+    }),
+    []
+  );
 
-  const awsInfra: AwsInfrastructureAccountsResource = {
-    data: mockAwsInfrastructureAccounts,
-    isFetching: false,
-    fetch: async () => {},
-    error: null,
-  };
+  const awsInfra = useMemo<AwsInfrastructureAccountsResource>(
+    () => ({
+      data: mockAwsInfrastructureAccounts,
+      isFetching: false,
+      fetch: async () => {},
+      error: null,
+    }),
+    []
+  );
 
-  const awsBilling: AwsBillingAccountsResource = {
-    data: mockAwsBillingAccounts,
-    isFetching: false,
-    fetch: async () => {},
-    error: null,
-  };
+  const awsBilling = useMemo<AwsBillingAccountsResource>(
+    () => ({
+      data: mockAwsBillingAccounts,
+      isFetching: false,
+      fetch: async () => {},
+      error: null,
+    }),
+    []
+  );
 
-  const regionsProps: RegionsResource = {
-    data: mockRegions,
-    isFetching: false,
-    fetch: async (_awsAccount: string) => {},
-    error: null,
-  };
+  const regionsProps = useMemo<RegionsResource>(
+    () => ({
+      data: mockRegions,
+      isFetching: false,
+      fetch: async (_awsAccount: string) => {},
+      error: null,
+    }),
+    []
+  );
 
-  const rolesProps: RolesResource = {
-    data: mockRoles,
-    isFetching: false,
-    fetch: async (_awsAccount: string) => {},
-    error: null,
-    ocmRoleError: null,
-    userRoleError: null,
-    ocmRoleARN: null,
-  };
+  const rolesProps = useMemo<RolesResource>(
+    () => ({
+      data: mockRoles,
+      isFetching: false,
+      fetch: async (_awsAccount: string) => {},
+      error: null,
+      ocmRoleError: null,
+      userRoleError: null,
+      ocmRoleARN: null,
+    }),
+    []
+  );
 
-  const oidcProps = {
-    data: fixtures.mockOicdConfig,
-    error: null,
-    isFetching: false,
-    fetch: async () => {},
-  };
+  const oidcProps = useMemo(
+    () => ({
+      data: fixtures.mockOicdConfig,
+      error: null,
+      isFetching: false,
+      fetch: async () => {},
+    }),
+    []
+  );
 
-  const vpcListProps = makeVpcListResource();
+  const vpcListProps = useMemo(() => makeVpcListResource(), []);
+  const machineTypesProps = useMemo(() => makeMachineTypesResource(), []);
+  const subnetsProps = useMemo(
+    () => ({
+      data: mockSubnets,
+      error: null,
+      isFetching: false,
+    }),
+    []
+  );
+
+  const wizardData = useMemo(
+    () =>
+      makeDefaultRosaHcpCtWizardData({
+        awsInfrastructureAccounts: awsInfra,
+        awsBillingAccounts: awsBilling,
+        regions: regionsProps,
+        versions: versionsProps,
+        roles: rolesProps,
+        oidcConfig: oidcProps,
+        machineTypes: machineTypesProps,
+        vpcList: vpcListProps,
+        subnets: subnetsProps,
+      }),
+    [
+      awsBilling,
+      awsInfra,
+      machineTypesProps,
+      oidcProps,
+      regionsProps,
+      rolesProps,
+      subnetsProps,
+      versionsProps,
+      vpcListProps,
+    ]
+  );
 
   return withRosaCt(
     <FormProvider {...methods}>
       <RosaHcpWizardValidationProvider>
-        <Wizard height={720} footer={rosaHcpWizardFooter}>
+        <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
+        <Wizard height={720} footer={rosaHcpWizardFooter} isVisitRequired>
           <WizardStep
             isExpandable
             name={sl.basicSetup}
@@ -168,6 +230,16 @@ export const RosaHcpWizardValidationMount: React.FC<RosaHcpWizardValidationMount
                 id={STEP_IDS.ROLES_AND_POLICIES}
               >
                 <RolesAndPolicies roles={rolesProps} oidcConfig={oidcProps} />
+              </WizardStep>,
+              <WizardStep
+                key={STEP_IDS.MACHINE_POOLS}
+                name={sl.machinePools}
+                id={STEP_IDS.MACHINE_POOLS}
+              >
+                <MachinePools vpcList={vpcListProps} machineTypes={machineTypesProps} />
+              </WizardStep>,
+              <WizardStep name={sl.networking} id={STEP_IDS.NETWORKING} key={STEP_IDS.NETWORKING}>
+                <Networking vpcList={vpcListProps} subnets={subnetsProps} />
               </WizardStep>,
             ]}
           />

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec-helpers.tsx
@@ -43,7 +43,7 @@ import {
   makeDefaultRosaHcpCtWizardData,
   makeMachineTypesResource,
   makeVpcListResource,
-  WizardFieldMetaChangeEffectsCtHarness,
+  WizardFieldMetaChangeEffectsRunner,
 } from '../test/rosaHcpWizardCtSpecHelpers';
 import type {
   AwsBillingAccountsResource,
@@ -208,7 +208,7 @@ export const RosaHcpWizardValidationMount: React.FC<RosaHcpWizardValidationMount
   return withRosaCt(
     <FormProvider {...methods}>
       <RosaHcpWizardValidationProvider>
-        <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
+        <WizardFieldMetaChangeEffectsRunner wizardData={wizardData} />
         <Wizard height={720} footer={rosaHcpWizardFooter} isVisitRequired>
           <WizardStep
             isExpandable

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
@@ -61,6 +61,26 @@ async function advanceToReviewStep(component: MountResult): Promise<void> {
   await clickNextTimes(component, 6);
 }
 
+async function clickBackTimes(component: MountResult, count: number): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await component.getByRole('button', { name: FOOTER_BACK }).click();
+  }
+}
+
+async function selectAwsInfrastructureAccount(
+  component: MountResult,
+  page: import('@playwright/test').Page,
+  accountLabel: string
+): Promise<void> {
+  const combo = component.locator('#associated_aws_id-form-group').getByRole('combobox', {
+    name: defaultRosaHcpWizardStrings.details.awsInfraPlaceholder,
+    exact: true,
+  });
+  await combo.click();
+  await combo.fill(accountLabel.includes('Staging') ? 'Staging' : accountLabel);
+  await page.getByRole('option', { name: accountLabel, exact: true }).click();
+}
+
 test.describe('RosaHcpWizardFooter — left nav validation icons', () => {
   test('shows error icons on Details and Basic setup after Next fails validation', async ({
     mount,
@@ -197,6 +217,30 @@ test.describe('RosaHcpWizardFooter — step validation on Next', () => {
     await expect(
       component.getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
     ).toBeDisabled();
+  });
+
+  test('disables future nav steps after changing associated AWS infrastructure account on Details', async ({
+    mount,
+    page,
+  }) => {
+    test.setTimeout(30_000);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
+
+    await advanceToReviewStep(component);
+    await expect(component.getByText(review.sectionLabel, { exact: true })).toBeVisible();
+
+    await clickBackTimes(component, 6);
+    await expect(
+      component.getByText(defaultRosaHcpWizardStrings.details.awsInfraLabel)
+    ).toBeVisible();
+
+    await selectAwsInfrastructureAccount(component, page, 'AWS Account - Staging (234567890123)');
+
+    await expect(wizardNavStep(component, STEP_IDS.ROLES_AND_POLICIES)).toBeDisabled();
+    await expect(wizardNavStep(component, STEP_IDS.MACHINE_POOLS)).toBeDisabled();
+    await expect(wizardNavStep(component, STEP_IDS.REVIEW)).toBeDisabled();
   });
 });
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/experimental-ct-react';
+import { test, expect, type MountResult } from '@playwright/experimental-ct-react';
 
 import {
   defaultRosaHcpWizardStrings,
@@ -11,6 +11,7 @@ import {
   VALID_DETAILS_FORM_VALUES,
   VALID_REVIEW_SUBMIT_FORM_VALUES,
 } from './rosaHcpWizardFooter.test-data';
+import { STEP_IDS } from '../constants';
 
 const INSTALLER_ROLE_LABEL = mockRoles[0].installerRole.label;
 
@@ -27,6 +28,85 @@ const encryption = defaultRosaHcpWizardStrings.encryption;
 
 /** PatternFly danger Alert exposes the title as a heading (e.g. "Danger alert: …"). */
 const validationAlertHeading = { name: new RegExp(FIX_VALIDATION_ALERT) };
+
+async function expectWizardNavError(component: MountResult, stepId: string): Promise<void> {
+  await expect(component.locator(`#${stepId}`)).toContainText(', error');
+}
+
+async function expectWizardNavNoError(component: MountResult, stepId: string): Promise<void> {
+  await expect(component.locator(`#${stepId}`)).not.toContainText(', error');
+}
+
+function wizardNavStep(component: MountResult, stepId: string) {
+  return component.locator(`#${stepId}`);
+}
+
+test.describe('RosaHcpWizardFooter — left nav validation icons', () => {
+  test('shows error icons on Details and Basic setup after Next fails validation', async ({
+    mount,
+  }) => {
+    const component = await mount(<RosaHcpWizardValidationMount />);
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+
+    await expectWizardNavError(component, STEP_IDS.DETAILS);
+    await expectWizardNavError(component, STEP_IDS.BASIC_SETUP);
+    await expectWizardNavNoError(component, STEP_IDS.OPTIONAL_SETUP);
+  });
+
+  test('clears nav error icons after Details fields become valid', async ({ mount }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        defaultValues={{
+          ...VALID_DETAILS_FORM_VALUES,
+          name: '',
+        }}
+      />
+    );
+
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+    await expectWizardNavError(component, STEP_IDS.DETAILS);
+
+    await component.getByRole('textbox', { name: /Cluster name/i }).fill('mycluster');
+
+    await expectWizardNavNoError(component, STEP_IDS.DETAILS);
+    await expectWizardNavNoError(component, STEP_IDS.BASIC_SETUP);
+  });
+
+  test('shows error icons on Encryption and Additional setup after Skip to review fails', async ({
+    mount,
+  }) => {
+    const component = await mount(<RosaHcpWizardValidationMount />);
+
+    await component.getByText(w.stepLabels.additionalSetup).click();
+    await component
+      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
+      .click();
+    await component.getByRole('checkbox', { name: encryption.etcdLabel }).check();
+    await component.getByRole('button', { name: SKIP_TO_REVIEW }).click();
+
+    await expectWizardNavError(component, STEP_IDS.ENCRYPTION);
+    await expectWizardNavError(component, STEP_IDS.OPTIONAL_SETUP);
+    await expectWizardNavNoError(component, STEP_IDS.BASIC_SETUP);
+  });
+
+  test('shows error icons on steps with errors after a failed Review Submit', async ({ mount }) => {
+    const component = await mount(
+      <RosaHcpWizardValidationMount
+        defaultValues={{
+          ...VALID_REVIEW_SUBMIT_FORM_VALUES,
+          name: '',
+        }}
+      />
+    );
+
+    await component.getByRole('button', { name: w.stepLabels.review, exact: true }).click();
+    await component.getByRole('button', { name: FOOTER_SUBMIT }).click();
+
+    await expectWizardNavError(component, STEP_IDS.DETAILS);
+    await expectWizardNavError(component, STEP_IDS.BASIC_SETUP);
+  });
+});
 
 test.describe('RosaHcpWizardFooter — step validation on Next', () => {
   test('disables Back on the Details step', async ({ mount }) => {
@@ -186,10 +266,7 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
     await expect(component.getByRole('button', { name: FOOTER_NEXT })).toBeEnabled();
 
     await component.getByText(w.stepLabels.additionalSetup).click();
-    const encryptionNav = component.getByRole('button', {
-      name: w.stepLabels.encryptionOptional,
-      exact: true,
-    });
+    const encryptionNav = wizardNavStep(component, STEP_IDS.ENCRYPTION);
     await expect(encryptionNav).toBeVisible();
     await encryptionNav.click();
     await expect(component.getByText(REQUIRED_FIELD_MESSAGE).first()).toBeVisible();

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.spec.tsx
@@ -41,6 +41,26 @@ function wizardNavStep(component: MountResult, stepId: string) {
   return component.locator(`#${stepId}`);
 }
 
+async function clickNextTimes(component: MountResult, count: number): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+  }
+}
+
+async function advancePastDetailsStep(component: MountResult): Promise<void> {
+  await clickNextTimes(component, 1);
+}
+
+/** Details → Roles → Machine pools → Networking → Encryption (requires `isVisitRequired`). */
+async function advanceToEncryptionStep(component: MountResult): Promise<void> {
+  await clickNextTimes(component, 4);
+}
+
+/** Details → … → Cluster updates → Review. */
+async function advanceToReviewStep(component: MountResult): Promise<void> {
+  await clickNextTimes(component, 6);
+}
+
 test.describe('RosaHcpWizardFooter — left nav validation icons', () => {
   test('shows error icons on Details and Basic setup after Next fails validation', async ({
     mount,
@@ -76,12 +96,11 @@ test.describe('RosaHcpWizardFooter — left nav validation icons', () => {
   test('shows error icons on Encryption and Additional setup after Skip to review fails', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    await advanceToEncryptionStep(component);
     await component.getByRole('checkbox', { name: encryption.etcdLabel }).check();
     await component.getByRole('button', { name: SKIP_TO_REVIEW }).click();
 
@@ -92,15 +111,16 @@ test.describe('RosaHcpWizardFooter — left nav validation icons', () => {
 
   test('shows error icons on steps with errors after a failed Review Submit', async ({ mount }) => {
     const component = await mount(
-      <RosaHcpWizardValidationMount
-        defaultValues={{
-          ...VALID_REVIEW_SUBMIT_FORM_VALUES,
-          name: '',
-        }}
-      />
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
     );
 
+    await advanceToReviewStep(component);
+    await expect(component.getByText(review.sectionLabel, { exact: true })).toBeVisible();
+
+    await component.getByRole('button', { name: review.editStep }).first().click();
+    await component.getByRole('textbox', { name: /Cluster name/i }).fill('');
     await component.getByRole('button', { name: w.stepLabels.review, exact: true }).click();
+
     await component.getByRole('button', { name: FOOTER_SUBMIT }).click();
 
     await expectWizardNavError(component, STEP_IDS.DETAILS);
@@ -166,7 +186,7 @@ test.describe('RosaHcpWizardFooter — step validation on Next', () => {
     );
   });
 
-  test('does not show the validation alert on another step after Details Next failed and the user navigates away', async ({
+  test('keeps future nav steps disabled after Details Next failed validation', async ({
     mount,
   }) => {
     const component = await mount(<RosaHcpWizardValidationMount />);
@@ -174,15 +194,9 @@ test.describe('RosaHcpWizardFooter — step validation on Next', () => {
     await component.getByRole('button', { name: FOOTER_NEXT }).click();
     await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
 
-    await component
-      .getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
-      .click();
-
-    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
-    await expect(component.getByRole('heading', validationAlertHeading)).not.toBeVisible();
-    await expect(component.locator('#installer_role_arn-form-group')).not.toContainText(
-      REQUIRED_FIELD_MESSAGE
-    );
+    await expect(
+      component.getByRole('button', { name: w.stepLabels.rolesAndPolicies, exact: true })
+    ).toBeDisabled();
   });
 });
 
@@ -193,12 +207,11 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   });
 
   test('shows Skip to review on an Additional setup step', async ({ mount }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    await advanceToEncryptionStep(component);
 
     await expect(component.getByText(encryption.sectionLabel, { exact: true })).toBeVisible();
     await expect(component.getByRole('button', { name: SKIP_TO_REVIEW })).toBeVisible();
@@ -207,12 +220,11 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   test('shows the validation alert and stays on the step when Skip to review is pressed with invalid fields', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    await advanceToEncryptionStep(component);
     await component.getByRole('checkbox', { name: encryption.etcdLabel }).check();
     await component.getByRole('button', { name: SKIP_TO_REVIEW }).click();
 
@@ -224,12 +236,11 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   test('keeps Next and Skip to review enabled after field blur validation on Encryption', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    await advanceToEncryptionStep(component);
     await component.getByRole('radio', { name: encryption.customKms }).check();
     await component.getByRole('textbox', { name: encryption.keyArnLabel }).focus();
     await component.getByRole('textbox', { name: encryption.keyArnLabel }).blur();
@@ -243,12 +254,11 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
     mount,
   }) => {
     test.setTimeout(30_000);
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    await advanceToEncryptionStep(component);
     await component.getByRole('radio', { name: encryption.customKms }).check();
     const keyArn = component.getByRole('textbox', { name: encryption.keyArnLabel });
     await keyArn.focus();
@@ -277,12 +287,11 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
   test('navigates to Review when Skip to review is pressed with a valid current step', async ({
     mount,
   }) => {
-    const component = await mount(<RosaHcpWizardValidationMount />);
+    const component = await mount(
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
+    );
 
-    await component.getByText(w.stepLabels.additionalSetup).click();
-    await component
-      .getByRole('button', { name: w.stepLabels.encryptionOptional, exact: true })
-      .click();
+    await advanceToEncryptionStep(component);
     await component.getByRole('button', { name: SKIP_TO_REVIEW }).click();
 
     await expect(component.getByText(review.sectionLabel, { exact: true })).toBeVisible();
@@ -291,26 +300,22 @@ test.describe('RosaHcpWizardFooter — Skip to review', () => {
 });
 
 test.describe('RosaHcpWizardFooter — Review Submit validation alert', () => {
-  test('hides the validation alert on Review after a failed Submit when the form becomes valid', async ({
+  test('hides the validation alert after a failed Submit when the edited field becomes valid', async ({
     mount,
   }) => {
     const component = await mount(
-      <RosaHcpWizardValidationMount
-        defaultValues={{
-          ...VALID_REVIEW_SUBMIT_FORM_VALUES,
-          name: '',
-        }}
-      />
+      <RosaHcpWizardValidationMount defaultValues={VALID_REVIEW_SUBMIT_FORM_VALUES} />
     );
 
-    await component.getByRole('button', { name: w.stepLabels.review, exact: true }).click();
+    await advanceToReviewStep(component);
     await expect(component.getByText(review.sectionLabel, { exact: true })).toBeVisible();
-
-    await component.getByRole('button', { name: FOOTER_SUBMIT }).click();
-    await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
 
     await component.getByRole('button', { name: review.editStep }).first().click();
     const nameInput = component.getByRole('textbox', { name: /Cluster name/i });
+    await nameInput.fill('');
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
+    await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
+
     await nameInput.fill('mycluster');
 
     await expect(component.getByRole('heading', validationAlertHeading)).not.toBeVisible();
@@ -332,12 +337,9 @@ test.describe('RosaHcpWizardFooter — validation alert after failed Review Subm
       />
     );
 
-    await component.getByRole('button', { name: w.stepLabels.review, exact: true }).click();
-    await component.getByRole('button', { name: FOOTER_SUBMIT }).click();
+    await advancePastDetailsStep(component);
+    await component.getByRole('button', { name: FOOTER_NEXT }).click();
     await expect(component.getByRole('heading', validationAlertHeading)).toBeVisible();
-
-    await component.getByRole('button', { name: review.editStep }).nth(1).click();
-    await expect(component.getByText(rp.accountRolesSection, { exact: true })).toBeVisible();
 
     await component.locator('#installer_role_arn-form-group .pf-v6-c-menu-toggle').click();
     await page.getByRole('option', { name: INSTALLER_ROLE_LABEL }).click();

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx
@@ -71,6 +71,7 @@ export function RosaHcpWizardFooter({
   useRosaHcpWizardNavStatusSync(!!clusterWideProxySelected);
 
   const activeStepId = String(activeStep.id);
+
   const getCurrentStepId = useCallback(() => String(activeStep.id), [activeStep.id]);
   const isReviewStep = activeStepId === STEP_IDS.REVIEW;
   const showSkipToReview = isRosaHcpWizardSkipToReviewVisible(activeStepId);

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/RosaHcpWizardFooter.tsx
@@ -28,6 +28,7 @@ import {
 import { useRosaHcpWizardValidation } from '../rosaHcpWizardValidationContext';
 import { useRosaHcpWizardStrings } from '../stringsProvider/RosaHcpWizardStringsContext';
 import { useRosaHcpWizardSubmit } from './useRosaHcpWizardSubmit';
+import { useRosaHcpWizardNavStatusSync } from '../hooks/useRosaHcpWizardNavStatusSync';
 
 type RosaHcpWizardFooterProps = Pick<
   WizardFooterProps,
@@ -65,6 +66,9 @@ export function RosaHcpWizardFooter({
     formState: { errors },
   } = useFormContext<Partial<ROSAHCPCluster>>();
   const { isSubmitting, submitWizard } = useRosaHcpWizardSubmit({ onSubmit });
+
+  const clusterWideProxySelected = useWatch({ name: 'configure_proxy' });
+  useRosaHcpWizardNavStatusSync(!!clusterWideProxySelected);
 
   const activeStepId = String(activeStep.id);
   const getCurrentStepId = useCallback(() => String(activeStep.id), [activeStep.id]);

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.test-data.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.test-data.ts
@@ -1,4 +1,11 @@
+import fixtures from '../ROSAHCPWizard.fixtures';
+import { mockRoles } from '../Steps/BasicSetup/Details/Details.fixtures';
 import type { ROSAHCPCluster } from '../types';
+
+const mockRoleSet = mockRoles[0];
+const mockVpc = fixtures.mockVPCs[0];
+const mockMachinePoolSubnet =
+  mockVpc.aws_subnets.find((subnet) => subnet.name.includes('private'))?.subnet_id ?? '';
 
 /** Values that pass Details-step validation in CT and unit tests. */
 export const VALID_DETAILS_FORM_VALUES: Partial<ROSAHCPCluster> = {
@@ -12,9 +19,12 @@ export const VALID_DETAILS_FORM_VALUES: Partial<ROSAHCPCluster> = {
 /** Values that pass full-form validation for footer Review Submit CT (wizard subset of fields). */
 export const VALID_REVIEW_SUBMIT_FORM_VALUES: Partial<ROSAHCPCluster> = {
   ...VALID_DETAILS_FORM_VALUES,
-  installer_role_arn: 'arn:aws:iam::123456789012:role/installer',
-  support_role_arn: 'arn:aws:iam::123456789012:role/support',
-  worker_role_arn: 'arn:aws:iam::123456789012:role/worker',
-  byo_oidc_config_id: 'oidc-config-1',
+  installer_role_arn: mockRoleSet.installerRole.value,
+  support_role_arn: mockRoleSet.supportRole[0].value,
+  worker_role_arn: mockRoleSet.workerRole[0].value,
+  byo_oidc_config_id: fixtures.mockOicdConfig[0].value,
   custom_operator_roles_prefix: 'mycluster-a1b2',
+  selected_vpc: mockVpc.id,
+  machine_pools_subnets: [{ machine_pool_subnet: mockMachinePoolSubnet }],
+  machine_type: fixtures.mockMachineTypes[0].value,
 };

--- a/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.test-data.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Footer/rosaHcpWizardFooter.test-data.ts
@@ -4,8 +4,13 @@ import type { ROSAHCPCluster } from '../types';
 
 const mockRoleSet = mockRoles[0];
 const mockVpc = fixtures.mockVPCs[0];
-const mockMachinePoolSubnet =
-  mockVpc.aws_subnets.find((subnet) => subnet.name.includes('private'))?.subnet_id ?? '';
+const privateSubnet = mockVpc.aws_subnets.find((subnet) => subnet.name.includes('private'));
+if (!privateSubnet?.subnet_id) {
+  throw new Error(
+    `Expected mock VPC "${mockVpc.id}" to include a private subnet in aws_subnets for footer test data`
+  );
+}
+const mockMachinePoolSubnet = privateSubnet.subnet_id;
 
 /** Values that pass Details-step validation in CT and unit tests. */
 export const VALID_DETAILS_FORM_VALUES: Partial<ROSAHCPCluster> = {

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
@@ -101,6 +101,7 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
         footer={footer}
         onClose={onCancel}
         onStepChange={handleWizardStepChange}
+        isVisitRequired
       >
         <WizardStep
           isExpandable

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Details/Details.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Details/Details.spec-helpers.tsx
@@ -23,6 +23,7 @@ import {
 import { clusterValidationSchema } from '../../../yupSchemas';
 import type { CheckClusterNameUniqueness } from '../../../types';
 import { defaultRosaHcpWizardValidatorStrings } from '../../../stringsProvider/rosaHcpWizardStrings.defaults';
+import { RosaHcpWizardValidationProvider } from '../../../rosaHcpWizardValidationContext';
 import { withRosaCt } from '../../../components/WizFields/wizFieldCtSpecHelpers';
 import {
   makeDefaultRosaHcpCtWizardData,
@@ -204,19 +205,21 @@ export const DetailsMount: React.FC<DetailsMountProps> = ({
   );
 
   return withRosaCt(
-    <FormProvider {...methods}>
-      <Form>
-        <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
-        <Details
-          awsInfrastructureAccounts={awsInfra}
-          awsBillingAccounts={awsBilling}
-          regions={regionsProps}
-          versions={versionsProps}
-          roles={rolesProps}
-          checkClusterNameUniqueness={resolvedCheckClusterNameUniqueness}
-        />
-        <DetailsFormValuesProbe />
-      </Form>
-    </FormProvider>
+    <RosaHcpWizardValidationProvider>
+      <FormProvider {...methods}>
+        <Form>
+          <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
+          <Details
+            awsInfrastructureAccounts={awsInfra}
+            awsBillingAccounts={awsBilling}
+            regions={regionsProps}
+            versions={versionsProps}
+            roles={rolesProps}
+            checkClusterNameUniqueness={resolvedCheckClusterNameUniqueness}
+          />
+          <DetailsFormValuesProbe />
+        </Form>
+      </FormProvider>
+    </RosaHcpWizardValidationProvider>
   );
 };

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Details/Details.spec-helpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/BasicSetup/Details/Details.spec-helpers.tsx
@@ -28,7 +28,7 @@ import { withRosaCt } from '../../../components/WizFields/wizFieldCtSpecHelpers'
 import {
   makeDefaultRosaHcpCtWizardData,
   makeVpcListResource,
-  WizardFieldMetaChangeEffectsCtHarness,
+  WizardFieldMetaChangeEffectsRunner,
 } from '../../../test/rosaHcpWizardCtSpecHelpers';
 import type {
   AwsBillingAccountsResource,
@@ -208,7 +208,7 @@ export const DetailsMount: React.FC<DetailsMountProps> = ({
     <RosaHcpWizardValidationProvider>
       <FormProvider {...methods}>
         <Form>
-          <WizardFieldMetaChangeEffectsCtHarness wizardData={wizardData} />
+          <WizardFieldMetaChangeEffectsRunner wizardData={wizardData} />
           <Details
             awsInfrastructureAccounts={awsInfra}
             awsBillingAccounts={awsBilling}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizMultiSelect/WizMultiSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizMultiSelect/WizMultiSelect.tsx
@@ -4,7 +4,12 @@ import { requiredFromYup } from '../../../utilities/yupFieldRequired';
 import { FieldWithAPIErrorAlert } from '../../FieldWithAPIErrorAlert';
 import { MultiSelect, type MultiSelectProps } from '../../Fields/MultiSelect';
 import { useWizFieldPresentation } from '../wizFieldPresentation';
-import { useWizRhfControl, wizFieldShowsError, type WizRhfBoundFieldProps } from '../wizFieldRhf';
+import {
+  useWizRhfControl,
+  useWizMenuFieldBlur,
+  wizFieldShowsError,
+  type WizRhfBoundFieldProps,
+} from '../wizFieldRhf';
 
 type WizMultiSelectControlledKeys = 'value' | 'onChange' | 'onBlur' | 'errorMessage' | 'isError';
 
@@ -93,6 +98,7 @@ export function WizMultiSelect<TFieldValues extends FieldValues = FieldValues, T
   } = useController({ name, control });
 
   const showError = wizFieldShowsError(invalid, isTouched, isSubmitted);
+  const handleBlur = useWizMenuFieldBlur(field.onBlur, isMenuOpen);
 
   const raw = field.value;
   const value = Array.isArray(raw) ? (raw as TOption[]) : [];
@@ -108,7 +114,7 @@ export function WizMultiSelect<TFieldValues extends FieldValues = FieldValues, T
       labelHelpTitle={labelHelpTitle}
       isRequired={isRequired}
       value={value}
-      onBlur={field.onBlur}
+      onBlur={handleBlur}
       onChange={field.onChange}
       errorMessage={error?.message}
       isError={showError && !isMenuOpen}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/WizSelect/WizSelect.tsx
@@ -11,7 +11,12 @@ import { FieldWithAPIErrorAlert } from '../../FieldWithAPIErrorAlert';
 import { Select, type SelectProps } from '../../Fields/Select';
 import { useWizFieldPresentation } from '../wizFieldPresentation';
 import { useWizStepValidationRevealed } from '../../../rosaHcpWizardValidationContext';
-import { useWizRhfControl, wizFieldShowsError, type WizRhfBoundFieldProps } from '../wizFieldRhf';
+import {
+  useWizRhfControl,
+  useWizMenuFieldBlur,
+  wizFieldShowsError,
+  type WizRhfBoundFieldProps,
+} from '../wizFieldRhf';
 
 type WizSelectControlledKeys = 'value' | 'onChange' | 'onBlur' | 'errorMessage' | 'isError';
 
@@ -104,6 +109,7 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
 
   const stepValidationRevealed = useWizStepValidationRevealed(String(name));
   const showError = wizFieldShowsError(invalid, isTouched, isSubmitted || stepValidationRevealed);
+  const handleBlur = useWizMenuFieldBlur(onBlur, isMenuOpen);
   useReconcileWizSelectValueWithOptions({
     name,
     schema,
@@ -149,7 +155,7 @@ export function WizSelect<TFieldValues extends FieldValues = FieldValues, TOptio
       labelHelpTitle={labelHelpTitle}
       isRequired={isRequired}
       value={value}
-      onBlur={onBlur}
+      onBlur={handleBlur}
       onChange={handleChange}
       errorMessage={error?.message}
       isError={showError && !isMenuOpen}

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/wizFieldRhf.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/WizFields/wizFieldRhf.ts
@@ -1,4 +1,11 @@
-import { type ReactNode } from 'react';
+import {
+  type FocusEvent,
+  type FocusEventHandler,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import {
   type Control,
   type FieldPath,
@@ -120,6 +127,37 @@ export function wizFieldShowsError(
   validationRevealed: boolean
 ): boolean {
   return invalid && (isTouched || validationRevealed);
+}
+
+/**
+ * Defers react-hook-form touch until a dropdown closes. The menu toggle blurs on mousedown
+ * while an option is being chosen; marking touched then briefly shows invalid+ touched in nav
+ * before the new value lands.
+ */
+export function useWizMenuFieldBlur(
+  onBlur: FocusEventHandler<HTMLElement>,
+  isMenuOpen: boolean
+): FocusEventHandler<HTMLElement> {
+  const wasMenuOpenRef = useRef(false);
+  const onBlurRef = useRef(onBlur);
+  onBlurRef.current = onBlur;
+
+  useEffect(() => {
+    if (wasMenuOpenRef.current && !isMenuOpen) {
+      onBlurRef.current({ type: 'blur' } as FocusEvent<HTMLElement>);
+    }
+    wasMenuOpenRef.current = isMenuOpen;
+  }, [isMenuOpen]);
+
+  return useCallback(
+    (event: FocusEvent<HTMLElement>) => {
+      if (isMenuOpen) {
+        return;
+      }
+      onBlur(event);
+    },
+    [isMenuOpen, onBlur]
+  );
 }
 
 /** Like {@link wizFieldShowsError}, but keyed on a resolved error message string. */

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/readWatchedFieldValue.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/readWatchedFieldValue.ts
@@ -1,0 +1,4 @@
+/** Reads one field value from a react-hook-form `useWatch` result (scalar or parallel array). */
+export function readWatchedFieldValue(watchedValues: unknown, fieldIndex: number): unknown {
+  return Array.isArray(watchedValues) ? watchedValues[fieldIndex] : watchedValues;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
@@ -67,6 +67,9 @@ export function useWizardFieldMetaChangeEffects(wizardData: ROSAHCPWizardData): 
       const previousValue = isInitialPass ? undefined : previousByFieldRef.current[field];
 
       if (!isInitialPass && wizardFormFieldValuesEqual(previousValue, currentValue)) {
+        if (programmaticallyResetFieldsRef.current.has(field)) {
+          programmaticallyResetFieldsRef.current.delete(field);
+        }
         continue;
       }
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from 'react';
 import { type FieldPath, useFormContext, useWatch } from 'react-hook-form';
 
 import { applyWizardFieldMetaChangeEffects } from './applyWizardFieldMetaChangeEffects';
+import { readWatchedFieldValue } from './readWatchedFieldValue';
 import { reapplyWizardFieldDerivedSyncs } from './wizardFieldDerivedSyncs';
 import { wizardFormFieldValuesEqual } from './wizardFormFieldValuesEqual';
 import type { ROSAHCPCluster, ROSAHCPWizardData } from '../types';
@@ -10,10 +11,6 @@ import {
   listWizardFieldMetaChangeSourceFields,
 } from '../yupSchemas';
 import type { WizardFormFieldName } from '../yupSchemas/types';
-
-function readWatchedFieldValue(watchedValues: unknown, fieldIndex: number): unknown {
-  return Array.isArray(watchedValues) ? watchedValues[fieldIndex] : watchedValues;
-}
 
 /** Merges live `useWatch` values into `getValues()` so refetch args match the field being processed. */
 function buildFormValuesForMetaEffects(

--- a/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/fieldMetaChangeEffects/useWizardFieldMetaChangeEffects.ts
@@ -5,10 +5,14 @@ import { applyWizardFieldMetaChangeEffects } from './applyWizardFieldMetaChangeE
 import { readWatchedFieldValue } from './readWatchedFieldValue';
 import { reapplyWizardFieldDerivedSyncs } from './wizardFieldDerivedSyncs';
 import { wizardFormFieldValuesEqual } from './wizardFormFieldValuesEqual';
+import { useRosaHcpWizardValidation } from '../rosaHcpWizardValidationContext';
 import type { ROSAHCPCluster, ROSAHCPWizardData } from '../types';
 import {
+  getWizardFieldResetsForSourceField,
   listWizardFieldDerivedSyncEntries,
   listWizardFieldMetaChangeSourceFields,
+  listWizardNavUnvisitSourceFields,
+  wizardFieldMetaByPath,
 } from '../yupSchemas';
 import type { WizardFormFieldName } from '../yupSchemas/types';
 
@@ -39,13 +43,16 @@ function buildFormValuesForMetaEffects(
  */
 export function useWizardFieldMetaChangeEffects(wizardData: ROSAHCPWizardData): void {
   const { setValue, getValues, control } = useFormContext<Partial<ROSAHCPCluster>>();
+  const { requestNavUnvisitAfterSteps } = useRosaHcpWizardValidation();
   const sourceFields = useMemo(() => listWizardFieldMetaChangeSourceFields(), []);
+  const unvisitSourceFieldSet = useMemo(() => new Set(listWizardNavUnvisitSourceFields()), []);
   const derivedSyncEntries = useMemo(() => listWizardFieldDerivedSyncEntries(), []);
   const watchedValues = useWatch({
     control,
     name: sourceFields as FieldPath<Partial<ROSAHCPCluster>>[],
   });
   const previousByFieldRef = useRef<Partial<Record<WizardFormFieldName, unknown>>>({});
+  const programmaticallyResetFieldsRef = useRef<Set<WizardFormFieldName>>(new Set());
   const hasInitializedRef = useRef(false);
   const wizardDataRef = useRef(wizardData);
   wizardDataRef.current = wizardData;
@@ -53,6 +60,7 @@ export function useWizardFieldMetaChangeEffects(wizardData: ROSAHCPWizardData): 
   useEffect(() => {
     const formValues = buildFormValuesForMetaEffects(sourceFields, watchedValues, getValues);
     const isInitialPass = !hasInitializedRef.current;
+    const unvisitSourceStepIds = new Set<string>();
 
     for (const [index, field] of sourceFields.entries()) {
       const currentValue = readWatchedFieldValue(watchedValues, index);
@@ -70,11 +78,44 @@ export function useWizardFieldMetaChangeEffects(wizardData: ROSAHCPWizardData): 
         wizardData: wizardDataRef.current,
         setValue,
       });
+
+      if (!isInitialPass) {
+        for (const resetTarget of getWizardFieldResetsForSourceField(field)) {
+          programmaticallyResetFieldsRef.current.add(resetTarget);
+        }
+      }
+
+      if (
+        !isInitialPass &&
+        unvisitSourceFieldSet.has(field) &&
+        !programmaticallyResetFieldsRef.current.has(field)
+      ) {
+        const stepId = wizardFieldMetaByPath(field)?.stepId;
+        if (stepId) {
+          unvisitSourceStepIds.add(stepId);
+        }
+      }
+
+      if (programmaticallyResetFieldsRef.current.has(field)) {
+        programmaticallyResetFieldsRef.current.delete(field);
+      }
+
       previousByFieldRef.current[field] = currentValue;
     }
 
+    if (unvisitSourceStepIds.size > 0) {
+      requestNavUnvisitAfterSteps([...unvisitSourceStepIds]);
+    }
+
     hasInitializedRef.current = true;
-  }, [getValues, setValue, sourceFields, watchedValues]);
+  }, [
+    getValues,
+    requestNavUnvisitAfterSteps,
+    setValue,
+    sourceFields,
+    unvisitSourceFieldSet,
+    watchedValues,
+  ]);
 
   useEffect(() => {
     if (!hasInitializedRef.current) {

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.test.ts
@@ -11,7 +11,10 @@ import {
   buildRosaHcpWizardNavStepDisabledByValidation,
   buildRosaHcpWizardNavStepStatuses,
   buildVisibleWizardStepIds,
+  findActiveWizardNavStepIndexWithPendingValidation,
   findFirstWizardNavStepIndexWithVisibleErrors,
+  stepHasAsyncValidationInProgress,
+  stepHasPendingAsyncValidation,
   stepHasVisibleValidationErrors,
 } from './rosaHcpWizardNavStepStatus';
 
@@ -29,13 +32,13 @@ const allReviewSections = buildRosaHcpWizardReviewSections(reviewStepLabels);
 const visibleStepIds = buildVisibleWizardStepIds(allReviewSections, false);
 
 const mockGetFieldState = (
-  impl: (path: string) => { invalid: boolean; isTouched: boolean }
+  impl: (path: string) => { invalid: boolean; isTouched: boolean; isValidating?: boolean }
 ): UseFormGetFieldState<FieldValues> =>
   jest.fn((path: string) => ({
     invalid: impl(path).invalid,
     isTouched: impl(path).isTouched,
     isDirty: false,
-    isValidating: false,
+    isValidating: impl(path).isValidating ?? false,
     error: undefined,
   })) as UseFormGetFieldState<FieldValues>;
 
@@ -115,6 +118,116 @@ describe('stepHasVisibleValidationErrors', () => {
   });
 });
 
+describe('stepHasPendingAsyncValidation', () => {
+  it('returns true when any field on the step is validating', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: path === 'name',
+    }));
+
+    expect(stepHasPendingAsyncValidation(['name'], getFieldState)).toBe(true);
+  });
+
+  it('returns false when no fields on the step are validating', () => {
+    const getFieldState = mockGetFieldState(() => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: false,
+    }));
+
+    expect(stepHasPendingAsyncValidation(['name'], getFieldState)).toBe(false);
+  });
+});
+
+describe('stepHasAsyncValidationInProgress', () => {
+  it('returns true when the step is tracked in asyncValidatingStepIds', () => {
+    const getFieldState = mockGetFieldState(() => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: false,
+    }));
+
+    expect(
+      stepHasAsyncValidationInProgress(
+        STEP_IDS.DETAILS,
+        ['name'],
+        getFieldState,
+        new Set([STEP_IDS.DETAILS])
+      )
+    ).toBe(true);
+  });
+
+  it('falls back to RHF isValidating when the step is not tracked in context', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: path === 'name',
+    }));
+
+    expect(
+      stepHasAsyncValidationInProgress(STEP_IDS.DETAILS, ['name'], getFieldState, new Set())
+    ).toBe(true);
+  });
+});
+
+describe('findActiveWizardNavStepIndexWithPendingValidation', () => {
+  it('returns the active step index when that step has pending async validation', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: path === 'name',
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    expect(
+      findActiveWizardNavStepIndexWithPendingValidation({
+        orderedStepIds,
+        sections,
+        getFieldState,
+        activeStepId: STEP_IDS.DETAILS,
+      })
+    ).toBe(orderedStepIds.indexOf(STEP_IDS.DETAILS));
+  });
+
+  it('returns undefined when async validation is pending on a different step', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: path === 'name',
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    expect(
+      findActiveWizardNavStepIndexWithPendingValidation({
+        orderedStepIds,
+        sections,
+        getFieldState,
+        activeStepId: STEP_IDS.NETWORKING,
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns the active step index when async validation is tracked in context', () => {
+    const getFieldState = mockGetFieldState(() => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: false,
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    expect(
+      findActiveWizardNavStepIndexWithPendingValidation({
+        orderedStepIds,
+        sections,
+        getFieldState,
+        activeStepId: STEP_IDS.DETAILS,
+        asyncValidatingStepIds: new Set([STEP_IDS.DETAILS]),
+      })
+    ).toBe(orderedStepIds.indexOf(STEP_IDS.DETAILS));
+  });
+});
+
 describe('findFirstWizardNavStepIndexWithVisibleErrors', () => {
   it('returns the earliest ordered step index with a visible error', () => {
     const getFieldState = mockGetFieldState((path) => ({
@@ -135,6 +248,49 @@ describe('findFirstWizardNavStepIndexWithVisibleErrors', () => {
 });
 
 describe('buildRosaHcpWizardNavStepDisabledByValidation', () => {
+  it('disables only steps after the earliest pending async validation from context', () => {
+    const getFieldState = mockGetFieldState(() => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: false,
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    const disabled = buildRosaHcpWizardNavStepDisabledByValidation({
+      orderedStepIds,
+      sections,
+      getFieldState,
+      validationAttemptedStepIds: new Set(),
+      activeStepId: STEP_IDS.DETAILS,
+      asyncValidatingStepIds: new Set([STEP_IDS.DETAILS]),
+    });
+
+    expect(disabled[STEP_IDS.DETAILS]).toBe(false);
+    expect(disabled[STEP_IDS.ROLES_AND_POLICIES]).toBe(true);
+    expect(disabled[STEP_IDS.REVIEW]).toBe(true);
+  });
+
+  it('disables only steps after the earliest pending async validation from RHF', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: false,
+      isTouched: false,
+      isValidating: path === 'name',
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    const disabled = buildRosaHcpWizardNavStepDisabledByValidation({
+      orderedStepIds,
+      sections,
+      getFieldState,
+      validationAttemptedStepIds: new Set(),
+      activeStepId: STEP_IDS.DETAILS,
+    });
+
+    expect(disabled[STEP_IDS.DETAILS]).toBe(false);
+    expect(disabled[STEP_IDS.ROLES_AND_POLICIES]).toBe(true);
+    expect(disabled[STEP_IDS.REVIEW]).toBe(true);
+  });
+
   it('disables only steps after the earliest visible validation error', () => {
     const getFieldState = mockGetFieldState((path) => ({
       invalid: path === 'name',
@@ -147,6 +303,7 @@ describe('buildRosaHcpWizardNavStepDisabledByValidation', () => {
       sections,
       getFieldState,
       validationAttemptedStepIds: new Set(),
+      activeStepId: STEP_IDS.DETAILS,
     });
 
     expect(disabled[STEP_IDS.DETAILS]).toBe(false);

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.test.ts
@@ -1,15 +1,32 @@
 import type { FieldValues, UseFormGetFieldState } from 'react-hook-form';
 
 import { STEP_IDS } from '../constants';
-import type { RosaHcpWizardReviewSection } from '../Steps/Review/rosaHcpWizardReviewSections.data';
+import {
+  buildRosaHcpWizardReviewSections,
+  type RosaHcpWizardReviewSection,
+} from '../Steps/Review/rosaHcpWizardReviewSections.data';
 
 import {
+  buildOrderedWizardNavStepIds,
+  buildRosaHcpWizardNavStepDisabledByValidation,
   buildRosaHcpWizardNavStepStatuses,
   buildVisibleWizardStepIds,
+  findFirstWizardNavStepIndexWithVisibleErrors,
   stepHasVisibleValidationErrors,
 } from './rosaHcpWizardNavStepStatus';
 
-const visibleStepIds = buildVisibleWizardStepIds(false);
+const reviewStepLabels = {
+  details: 'Details',
+  rolesAndPolicies: 'Roles and policies',
+  machinePools: 'Machine pools',
+  networking: 'Networking',
+  clusterWideProxy: 'Cluster-wide proxy',
+  encryptionOptional: 'Encryption (optional)',
+  clusterUpdatesOptional: 'Cluster updates (optional)',
+};
+
+const allReviewSections = buildRosaHcpWizardReviewSections(reviewStepLabels);
+const visibleStepIds = buildVisibleWizardStepIds(allReviewSections, false);
 
 const mockGetFieldState = (
   impl: (path: string) => { invalid: boolean; isTouched: boolean }
@@ -28,9 +45,29 @@ const sections: RosaHcpWizardReviewSection[] = [
   { id: STEP_IDS.ENCRYPTION, label: 'Encryption', fieldPaths: ['etcd_key_arn'] },
 ];
 
+describe('buildOrderedWizardNavStepIds', () => {
+  it('orders leaf steps ending with Review', () => {
+    const ids = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    expect(ids[0]).toBe(STEP_IDS.DETAILS);
+    expect(ids.at(-1)).toBe(STEP_IDS.REVIEW);
+    expect(ids).not.toContain(STEP_IDS.CLUSTER_WIDE_PROXY);
+  });
+
+  it('includes cluster-wide proxy before optional setup when enabled', () => {
+    const ids = buildOrderedWizardNavStepIds(allReviewSections, true);
+    const networkingIndex = ids.indexOf(STEP_IDS.NETWORKING);
+    const proxyIndex = ids.indexOf(STEP_IDS.CLUSTER_WIDE_PROXY);
+    const encryptionIndex = ids.indexOf(STEP_IDS.ENCRYPTION);
+
+    expect(proxyIndex).toBeGreaterThan(networkingIndex);
+    expect(encryptionIndex).toBeGreaterThan(proxyIndex);
+  });
+});
+
 describe('buildVisibleWizardStepIds', () => {
   it('omits cluster-wide proxy when not enabled', () => {
-    const ids = buildVisibleWizardStepIds(false);
+    const ids = buildVisibleWizardStepIds(allReviewSections, false);
 
     expect(ids.has(STEP_IDS.CLUSTER_WIDE_PROXY)).toBe(false);
     expect(ids.has(STEP_IDS.NETWORKING)).toBe(true);
@@ -38,7 +75,9 @@ describe('buildVisibleWizardStepIds', () => {
   });
 
   it('includes cluster-wide proxy when enabled', () => {
-    expect(buildVisibleWizardStepIds(true).has(STEP_IDS.CLUSTER_WIDE_PROXY)).toBe(true);
+    expect(
+      buildVisibleWizardStepIds(allReviewSections, true).has(STEP_IDS.CLUSTER_WIDE_PROXY)
+    ).toBe(true);
   });
 });
 
@@ -73,6 +112,46 @@ describe('stepHasVisibleValidationErrors', () => {
         new Set([STEP_IDS.DETAILS])
       )
     ).toBe(true);
+  });
+});
+
+describe('findFirstWizardNavStepIndexWithVisibleErrors', () => {
+  it('returns the earliest ordered step index with a visible error', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: path === 'region',
+      isTouched: path === 'region',
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    expect(
+      findFirstWizardNavStepIndexWithVisibleErrors({
+        orderedStepIds,
+        sections,
+        getFieldState,
+        validationAttemptedStepIds: new Set(),
+      })
+    ).toBe(orderedStepIds.indexOf(STEP_IDS.NETWORKING));
+  });
+});
+
+describe('buildRosaHcpWizardNavStepDisabledByValidation', () => {
+  it('disables only steps after the earliest visible validation error', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: path === 'name',
+      isTouched: path === 'name',
+    }));
+    const orderedStepIds = buildOrderedWizardNavStepIds(allReviewSections, false);
+
+    const disabled = buildRosaHcpWizardNavStepDisabledByValidation({
+      orderedStepIds,
+      sections,
+      getFieldState,
+      validationAttemptedStepIds: new Set(),
+    });
+
+    expect(disabled[STEP_IDS.DETAILS]).toBe(false);
+    expect(disabled[STEP_IDS.ROLES_AND_POLICIES]).toBe(true);
+    expect(disabled[STEP_IDS.REVIEW]).toBe(true);
   });
 });
 

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.test.ts
@@ -1,0 +1,113 @@
+import type { FieldValues, UseFormGetFieldState } from 'react-hook-form';
+
+import { STEP_IDS } from '../constants';
+import type { RosaHcpWizardReviewSection } from '../Steps/Review/rosaHcpWizardReviewSections.data';
+
+import {
+  buildRosaHcpWizardNavStepStatuses,
+  buildVisibleWizardStepIds,
+  stepHasVisibleValidationErrors,
+} from './rosaHcpWizardNavStepStatus';
+
+const visibleStepIds = buildVisibleWizardStepIds(false);
+
+const mockGetFieldState = (
+  impl: (path: string) => { invalid: boolean; isTouched: boolean }
+): UseFormGetFieldState<FieldValues> =>
+  jest.fn((path: string) => ({
+    invalid: impl(path).invalid,
+    isTouched: impl(path).isTouched,
+    isDirty: false,
+    isValidating: false,
+    error: undefined,
+  })) as UseFormGetFieldState<FieldValues>;
+
+const sections: RosaHcpWizardReviewSection[] = [
+  { id: STEP_IDS.DETAILS, label: 'Details', fieldPaths: ['name'] },
+  { id: STEP_IDS.NETWORKING, label: 'Networking', fieldPaths: ['region'] },
+  { id: STEP_IDS.ENCRYPTION, label: 'Encryption', fieldPaths: ['etcd_key_arn'] },
+];
+
+describe('buildVisibleWizardStepIds', () => {
+  it('omits cluster-wide proxy when not enabled', () => {
+    const ids = buildVisibleWizardStepIds(false);
+
+    expect(ids.has(STEP_IDS.CLUSTER_WIDE_PROXY)).toBe(false);
+    expect(ids.has(STEP_IDS.NETWORKING)).toBe(true);
+    expect(ids.has(STEP_IDS.ENCRYPTION)).toBe(true);
+  });
+
+  it('includes cluster-wide proxy when enabled', () => {
+    expect(buildVisibleWizardStepIds(true).has(STEP_IDS.CLUSTER_WIDE_PROXY)).toBe(true);
+  });
+});
+
+describe('stepHasVisibleValidationErrors', () => {
+  it('returns true for touched invalid fields', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: path === 'name',
+      isTouched: path === 'name',
+    }));
+
+    expect(
+      stepHasVisibleValidationErrors(['name'], STEP_IDS.DETAILS, getFieldState, new Set())
+    ).toBe(true);
+  });
+
+  it('returns false for invalid fields that are not touched or revealed', () => {
+    const getFieldState = mockGetFieldState(() => ({ invalid: true, isTouched: false }));
+
+    expect(
+      stepHasVisibleValidationErrors(['name'], STEP_IDS.DETAILS, getFieldState, new Set())
+    ).toBe(false);
+  });
+
+  it('returns true when validation was attempted on the step', () => {
+    const getFieldState = mockGetFieldState(() => ({ invalid: true, isTouched: false }));
+
+    expect(
+      stepHasVisibleValidationErrors(
+        ['name'],
+        STEP_IDS.DETAILS,
+        getFieldState,
+        new Set([STEP_IDS.DETAILS])
+      )
+    ).toBe(true);
+  });
+});
+
+describe('buildRosaHcpWizardNavStepStatuses', () => {
+  it('marks steps with visible errors and their parent groups', () => {
+    const getFieldState = mockGetFieldState((path) => ({
+      invalid: path === 'name',
+      isTouched: path === 'name',
+    }));
+
+    const statuses = buildRosaHcpWizardNavStepStatuses({
+      sections,
+      getFieldState,
+      validationAttemptedStepIds: new Set(),
+      visibleStepIds,
+    });
+
+    expect(statuses[STEP_IDS.DETAILS]).toBe('error');
+    expect(statuses[STEP_IDS.BASIC_SETUP]).toBe('error');
+    expect(statuses[STEP_IDS.NETWORKING]).toBe('default');
+    expect(statuses[STEP_IDS.OPTIONAL_SETUP]).toBe('default');
+  });
+
+  it('marks Additional setup when an optional step has a revealed validation error', () => {
+    const getFieldState = mockGetFieldState(() => ({ invalid: true, isTouched: false }));
+
+    const statuses = buildRosaHcpWizardNavStepStatuses({
+      sections,
+      getFieldState,
+      validationAttemptedStepIds: new Set([STEP_IDS.ENCRYPTION]),
+      visibleStepIds,
+    });
+
+    expect(statuses[STEP_IDS.ENCRYPTION]).toBe('error');
+    expect(statuses[STEP_IDS.OPTIONAL_SETUP]).toBe('error');
+    expect(statuses[STEP_IDS.BASIC_SETUP]).toBe('default');
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.ts
@@ -6,23 +6,54 @@ import type { RosaHcpWizardReviewSection } from '../Steps/Review/rosaHcpWizardRe
 
 export type RosaHcpWizardNavStepStatus = 'default' | 'error';
 
-const BASIC_SETUP_CHILD_STEP_IDS = [
-  STEP_IDS.DETAILS,
-  STEP_IDS.ROLES_AND_POLICIES,
-  STEP_IDS.MACHINE_POOLS,
-  STEP_IDS.NETWORKING,
-  STEP_IDS.CLUSTER_WIDE_PROXY,
-] as const;
+const OPTIONAL_SETUP_CHILD_STEP_IDS = new Set<string>([
+  STEP_IDS.ENCRYPTION,
+  STEP_IDS.CLUSTER_UPDATES,
+]);
 
-const ADDITIONAL_SETUP_CHILD_STEP_IDS = [STEP_IDS.ENCRYPTION, STEP_IDS.CLUSTER_UPDATES] as const;
+function visibleLeafStepIdsFromSections(
+  sections: readonly RosaHcpWizardReviewSection[],
+  includeClusterWideProxy: boolean
+): readonly string[] {
+  return sections
+    .map((section) => section.id)
+    .filter((id) => includeClusterWideProxy || id !== STEP_IDS.CLUSTER_WIDE_PROXY);
+}
+
+function groupChildStepIdsFromSections(
+  sections: readonly RosaHcpWizardReviewSection[],
+  visibleStepIds: ReadonlySet<string>,
+  group: 'basic' | 'optional'
+): readonly string[] {
+  return sections
+    .map((section) => section.id)
+    .filter((id) => {
+      if (!visibleStepIds.has(id)) {
+        return false;
+      }
+      const isOptional = OPTIONAL_SETUP_CHILD_STEP_IDS.has(id);
+      return group === 'optional' ? isOptional : !isOptional;
+    });
+}
+
+/** Linear nav order for leaf wizard steps (cluster-wide proxy only when enabled). */
+export function buildOrderedWizardNavStepIds(
+  sections: readonly RosaHcpWizardReviewSection[],
+  includeClusterWideProxy: boolean
+): readonly string[] {
+  return [...visibleLeafStepIdsFromSections(sections, includeClusterWideProxy), STEP_IDS.REVIEW];
+}
 
 /** Wizard steps that participate in nav status (cluster-wide proxy only when enabled). */
-export function buildVisibleWizardStepIds(includeClusterWideProxy: boolean): ReadonlySet<string> {
-  const basicSetupStepIds = BASIC_SETUP_CHILD_STEP_IDS.filter(
-    (id) => includeClusterWideProxy || id !== STEP_IDS.CLUSTER_WIDE_PROXY
+export function buildVisibleWizardStepIds(
+  sections: readonly RosaHcpWizardReviewSection[],
+  includeClusterWideProxy: boolean
+): ReadonlySet<string> {
+  return new Set(
+    buildOrderedWizardNavStepIds(sections, includeClusterWideProxy).filter(
+      (id) => id !== STEP_IDS.REVIEW
+    )
   );
-
-  return new Set([...basicSetupStepIds, ...ADDITIONAL_SETUP_CHILD_STEP_IDS]);
 }
 
 /** True when any field on the step shows a validation error in the form UI. */
@@ -73,12 +104,62 @@ export function buildRosaHcpWizardNavStepStatuses<TFieldValues extends FieldValu
       : 'default';
   }
 
-  const basicSetupChildren = BASIC_SETUP_CHILD_STEP_IDS.filter((id) => visibleStepIds.has(id));
-  statuses[STEP_IDS.BASIC_SETUP] = parentStepHasChildErrors(basicSetupChildren, statuses);
+  statuses[STEP_IDS.BASIC_SETUP] = parentStepHasChildErrors(
+    groupChildStepIdsFromSections(sections, visibleStepIds, 'basic'),
+    statuses
+  );
   statuses[STEP_IDS.OPTIONAL_SETUP] = parentStepHasChildErrors(
-    ADDITIONAL_SETUP_CHILD_STEP_IDS,
+    groupChildStepIdsFromSections(sections, visibleStepIds, 'optional'),
     statuses
   );
 
   return statuses;
+}
+
+/** Index of the earliest ordered step with a visible validation error, if any. */
+export function findFirstWizardNavStepIndexWithVisibleErrors<
+  TFieldValues extends FieldValues,
+>(params: {
+  orderedStepIds: readonly string[];
+  sections: readonly RosaHcpWizardReviewSection[];
+  getFieldState: UseFormGetFieldState<TFieldValues>;
+  validationAttemptedStepIds: ReadonlySet<string>;
+}): number | undefined {
+  const { orderedStepIds, sections, getFieldState, validationAttemptedStepIds } = params;
+
+  for (const [index, stepId] of orderedStepIds.entries()) {
+    const section = sections.find((entry) => entry.id === stepId);
+    if (
+      section &&
+      stepHasVisibleValidationErrors(
+        section.fieldPaths,
+        section.id,
+        getFieldState,
+        validationAttemptedStepIds
+      )
+    ) {
+      return index;
+    }
+  }
+
+  return undefined;
+}
+
+/** PatternFly `isDisabled` for leaf nav steps blocked by a visible validation error upstream. */
+export function buildRosaHcpWizardNavStepDisabledByValidation<
+  TFieldValues extends FieldValues,
+>(params: {
+  orderedStepIds: readonly string[];
+  sections: readonly RosaHcpWizardReviewSection[];
+  getFieldState: UseFormGetFieldState<TFieldValues>;
+  validationAttemptedStepIds: ReadonlySet<string>;
+}): Readonly<Record<string, boolean>> {
+  const firstErrorIndex = findFirstWizardNavStepIndexWithVisibleErrors(params);
+  const disabled: Record<string, boolean> = {};
+
+  for (const [index, stepId] of params.orderedStepIds.entries()) {
+    disabled[stepId] = firstErrorIndex !== undefined && index > firstErrorIndex;
+  }
+
+  return disabled;
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.ts
@@ -72,6 +72,31 @@ export function stepHasVisibleValidationErrors<TFieldValues extends FieldValues>
   });
 }
 
+/** True when any field on the step has async validation in progress. */
+export function stepHasPendingAsyncValidation<TFieldValues extends FieldValues>(
+  fieldPaths: readonly string[],
+  getFieldState: UseFormGetFieldState<TFieldValues>
+): boolean {
+  return fieldPaths.some((path) => {
+    const fieldPath = path as FieldPath<TFieldValues>;
+    return getFieldState(fieldPath).isValidating;
+  });
+}
+
+/** True when a step has in-flight async validation tracked by RHF or wizard validation context. */
+export function stepHasAsyncValidationInProgress<TFieldValues extends FieldValues>(
+  stepId: string,
+  fieldPaths: readonly string[],
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  asyncValidatingStepIds?: ReadonlySet<string>
+): boolean {
+  if (asyncValidatingStepIds?.has(stepId)) {
+    return true;
+  }
+
+  return stepHasPendingAsyncValidation(fieldPaths, getFieldState);
+}
+
 function parentStepHasChildErrors(
   childStepIds: readonly string[],
   statuses: Readonly<Record<string, RosaHcpWizardNavStepStatus>>
@@ -145,7 +170,50 @@ export function findFirstWizardNavStepIndexWithVisibleErrors<
   return undefined;
 }
 
-/** PatternFly `isDisabled` for leaf nav steps blocked by a visible validation error upstream. */
+/** Index of the active step when it has async validation in progress, if any. */
+export function findActiveWizardNavStepIndexWithPendingValidation<
+  TFieldValues extends FieldValues,
+>(params: {
+  orderedStepIds: readonly string[];
+  sections: readonly RosaHcpWizardReviewSection[];
+  getFieldState: UseFormGetFieldState<TFieldValues>;
+  activeStepId?: string;
+  asyncValidatingStepIds?: ReadonlySet<string>;
+}): number | undefined {
+  const { orderedStepIds, sections, getFieldState, activeStepId, asyncValidatingStepIds } = params;
+  if (activeStepId === undefined) {
+    return undefined;
+  }
+
+  const activeIndex = orderedStepIds.indexOf(activeStepId);
+  if (activeIndex < 0) {
+    return undefined;
+  }
+
+  const section = sections.find((entry) => entry.id === activeStepId);
+  if (
+    section &&
+    stepHasAsyncValidationInProgress(
+      activeStepId,
+      section.fieldPaths,
+      getFieldState,
+      asyncValidatingStepIds
+    )
+  ) {
+    return activeIndex;
+  }
+
+  return undefined;
+}
+
+function earliestWizardNavStepIndex(
+  ...indices: readonly (number | undefined)[]
+): number | undefined {
+  const defined = indices.filter((index): index is number => index !== undefined);
+  return defined.length > 0 ? Math.min(...defined) : undefined;
+}
+
+/** PatternFly `isDisabled` for leaf nav steps blocked by validation upstream or on the active step. */
 export function buildRosaHcpWizardNavStepDisabledByValidation<
   TFieldValues extends FieldValues,
 >(params: {
@@ -153,12 +221,17 @@ export function buildRosaHcpWizardNavStepDisabledByValidation<
   sections: readonly RosaHcpWizardReviewSection[];
   getFieldState: UseFormGetFieldState<TFieldValues>;
   validationAttemptedStepIds: ReadonlySet<string>;
+  activeStepId?: string;
+  asyncValidatingStepIds?: ReadonlySet<string>;
 }): Readonly<Record<string, boolean>> {
-  const firstErrorIndex = findFirstWizardNavStepIndexWithVisibleErrors(params);
+  const firstBlockingIndex = earliestWizardNavStepIndex(
+    findFirstWizardNavStepIndexWithVisibleErrors(params),
+    findActiveWizardNavStepIndexWithPendingValidation(params)
+  );
   const disabled: Record<string, boolean> = {};
 
   for (const [index, stepId] of params.orderedStepIds.entries()) {
-    disabled[stepId] = firstErrorIndex !== undefined && index > firstErrorIndex;
+    disabled[stepId] = firstBlockingIndex !== undefined && index > firstBlockingIndex;
   }
 
   return disabled;

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/rosaHcpWizardNavStepStatus.ts
@@ -1,0 +1,84 @@
+import type { FieldPath, FieldValues, UseFormGetFieldState } from 'react-hook-form';
+
+import { wizFieldShowsError } from '../components/WizFields/wizFieldRhf';
+import { STEP_IDS } from '../constants';
+import type { RosaHcpWizardReviewSection } from '../Steps/Review/rosaHcpWizardReviewSections.data';
+
+export type RosaHcpWizardNavStepStatus = 'default' | 'error';
+
+const BASIC_SETUP_CHILD_STEP_IDS = [
+  STEP_IDS.DETAILS,
+  STEP_IDS.ROLES_AND_POLICIES,
+  STEP_IDS.MACHINE_POOLS,
+  STEP_IDS.NETWORKING,
+  STEP_IDS.CLUSTER_WIDE_PROXY,
+] as const;
+
+const ADDITIONAL_SETUP_CHILD_STEP_IDS = [STEP_IDS.ENCRYPTION, STEP_IDS.CLUSTER_UPDATES] as const;
+
+/** Wizard steps that participate in nav status (cluster-wide proxy only when enabled). */
+export function buildVisibleWizardStepIds(includeClusterWideProxy: boolean): ReadonlySet<string> {
+  const basicSetupStepIds = BASIC_SETUP_CHILD_STEP_IDS.filter(
+    (id) => includeClusterWideProxy || id !== STEP_IDS.CLUSTER_WIDE_PROXY
+  );
+
+  return new Set([...basicSetupStepIds, ...ADDITIONAL_SETUP_CHILD_STEP_IDS]);
+}
+
+/** True when any field on the step shows a validation error in the form UI. */
+export function stepHasVisibleValidationErrors<TFieldValues extends FieldValues>(
+  fieldPaths: readonly string[],
+  stepId: string,
+  getFieldState: UseFormGetFieldState<TFieldValues>,
+  validationAttemptedStepIds: ReadonlySet<string>
+): boolean {
+  const validationRevealed = validationAttemptedStepIds.has(stepId);
+
+  return fieldPaths.some((path) => {
+    const fieldPath = path as FieldPath<TFieldValues>;
+    const { invalid, isTouched } = getFieldState(fieldPath);
+    return wizFieldShowsError(invalid, isTouched, validationRevealed);
+  });
+}
+
+function parentStepHasChildErrors(
+  childStepIds: readonly string[],
+  statuses: Readonly<Record<string, RosaHcpWizardNavStepStatus>>
+): RosaHcpWizardNavStepStatus {
+  return childStepIds.some((id) => statuses[id] === 'error') ? 'error' : 'default';
+}
+
+/** Maps wizard step ids to PatternFly nav status for visible validation errors. */
+export function buildRosaHcpWizardNavStepStatuses<TFieldValues extends FieldValues>(params: {
+  sections: readonly RosaHcpWizardReviewSection[];
+  getFieldState: UseFormGetFieldState<TFieldValues>;
+  validationAttemptedStepIds: ReadonlySet<string>;
+  visibleStepIds: ReadonlySet<string>;
+}): Record<string, RosaHcpWizardNavStepStatus> {
+  const { sections, getFieldState, validationAttemptedStepIds, visibleStepIds } = params;
+  const statuses: Record<string, RosaHcpWizardNavStepStatus> = {};
+
+  for (const section of sections) {
+    if (!visibleStepIds.has(section.id)) {
+      continue;
+    }
+
+    statuses[section.id] = stepHasVisibleValidationErrors(
+      section.fieldPaths,
+      section.id,
+      getFieldState,
+      validationAttemptedStepIds
+    )
+      ? 'error'
+      : 'default';
+  }
+
+  const basicSetupChildren = BASIC_SETUP_CHILD_STEP_IDS.filter((id) => visibleStepIds.has(id));
+  statuses[STEP_IDS.BASIC_SETUP] = parentStepHasChildErrors(basicSetupChildren, statuses);
+  statuses[STEP_IDS.OPTIONAL_SETUP] = parentStepHasChildErrors(
+    ADDITIONAL_SETUP_CHILD_STEP_IDS,
+    statuses
+  );
+
+  return statuses;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/unvisitWizardNavStepsAfterSource.test.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/unvisitWizardNavStepsAfterSource.test.ts
@@ -1,0 +1,57 @@
+import {
+  unvisitWizardNavStepsAfterSourceIndex,
+  unvisitWizardNavStepsAfterSourcePfIndex,
+} from './unvisitWizardNavStepsAfterSource';
+
+describe('unvisitWizardNavStepsAfterSourcePfIndex', () => {
+  it('unvisits later steps in reverse PatternFly index order, including parent steps', () => {
+    const wizardSteps = [
+      { id: 'basic-setup', index: 1 },
+      { id: 'details', index: 2 },
+      { id: 'roles', index: 3 },
+      { id: 'networking', index: 5 },
+      { id: 'optional-setup', index: 6 },
+      { id: 'review', index: 9 },
+    ] as const;
+    const unvisited: string[] = [];
+
+    unvisitWizardNavStepsAfterSourcePfIndex(wizardSteps, 2, (stepId) => {
+      unvisited.push(stepId);
+    });
+
+    expect(unvisited).toEqual(['review', 'optional-setup', 'networking', 'roles']);
+  });
+
+  it('does nothing when the source PatternFly index is unknown', () => {
+    const unvisited: string[] = [];
+
+    unvisitWizardNavStepsAfterSourcePfIndex([{ id: 'details', index: 2 }], 0, (stepId) => {
+      unvisited.push(stepId);
+    });
+
+    expect(unvisited).toEqual([]);
+  });
+});
+
+describe('unvisitWizardNavStepsAfterSourceIndex', () => {
+  it('unvisits later steps in reverse order', () => {
+    const orderedStepIds = ['details', 'roles', 'networking', 'review'] as const;
+    const unvisited: string[] = [];
+
+    unvisitWizardNavStepsAfterSourceIndex(orderedStepIds, 0, (stepId) => {
+      unvisited.push(stepId);
+    });
+
+    expect(unvisited).toEqual(['review', 'networking', 'roles']);
+  });
+
+  it('does nothing when the source step index is unknown', () => {
+    const unvisited: string[] = [];
+
+    unvisitWizardNavStepsAfterSourceIndex(['details', 'roles'], -1, (stepId) => {
+      unvisited.push(stepId);
+    });
+
+    expect(unvisited).toEqual([]);
+  });
+});

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/unvisitWizardNavStepsAfterSource.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/unvisitWizardNavStepsAfterSource.ts
@@ -1,0 +1,42 @@
+export type WizardStepWithPfIndex = {
+  id: string | number;
+  index: number;
+};
+
+/**
+ * Unvisit PatternFly wizard steps after a source step's 1-based index.
+ * Reverse index order avoids PatternFly `hasVisitedNextStep` keeping earlier steps enabled
+ * when a later step is still visited (including parent container steps).
+ */
+export function unvisitWizardNavStepsAfterSourcePfIndex(
+  wizardSteps: readonly WizardStepWithPfIndex[],
+  sourcePfIndex: number,
+  unvisitStep: (stepId: string) => void
+): void {
+  if (sourcePfIndex < 1) {
+    return;
+  }
+
+  const stepsToUnvisit = wizardSteps
+    .filter((step) => step.index > sourcePfIndex)
+    .sort((left, right) => right.index - left.index);
+
+  for (const step of stepsToUnvisit) {
+    unvisitStep(String(step.id));
+  }
+}
+
+/** @deprecated Use {@link unvisitWizardNavStepsAfterSourcePfIndex} with PatternFly step indices. */
+export function unvisitWizardNavStepsAfterSourceIndex(
+  orderedStepIds: readonly string[],
+  sourceStepIndex: number,
+  unvisitStep: (stepId: string) => void
+): void {
+  if (sourceStepIndex < 0) {
+    return;
+  }
+
+  for (let stepIndex = orderedStepIds.length - 1; stepIndex > sourceStepIndex; stepIndex--) {
+    unvisitStep(orderedStepIds[stepIndex]);
+  }
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useClusterNameUniquenessValidation.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useClusterNameUniquenessValidation.ts
@@ -35,6 +35,7 @@ export function useClusterNameUniquenessValidation({
   const hasInitializedRegionRef = useRef(false);
   const checkClusterNameUniquenessRef = useRef(checkClusterNameUniqueness);
   const uniquenessRequestIdRef = useRef(0);
+  const asyncValidatingRequestIdRef = useRef<number | null>(null);
   const lastCheckedRef = useRef<LastCheckedPair | null>(null);
   checkClusterNameUniquenessRef.current = checkClusterNameUniqueness;
 
@@ -68,14 +69,23 @@ export function useClusterNameUniquenessValidation({
 
     const name = getValues('name');
     const currentRegion = getValues('region');
+    const clearAsyncValidatingIfInFlight = (): void => {
+      if (asyncValidatingRequestIdRef.current !== null) {
+        asyncValidatingRequestIdRef.current = null;
+        setStepAsyncValidating(STEP_IDS.DETAILS, false);
+      }
+    };
+
     if (!hasRefetchableStringValue(name) || !hasRefetchableStringValue(currentRegion)) {
       ++uniquenessRequestIdRef.current;
+      clearAsyncValidatingIfInFlight();
       lastCheckedRef.current = null;
       applyUniqueErrorToForm(null);
       return;
     }
     if (validateClusterNameSync(name, msgs.clusterName)) {
       ++uniquenessRequestIdRef.current;
+      clearAsyncValidatingIfInFlight();
       applyUniqueErrorToForm(null);
       return;
     }
@@ -86,6 +96,7 @@ export function useClusterNameUniquenessValidation({
     }
 
     const requestId = ++uniquenessRequestIdRef.current;
+    asyncValidatingRequestIdRef.current = requestId;
     setStepAsyncValidating(STEP_IDS.DETAILS, true);
     let error: string | null | undefined;
     try {
@@ -93,7 +104,8 @@ export function useClusterNameUniquenessValidation({
     } catch {
       return;
     } finally {
-      if (requestId === uniquenessRequestIdRef.current) {
+      if (asyncValidatingRequestIdRef.current === requestId) {
+        asyncValidatingRequestIdRef.current = null;
         setStepAsyncValidating(STEP_IDS.DETAILS, false);
       }
     }

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useClusterNameUniquenessValidation.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useClusterNameUniquenessValidation.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 
+import { STEP_IDS } from '../constants';
+import { useRosaHcpWizardValidation } from '../rosaHcpWizardValidationContext';
 import { hasRefetchableStringValue } from '../utilities/hasRefetchableStringValue';
 import type { CheckClusterNameUniqueness, ROSAHCPCluster } from '../types';
 import { useRosaHcpWizardValidators } from '../stringsProvider/RosaHcpWizardStringsContext';
@@ -24,6 +26,7 @@ export function useClusterNameUniquenessValidation({
   checkOnNameBlur: () => Promise<void>;
 } {
   const msgs = useRosaHcpWizardValidators();
+  const { setStepAsyncValidating } = useRosaHcpWizardValidation();
   const { control, getValues, setError, clearErrors, getFieldState } =
     useFormContext<Partial<ROSAHCPCluster>>();
   const region = useWatch({ control, name: 'region' });
@@ -83,11 +86,16 @@ export function useClusterNameUniquenessValidation({
     }
 
     const requestId = ++uniquenessRequestIdRef.current;
+    setStepAsyncValidating(STEP_IDS.DETAILS, true);
     let error: string | null | undefined;
     try {
       error = await check(name, currentRegion);
     } catch {
       return;
+    } finally {
+      if (requestId === uniquenessRequestIdRef.current) {
+        setStepAsyncValidating(STEP_IDS.DETAILS, false);
+      }
     }
     if (requestId !== uniquenessRequestIdRef.current) {
       return;
@@ -95,7 +103,7 @@ export function useClusterNameUniquenessValidation({
 
     lastCheckedRef.current = { name, region: currentRegion };
     applyUniqueErrorToForm(error ?? null);
-  }, [applyUniqueErrorToForm, getValues, msgs.clusterName]);
+  }, [applyUniqueErrorToForm, getValues, msgs.clusterName, setStepAsyncValidating]);
 
   const scheduleUniquenessCheck = useCallback(() => {
     clearPendingDebounce();

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
@@ -1,29 +1,27 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useWizardContext } from '@patternfly/react-core';
-import { type FieldPath, useFormContext, useFormState, useWatch } from 'react-hook-form';
+import { type FieldPath, useFormContext, useFormState } from 'react-hook-form';
 
-import { readWatchedFieldValue } from '../fieldMetaChangeEffects/readWatchedFieldValue';
-import { wizardFormFieldValuesEqual } from '../fieldMetaChangeEffects/wizardFormFieldValuesEqual';
 import { useRosaHcpWizardValidation } from '../rosaHcpWizardValidationContext';
 import { useRosaHcpWizardReviewSections } from '../Steps/Review/ROSAHCPWizardReviewSections';
 import type { ROSAHCPCluster } from '../types';
-import { listWizardNavUnvisitSourceFields, wizardFieldMetaByPath } from '../yupSchemas';
-import type { WizardFormFieldName } from '../yupSchemas/types';
 
 import {
   buildOrderedWizardNavStepIds,
   buildRosaHcpWizardNavStepDisabledByValidation,
 } from './rosaHcpWizardNavStepStatus';
+import { unvisitWizardNavStepsAfterSourcePfIndex } from './unvisitWizardNavStepsAfterSource';
 import { useRosaHcpWizardNavStepStatuses } from './useRosaHcpWizardNavStepStatuses';
 
 /** Pushes nav status, visit, and validation-disable state onto PatternFly wizard steps. */
 export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean): void {
   const navStepStatuses = useRosaHcpWizardNavStepStatuses(includeClusterWideProxy);
   const reviewSections = useRosaHcpWizardReviewSections();
-  const { validationAttemptedStepIds, asyncValidatingStepIds } = useRosaHcpWizardValidation();
+  const { validationAttemptedStepIds, asyncValidatingStepIds, registerNavUnvisitApplier } =
+    useRosaHcpWizardValidation();
   const { getFieldState } = useFormContext<Partial<ROSAHCPCluster>>();
   const formState = useFormState<Partial<ROSAHCPCluster>>();
-  const { activeStep, setStep } = useWizardContext();
+  const { activeStep, setStep, steps: wizardSteps } = useWizardContext();
   const activeStepId = String(activeStep.id);
   const parentStepId = 'parentId' in activeStep ? activeStep.parentId : undefined;
 
@@ -69,11 +67,66 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
     statuses: Record<string, string | undefined>;
     disabled: Record<string, boolean | undefined>;
   }>({ statuses: {}, disabled: {} });
+  const prevVisitedStepIdsRef = useRef<Set<string>>(new Set());
+  const maxVisitedPfStepIndexRef = useRef(0);
+
+  const applyNavUnvisit = useCallback(
+    (sourceStepIds: readonly string[]) => {
+      const sourcePfIndices = sourceStepIds
+        .map((stepId) => wizardSteps.find((step) => step.id === stepId)?.index ?? -1)
+        .filter((index) => index > 0);
+      if (sourcePfIndices.length === 0) {
+        return;
+      }
+
+      const sourcePfIndex = Math.min(...sourcePfIndices);
+      maxVisitedPfStepIndexRef.current = sourcePfIndex;
+      unvisitWizardNavStepsAfterSourcePfIndex(wizardSteps, sourcePfIndex, (unvisitStepId) => {
+        setStep({ id: unvisitStepId, isVisited: false });
+        prevVisitedStepIdsRef.current.delete(unvisitStepId);
+      });
+    },
+    [setStep, wizardSteps]
+  );
 
   useEffect(() => {
+    return () => registerNavUnvisitApplier(null);
+  }, [registerNavUnvisitApplier]);
+
+  registerNavUnvisitApplier(applyNavUnvisit);
+
+  useEffect(() => {
+    const visitedStepIds = [activeStepId, parentStepId].filter(
+      (stepId): stepId is string => stepId !== undefined
+    );
+
+    for (const stepId of visitedStepIds) {
+      const pfIndex = wizardSteps.find((step) => step.id === stepId)?.index ?? -1;
+      if (pfIndex > maxVisitedPfStepIndexRef.current) {
+        maxVisitedPfStepIndexRef.current = pfIndex;
+      }
+
+      if (prevVisitedStepIdsRef.current.has(stepId)) {
+        continue;
+      }
+
+      prevVisitedStepIdsRef.current.add(stepId);
+      setStep({ id: stepId, isVisited: true });
+    }
+  }, [activeStepId, parentStepId, setStep, wizardSteps]);
+
+  useEffect(() => {
+    for (const wizardStep of wizardSteps) {
+      if (wizardStep.index > maxVisitedPfStepIndexRef.current && wizardStep.isVisited) {
+        setStep({ id: String(wizardStep.id), isVisited: false });
+        prevVisitedStepIdsRef.current.delete(String(wizardStep.id));
+      }
+    }
+
     const stepIds = new Set([
       ...Object.keys(navStepStatuses),
       ...Object.keys(navStepDisabledByValidation),
+      ...orderedStepIds,
     ]);
 
     for (const stepId of stepIds) {
@@ -96,65 +149,5 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
         ...(isDisabled !== undefined ? { isDisabled } : {}),
       });
     }
-  }, [navStepDisabledByValidation, navStepStatuses, setStep]);
-
-  const prevVisitedStepIdsRef = useRef<Set<string>>(new Set());
-
-  useEffect(() => {
-    const visitedStepIds = [activeStepId, parentStepId].filter(
-      (stepId): stepId is string => stepId !== undefined
-    );
-
-    for (const stepId of visitedStepIds) {
-      if (prevVisitedStepIdsRef.current.has(stepId)) {
-        continue;
-      }
-
-      prevVisitedStepIdsRef.current.add(stepId);
-      setStep({ id: stepId, isVisited: true });
-    }
-  }, [activeStepId, parentStepId, setStep]);
-
-  const unvisitSourceFields = useMemo(() => listWizardNavUnvisitSourceFields(), []);
-  const watchedUnvisitFieldValues = useWatch({
-    name: unvisitSourceFields as FieldPath<Partial<ROSAHCPCluster>>[],
-  });
-  const previousUnvisitFieldValuesRef = useRef<Partial<Record<WizardFormFieldName, unknown>>>({});
-  const hasInitializedUnvisitTrackingRef = useRef(false);
-
-  useEffect(() => {
-    const isInitialPass = !hasInitializedUnvisitTrackingRef.current;
-
-    for (const [index, field] of unvisitSourceFields.entries()) {
-      const currentValue = readWatchedFieldValue(watchedUnvisitFieldValues, index);
-      const previousValue = isInitialPass
-        ? undefined
-        : previousUnvisitFieldValuesRef.current[field];
-
-      if (!isInitialPass && wizardFormFieldValuesEqual(previousValue, currentValue)) {
-        continue;
-      }
-
-      if (!isInitialPass) {
-        const sourceStepId = wizardFieldMetaByPath(field)?.stepId;
-        const sourceStepIndex =
-          sourceStepId !== undefined ? orderedStepIds.indexOf(sourceStepId) : -1;
-
-        if (sourceStepIndex >= 0) {
-          for (
-            let stepIndex = sourceStepIndex + 1;
-            stepIndex < orderedStepIds.length;
-            stepIndex++
-          ) {
-            setStep({ id: orderedStepIds[stepIndex], isVisited: false });
-            prevVisitedStepIdsRef.current.delete(orderedStepIds[stepIndex]);
-          }
-        }
-      }
-
-      previousUnvisitFieldValuesRef.current[field] = currentValue;
-    }
-
-    hasInitializedUnvisitTrackingRef.current = true;
-  }, [orderedStepIds, setStep, unvisitSourceFields, watchedUnvisitFieldValues]);
+  }, [navStepDisabledByValidation, navStepStatuses, orderedStepIds, setStep, wizardSteps]);
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
@@ -43,11 +43,17 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
   );
 
   useEffect(() => {
-    for (const [stepId, status] of Object.entries(navStepStatuses)) {
+    const stepIds = new Set([
+      ...Object.keys(navStepStatuses),
+      ...Object.keys(navStepDisabledByValidation),
+    ]);
+
+    for (const stepId of stepIds) {
+      const status = navStepStatuses[stepId];
       const isDisabled = navStepDisabledByValidation[stepId];
       setStep({
         id: stepId,
-        status,
+        ...(status !== undefined ? { status } : {}),
         ...(isDisabled !== undefined ? { isDisabled } : {}),
       });
     }

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
@@ -20,10 +20,19 @@ import { useRosaHcpWizardNavStepStatuses } from './useRosaHcpWizardNavStepStatus
 export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean): void {
   const navStepStatuses = useRosaHcpWizardNavStepStatuses(includeClusterWideProxy);
   const reviewSections = useRosaHcpWizardReviewSections();
-  const { validationAttemptedStepIds } = useRosaHcpWizardValidation();
+  const { validationAttemptedStepIds, asyncValidatingStepIds } = useRosaHcpWizardValidation();
   const { getFieldState } = useFormContext<Partial<ROSAHCPCluster>>();
   const formState = useFormState<Partial<ROSAHCPCluster>>();
   const { activeStep, setStep } = useWizardContext();
+  const activeStepId = String(activeStep.id);
+  const parentStepId = 'parentId' in activeStep ? activeStep.parentId : undefined;
+
+  const activeStepSection = reviewSections.find((section) => section.id === activeStepId);
+  const isActiveStepValidating =
+    activeStepSection?.fieldPaths.some(
+      (path) => getFieldState(path as FieldPath<Partial<ROSAHCPCluster>>, formState).isValidating
+    ) ?? false;
+  const isActiveStepAsyncValidating = asyncValidatingStepIds.has(activeStepId);
 
   const orderedStepIds = useMemo(
     () => buildOrderedWizardNavStepIds(reviewSections, includeClusterWideProxy),
@@ -38,9 +47,28 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
         getFieldState: (path, state) =>
           getFieldState(path as FieldPath<Partial<ROSAHCPCluster>>, state ?? formState),
         validationAttemptedStepIds,
+        activeStepId,
+        asyncValidatingStepIds,
       }),
-    [formState, getFieldState, orderedStepIds, reviewSections, validationAttemptedStepIds]
+    // isActiveStepValidating/isActiveStepAsyncValidating: RHF formState proxy may keep a stable reference while validation toggles.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- bust memo when active-step async validation runs
+    [
+      activeStepId,
+      asyncValidatingStepIds,
+      formState,
+      getFieldState,
+      isActiveStepAsyncValidating,
+      isActiveStepValidating,
+      orderedStepIds,
+      reviewSections,
+      validationAttemptedStepIds,
+    ]
   );
+
+  const prevNavSyncRef = useRef<{
+    statuses: Record<string, string | undefined>;
+    disabled: Record<string, boolean | undefined>;
+  }>({ statuses: {}, disabled: {} });
 
   useEffect(() => {
     const stepIds = new Set([
@@ -51,6 +79,17 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
     for (const stepId of stepIds) {
       const status = navStepStatuses[stepId];
       const isDisabled = navStepDisabledByValidation[stepId];
+
+      if (
+        prevNavSyncRef.current.statuses[stepId] === status &&
+        prevNavSyncRef.current.disabled[stepId] === isDisabled
+      ) {
+        continue;
+      }
+
+      prevNavSyncRef.current.statuses[stepId] = status;
+      prevNavSyncRef.current.disabled[stepId] = isDisabled;
+
       setStep({
         id: stepId,
         ...(status !== undefined ? { status } : {}),
@@ -59,15 +98,22 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
     }
   }, [navStepDisabledByValidation, navStepStatuses, setStep]);
 
-  useEffect(() => {
-    const activeStepId = String(activeStep.id);
-    setStep({ id: activeStepId, isVisited: true });
+  const prevVisitedStepIdsRef = useRef<Set<string>>(new Set());
 
-    const parentStepId = 'parentId' in activeStep ? activeStep.parentId : undefined;
-    if (parentStepId !== undefined) {
-      setStep({ id: parentStepId, isVisited: true });
+  useEffect(() => {
+    const visitedStepIds = [activeStepId, parentStepId].filter(
+      (stepId): stepId is string => stepId !== undefined
+    );
+
+    for (const stepId of visitedStepIds) {
+      if (prevVisitedStepIdsRef.current.has(stepId)) {
+        continue;
+      }
+
+      prevVisitedStepIdsRef.current.add(stepId);
+      setStep({ id: stepId, isVisited: true });
     }
-  }, [activeStep, setStep]);
+  }, [activeStepId, parentStepId, setStep]);
 
   const unvisitSourceFields = useMemo(() => listWizardNavUnvisitSourceFields(), []);
   const watchedUnvisitFieldValues = useWatch({
@@ -101,6 +147,7 @@ export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean):
             stepIndex++
           ) {
             setStep({ id: orderedStepIds[stepIndex], isVisited: false });
+            prevVisitedStepIdsRef.current.delete(orderedStepIds[stepIndex]);
           }
         }
       }

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useWizardContext } from '@patternfly/react-core';
+
+import { useRosaHcpWizardNavStepStatuses } from './useRosaHcpWizardNavStepStatuses';
+
+/** Pushes computed validation status onto PatternFly wizard nav items. */
+export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean): void {
+  const navStepStatuses = useRosaHcpWizardNavStepStatuses(includeClusterWideProxy);
+  const { setStep } = useWizardContext();
+
+  useEffect(() => {
+    for (const [stepId, status] of Object.entries(navStepStatuses)) {
+      setStep({ id: stepId, status });
+    }
+  }, [navStepStatuses, setStep]);
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStatusSync.ts
@@ -1,16 +1,107 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useWizardContext } from '@patternfly/react-core';
+import { type FieldPath, useFormContext, useFormState, useWatch } from 'react-hook-form';
 
+import { readWatchedFieldValue } from '../fieldMetaChangeEffects/readWatchedFieldValue';
+import { wizardFormFieldValuesEqual } from '../fieldMetaChangeEffects/wizardFormFieldValuesEqual';
+import { useRosaHcpWizardValidation } from '../rosaHcpWizardValidationContext';
+import { useRosaHcpWizardReviewSections } from '../Steps/Review/ROSAHCPWizardReviewSections';
+import type { ROSAHCPCluster } from '../types';
+import { listWizardNavUnvisitSourceFields, wizardFieldMetaByPath } from '../yupSchemas';
+import type { WizardFormFieldName } from '../yupSchemas/types';
+
+import {
+  buildOrderedWizardNavStepIds,
+  buildRosaHcpWizardNavStepDisabledByValidation,
+} from './rosaHcpWizardNavStepStatus';
 import { useRosaHcpWizardNavStepStatuses } from './useRosaHcpWizardNavStepStatuses';
 
-/** Pushes computed validation status onto PatternFly wizard nav items. */
+/** Pushes nav status, visit, and validation-disable state onto PatternFly wizard steps. */
 export function useRosaHcpWizardNavStatusSync(includeClusterWideProxy: boolean): void {
   const navStepStatuses = useRosaHcpWizardNavStepStatuses(includeClusterWideProxy);
-  const { setStep } = useWizardContext();
+  const reviewSections = useRosaHcpWizardReviewSections();
+  const { validationAttemptedStepIds } = useRosaHcpWizardValidation();
+  const { getFieldState } = useFormContext<Partial<ROSAHCPCluster>>();
+  const formState = useFormState<Partial<ROSAHCPCluster>>();
+  const { activeStep, setStep } = useWizardContext();
+
+  const orderedStepIds = useMemo(
+    () => buildOrderedWizardNavStepIds(reviewSections, includeClusterWideProxy),
+    [includeClusterWideProxy, reviewSections]
+  );
+
+  const navStepDisabledByValidation = useMemo(
+    () =>
+      buildRosaHcpWizardNavStepDisabledByValidation({
+        orderedStepIds,
+        sections: reviewSections,
+        getFieldState: (path, state) =>
+          getFieldState(path as FieldPath<Partial<ROSAHCPCluster>>, state ?? formState),
+        validationAttemptedStepIds,
+      }),
+    [formState, getFieldState, orderedStepIds, reviewSections, validationAttemptedStepIds]
+  );
 
   useEffect(() => {
     for (const [stepId, status] of Object.entries(navStepStatuses)) {
-      setStep({ id: stepId, status });
+      const isDisabled = navStepDisabledByValidation[stepId];
+      setStep({
+        id: stepId,
+        status,
+        ...(isDisabled !== undefined ? { isDisabled } : {}),
+      });
     }
-  }, [navStepStatuses, setStep]);
+  }, [navStepDisabledByValidation, navStepStatuses, setStep]);
+
+  useEffect(() => {
+    const activeStepId = String(activeStep.id);
+    setStep({ id: activeStepId, isVisited: true });
+
+    const parentStepId = 'parentId' in activeStep ? activeStep.parentId : undefined;
+    if (parentStepId !== undefined) {
+      setStep({ id: parentStepId, isVisited: true });
+    }
+  }, [activeStep, setStep]);
+
+  const unvisitSourceFields = useMemo(() => listWizardNavUnvisitSourceFields(), []);
+  const watchedUnvisitFieldValues = useWatch({
+    name: unvisitSourceFields as FieldPath<Partial<ROSAHCPCluster>>[],
+  });
+  const previousUnvisitFieldValuesRef = useRef<Partial<Record<WizardFormFieldName, unknown>>>({});
+  const hasInitializedUnvisitTrackingRef = useRef(false);
+
+  useEffect(() => {
+    const isInitialPass = !hasInitializedUnvisitTrackingRef.current;
+
+    for (const [index, field] of unvisitSourceFields.entries()) {
+      const currentValue = readWatchedFieldValue(watchedUnvisitFieldValues, index);
+      const previousValue = isInitialPass
+        ? undefined
+        : previousUnvisitFieldValuesRef.current[field];
+
+      if (!isInitialPass && wizardFormFieldValuesEqual(previousValue, currentValue)) {
+        continue;
+      }
+
+      if (!isInitialPass) {
+        const sourceStepId = wizardFieldMetaByPath(field)?.stepId;
+        const sourceStepIndex =
+          sourceStepId !== undefined ? orderedStepIds.indexOf(sourceStepId) : -1;
+
+        if (sourceStepIndex >= 0) {
+          for (
+            let stepIndex = sourceStepIndex + 1;
+            stepIndex < orderedStepIds.length;
+            stepIndex++
+          ) {
+            setStep({ id: orderedStepIds[stepIndex], isVisited: false });
+          }
+        }
+      }
+
+      previousUnvisitFieldValuesRef.current[field] = currentValue;
+    }
+
+    hasInitializedUnvisitTrackingRef.current = true;
+  }, [orderedStepIds, setStep, unvisitSourceFields, watchedUnvisitFieldValues]);
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStepStatuses.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStepStatuses.ts
@@ -24,8 +24,8 @@ export function useRosaHcpWizardNavStepStatuses(
   useWatch();
 
   const visibleStepIds = useMemo(
-    () => buildVisibleWizardStepIds(includeClusterWideProxy),
-    [includeClusterWideProxy]
+    () => buildVisibleWizardStepIds(reviewSections, includeClusterWideProxy),
+    [includeClusterWideProxy, reviewSections]
   );
 
   return useMemo(

--- a/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStepStatuses.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/hooks/useRosaHcpWizardNavStepStatuses.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react';
+import { type FieldPath, useFormContext, useFormState, useWatch } from 'react-hook-form';
+
+import { useRosaHcpWizardValidation } from '../rosaHcpWizardValidationContext';
+import { useRosaHcpWizardReviewSections } from '../Steps/Review/ROSAHCPWizardReviewSections';
+import type { ROSAHCPCluster } from '../types';
+
+import {
+  buildRosaHcpWizardNavStepStatuses,
+  buildVisibleWizardStepIds,
+  type RosaHcpWizardNavStepStatus,
+} from './rosaHcpWizardNavStepStatus';
+
+/** Reactive nav status for wizard steps (error icons in left nav). */
+export function useRosaHcpWizardNavStepStatuses(
+  includeClusterWideProxy: boolean
+): Record<string, RosaHcpWizardNavStepStatus> {
+  const reviewSections = useRosaHcpWizardReviewSections();
+  const { validationAttemptedStepIds } = useRosaHcpWizardValidation();
+  const { getFieldState } = useFormContext<Partial<ROSAHCPCluster>>();
+  const formState = useFormState<Partial<ROSAHCPCluster>>();
+
+  // Recompute when field values or touched state change.
+  useWatch();
+
+  const visibleStepIds = useMemo(
+    () => buildVisibleWizardStepIds(includeClusterWideProxy),
+    [includeClusterWideProxy]
+  );
+
+  return useMemo(
+    () =>
+      buildRosaHcpWizardNavStepStatuses({
+        sections: reviewSections,
+        getFieldState: (path, state) =>
+          getFieldState(path as FieldPath<Partial<ROSAHCPCluster>>, state ?? formState),
+        validationAttemptedStepIds,
+        visibleStepIds,
+      }),
+    [formState, getFieldState, reviewSections, validationAttemptedStepIds, visibleStepIds]
+  );
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx
@@ -1,5 +1,16 @@
-import { createContext, type ReactNode, useCallback, useContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useRosaHcpWizardReviewSections } from './Steps/Review/ROSAHCPWizardReviewSections';
+
+/** Applies nav unvisit for the earliest source step among the listed wizard step ids. */
+export type RosaHcpNavUnvisitApplier = (sourceStepIds: readonly string[]) => void;
 
 type RosaHcpWizardValidationContextValue = {
   fieldPathToStepId: Readonly<Record<string, string>>;
@@ -12,6 +23,10 @@ type RosaHcpWizardValidationContextValue = {
   setValidationAlertStepId: (
     stepId: string | null | ((prev: string | null) => string | null)
   ) => void;
+  /** Footer registers the PatternFly wizard `setStep` unvisit handler (Wizard context required). */
+  registerNavUnvisitApplier: (applier: RosaHcpNavUnvisitApplier | null) => void;
+  /** Unvisit later nav steps after the earliest listed source step id. */
+  requestNavUnvisitAfterSteps: (sourceStepIds: readonly string[]) => void;
 };
 
 const RosaHcpWizardValidationContext = createContext<RosaHcpWizardValidationContextValue | null>(
@@ -37,6 +52,7 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
   );
   const [asyncValidatingStepIds, setAsyncValidatingStepIds] = useState(() => new Set<string>());
   const [validationAlertStepId, setValidationAlertStepIdState] = useState<string | null>(null);
+  const navUnvisitApplierRef = useRef<RosaHcpNavUnvisitApplier | null>(null);
   const setValidationAlertStepId = useCallback(
     (stepIdOrFn: string | null | ((prev: string | null) => string | null)) => {
       setValidationAlertStepIdState((prev) =>
@@ -88,6 +104,17 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
     });
   }, []);
 
+  const registerNavUnvisitApplier = useCallback((applier: RosaHcpNavUnvisitApplier | null) => {
+    navUnvisitApplierRef.current = applier;
+  }, []);
+
+  const requestNavUnvisitAfterSteps = useCallback((sourceStepIds: readonly string[]) => {
+    if (sourceStepIds.length === 0) {
+      return;
+    }
+    navUnvisitApplierRef.current?.(sourceStepIds);
+  }, []);
+
   const value = useMemo(
     () => ({
       fieldPathToStepId,
@@ -98,12 +125,16 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
       clearValidationAttempted,
       setStepAsyncValidating,
       setValidationAlertStepId,
+      registerNavUnvisitApplier,
+      requestNavUnvisitAfterSteps,
     }),
     [
       asyncValidatingStepIds,
       clearValidationAttempted,
       fieldPathToStepId,
       markValidationAttempted,
+      registerNavUnvisitApplier,
+      requestNavUnvisitAfterSteps,
       setStepAsyncValidating,
       setValidationAlertStepId,
       validationAlertStepId,

--- a/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/rosaHcpWizardValidationContext.tsx
@@ -4,9 +4,11 @@ import { useRosaHcpWizardReviewSections } from './Steps/Review/ROSAHCPWizardRevi
 type RosaHcpWizardValidationContextValue = {
   fieldPathToStepId: Readonly<Record<string, string>>;
   validationAttemptedStepIds: ReadonlySet<string>;
+  asyncValidatingStepIds: ReadonlySet<string>;
   validationAlertStepId: string | null;
   markValidationAttempted: (stepId: string) => void;
   clearValidationAttempted: (stepId: string) => void;
+  setStepAsyncValidating: (stepId: string, isValidating: boolean) => void;
   setValidationAlertStepId: (
     stepId: string | null | ((prev: string | null) => string | null)
   ) => void;
@@ -33,6 +35,7 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
   const [validationAttemptedStepIds, setValidationAttemptedStepIds] = useState(
     () => new Set<string>()
   );
+  const [asyncValidatingStepIds, setAsyncValidatingStepIds] = useState(() => new Set<string>());
   const [validationAlertStepId, setValidationAlertStepIdState] = useState<string | null>(null);
   const setValidationAlertStepId = useCallback(
     (stepIdOrFn: string | null | ((prev: string | null) => string | null)) => {
@@ -65,19 +68,43 @@ export function RosaHcpWizardValidationProvider({ children }: { children: ReactN
     });
   }, []);
 
+  const setStepAsyncValidating = useCallback((stepId: string, isValidating: boolean) => {
+    setAsyncValidatingStepIds((prev) => {
+      if (isValidating) {
+        if (prev.has(stepId)) {
+          return prev;
+        }
+        const next = new Set(prev);
+        next.add(stepId);
+        return next;
+      }
+
+      if (!prev.has(stepId)) {
+        return prev;
+      }
+      const next = new Set(prev);
+      next.delete(stepId);
+      return next;
+    });
+  }, []);
+
   const value = useMemo(
     () => ({
       fieldPathToStepId,
       validationAttemptedStepIds,
+      asyncValidatingStepIds,
       validationAlertStepId,
       markValidationAttempted,
       clearValidationAttempted,
+      setStepAsyncValidating,
       setValidationAlertStepId,
     }),
     [
+      asyncValidatingStepIds,
       clearValidationAttempted,
       fieldPathToStepId,
       markValidationAttempted,
+      setStepAsyncValidating,
       setValidationAlertStepId,
       validationAlertStepId,
       validationAttemptedStepIds,

--- a/packages/nxtcm-rosa-hcp-wizard/src/test/rosaHcpWizardCtSpecHelpers.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/test/rosaHcpWizardCtSpecHelpers.tsx
@@ -1,5 +1,7 @@
+import type { ReactElement } from 'react';
 import rosaHcpWizardFixtures from '../ROSAHCPWizard.fixtures';
 import { useWizardFieldMetaChangeEffects } from '../fieldMetaChangeEffects/useWizardFieldMetaChangeEffects';
+import { RosaHcpWizardValidationProvider } from '../rosaHcpWizardValidationContext';
 
 import type { MachineTypesResource, ROSAHCPWizardData, VpcListResource } from '../types';
 
@@ -67,13 +69,27 @@ type WizardFieldMetaChangeEffectsCtHarnessProps = {
   wizardData: ROSAHCPWizardData;
 };
 
-/**
- * Playwright CT only: mounts {@link useWizardFieldMetaChangeEffects} for step-isolated tests.
- * Production uses the hook directly in {@link ROSAHCPWizardBody}.
- */
-export function WizardFieldMetaChangeEffectsCtHarness({
+/** Runs meta change effects; requires an ancestor {@link RosaHcpWizardValidationProvider}. */
+export function WizardFieldMetaChangeEffectsRunner({
   wizardData,
 }: WizardFieldMetaChangeEffectsCtHarnessProps): null {
   useWizardFieldMetaChangeEffects(wizardData);
   return null;
+}
+
+/**
+ * Playwright CT only: mounts {@link useWizardFieldMetaChangeEffects} for step-isolated tests.
+ * Production uses the hook directly in {@link ROSAHCPWizardBody}.
+ *
+ * Wraps {@link WizardFieldMetaChangeEffectsRunner} with {@link RosaHcpWizardValidationProvider}.
+ * When a parent already provides validation context (Footer/Details CT), use the runner instead.
+ */
+export function WizardFieldMetaChangeEffectsCtHarness({
+  wizardData,
+}: WizardFieldMetaChangeEffectsCtHarnessProps): ReactElement {
+  return (
+    <RosaHcpWizardValidationProvider>
+      <WizardFieldMetaChangeEffectsRunner wizardData={wizardData} />
+    </RosaHcpWizardValidationProvider>
+  );
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/index.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/index.ts
@@ -126,6 +126,7 @@ export {
   listWizardFieldRefetchEntries,
   listWizardFieldResetEntries,
   listWizardFieldSyncEntries,
+  listWizardNavUnvisitSourceFields,
 } from './wizardFieldMetaChangeRegistry';
 export type {
   WizardFieldDerivedSyncEntry,

--- a/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/yupSchemas/wizardFieldMetaChangeRegistry.ts
@@ -129,6 +129,18 @@ export function listWizardFieldMetaChangeSourceFields(): WizardFormFieldName[] {
   return getWizardFieldMetaChangeRegistry().sourceFields;
 }
 
+/** Fields whose change should unvisit later wizard nav steps (reset or refetch metadata). */
+export function listWizardNavUnvisitSourceFields(): WizardFormFieldName[] {
+  const fields = new Set<WizardFormFieldName>();
+  for (const { sourceField } of getWizardFieldMetaChangeRegistry().resetEntries) {
+    fields.add(sourceField);
+  }
+  for (const { sourceField } of getWizardFieldMetaChangeRegistry().refetchEntries) {
+    fields.add(sourceField);
+  }
+  return [...fields].sort((a, b) => a.localeCompare(b));
+}
+
 export function getWizardFieldResetsForSourceField(
   sourceField: WizardFormFieldName
 ): readonly WizardFormFieldName[] {


### PR DESCRIPTION
## Description

Adds left-nav validation feedback to the ROSA HCP wizard: steps with visible validation errors show an error icon, and steps after the first failing step are disabled until the error is resolved. Parent steps (Basic setup, Optional setup) bubble error status from their children.

When a field with reset or refetch metadata changes, later wizard steps are marked unvisited so nav state stays consistent with the updated form.

Here are the exact rules:
1.  All unvisited steps are disabled
2.  Any visited steps are enabled
3.  IF a user changes the value of any field that resetsFieldsToDefaultOnChange, refetchesResourcesOnChange in that field's Yup meta,  all future steps are now considered unvisited.
4.  If any field has a visible validation error all future steps are disabled.  Once the validation error is fixed then all previous rules are applied)

**Jira issue #** [FCN-162](https://redhat.atlassian.net/browse/FCN-162)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Open the ROSA HCP wizard in Storybook and advance through steps without filling required fields; click Next to trigger validation on the active step.
2. Confirm the left nav shows an error icon on the step with visible validation errors and on its parent group step when applicable.
3. Confirm steps after the first failing step are disabled in the left nav until the error is fixed.
4. Change a field that resets or refetches downstream data (e.g. region or cloud provider); confirm later steps are marked unvisited in the nav.
5. Fix validation errors and verify error icons clear and disabled steps become clickable again.

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [x] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

N/A

### Before
<!-- Screenshot or description of the previous behavior -->

Left nav did not reflect per-step validation errors or block navigation past the first failing step.

### After
<!-- Screenshot or description of the new behavior -->

Left nav shows error icons on invalid steps (and parent groups), disables downstream steps until errors are resolved, and unvisits later steps when reset/refetch source fields change.


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->



[FCN-162]: https://redhat.atlassian.net/browse/FCN-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ