### PR TITLE
FCN-539 Hide Left wizard nav while yaml

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.css
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.css
@@ -1,0 +1,7 @@
+.rosa-hcp-wizard--yaml-editor-open .pf-v6-c-wizard__nav {
+  display: none;
+}
+
+.rosa-hcp-wizard--yaml-editor-open .pf-v6-c-wizard__outer-wrap {
+  padding-left: 0;
+}

--- a/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/ROSAHCPWizardBody.tsx
@@ -17,6 +17,7 @@ import { useRosaHcpWizardStrings } from './stringsProvider/RosaHcpWizardStringsC
 import { STEP_IDS } from './constants';
 import type { RosaHCPWizardProps } from './types';
 import { RosaWizardSubmitError } from './RosaWizardSubmitError';
+import './ROSAHCPWizardBody.css';
 
 const RosaHcpYamlEditorStep = lazy(() =>
   import('./Steps/YamlEditor/RosaHcpYamlEditorStep').then((module) => ({
@@ -90,7 +91,9 @@ export const ROSAHCPWizardBody = (props: RosaHCPWizardProps) => {
   }
 
   return (
-    <div>
+    <div
+      className={`rosa-hcp-wizard${isYamlEditorOpen ? ' rosa-hcp-wizard--yaml-editor-open' : ''}`}
+    >
       <Wizard
         height="100vh"
         footer={footer}


### PR DESCRIPTION
## Description

Hides the ROSA HCP wizard left navigation when the YAML editor is open so the editor can use the full width. Applies a modifier class on the wizard wrapper when `isYamlEditorOpen` is true and uses co-located CSS to hide `.pf-v6-c-wizard__nav` and remove left padding on `.pf-v6-c-wizard__outer-wrap`.

This allows the YMAL editor to continue to live within the wizard (aka it is a "hidden" wizard step).  This allows for consistency in design.  This also prevents the wizard from unmounting if the user does go back.    Not the most elegant solution - but the simplest allowing for the most flexibility

**Jira issue #** [FCN-539](https://redhat.atlassian.net/browse/FCN-539)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Open the ROSA HCP wizard in Storybook (or a consuming app).
2. Navigate to the Review step and open the YAML editor.
3. Confirm the left wizard step navigation is hidden and the YAML editor content uses the available width.
4. Close the YAML editor (or navigate to another step) and confirm the left navigation reappears with normal layout.

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

N/A

### Before
<!-- Screenshot or description of the previous behavior -->

Left wizard nav remains visible while the YAML editor is open.

### After
<!-- Screenshot or description of the new behavior -->

Left wizard nav is hidden while the YAML editor is open; layout padding adjusts accordingly.


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->

Uses a BEM-style modifier class (`rosa-hcp-wizard--yaml-editor-open`) on the existing wizard wrapper rather than inline styles, matching PatternFly wizard structure.




[FCN-539]: https://redhat.atlassian.net/browse/FCN-539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ