### PR TITLE
FCN-549 Work with ACM monaco version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "handlebars": "^4.7.8",
         "ip-cidr": "^3.1.0",
         "js-yaml": "^4.1.0",
-        "monaco-yaml": "^5.4.1",
+        "monaco-yaml": "4.0.4",
         "progress": "^2.0.3",
         "react-hook-form": "^7.74.0",
         "yup": "^1.7.1"
@@ -5188,8 +5188,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/mdx": {
       "version": "2.0.13",
@@ -5262,14 +5261,6 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.34",
@@ -7144,16 +7135,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
-      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -11261,19 +11242,6 @@
         "tmpl": "1.0.5"
       }
     },
-    "node_modules/marked": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -11396,29 +11364,11 @@
       }
     },
     "node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
-      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
-      }
-    },
-    "node_modules/monaco-languageserver-types": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/monaco-languageserver-types/-/monaco-languageserver-types-0.4.0.tgz",
-      "integrity": "sha512-QQ3BZiU5LYkJElGncSNb5AKoJ/LCs6YBMCJMAz9EA7v+JaOdn3kx2cXpPTcZfKA5AEsR0vc97sAw+5mdNhVBmw==",
-      "license": "MIT",
-      "dependencies": {
-        "monaco-types": "^0.1.0",
-        "vscode-languageserver-protocol": "^3.0.0",
-        "vscode-uri": "^3.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/remcohaszing"
-      }
+      "peer": true
     },
     "node_modules/monaco-marker-data-provider": {
       "version": "1.2.5",
@@ -11451,21 +11401,20 @@
       }
     },
     "node_modules/monaco-yaml": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-5.4.1.tgz",
-      "integrity": "sha512-YQ6d/Ei98Uk073SJLFbwuSi95qhnl8F8NNmIUqN2XhDt9psZN2LqQ1T7pPQ866NJb2wFj44IrjnANgpa2jTfag==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/monaco-yaml/-/monaco-yaml-4.0.4.tgz",
+      "integrity": "sha512-qbM36fY1twpDUs4lhhxoXDQGUPVyYAFCPJi3E0JKgLioD8wzsD/pawgauFFXSzpMa09z8wbt/DTLXjXEehnVFA==",
       "license": "MIT",
       "workspaces": [
         "examples/*"
       ],
       "dependencies": {
+        "@types/json-schema": "^7.0.0",
         "jsonc-parser": "^3.0.0",
-        "monaco-languageserver-types": "^0.4.0",
         "monaco-marker-data-provider": "^1.0.0",
-        "monaco-types": "^0.1.0",
         "monaco-worker-manager": "^2.0.0",
         "path-browserify": "^1.0.0",
-        "prettier": "^3.0.0",
+        "prettier": "^2.0.0",
         "vscode-languageserver-textdocument": "^1.0.0",
         "vscode-languageserver-types": "^3.0.0",
         "vscode-uri": "^3.0.0",
@@ -11475,7 +11424,22 @@
         "url": "https://github.com/sponsors/remcohaszing"
       },
       "peerDependencies": {
-        "monaco-editor": ">=0.36"
+        "monaco-editor": ">=0.30"
+      }
+    },
+    "node_modules/monaco-yaml/node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/ms": {
@@ -12055,6 +12019,7 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
       "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -15243,25 +15208,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/vscode-jsonrpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
-      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
-      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
-      "license": "MIT",
-      "dependencies": {
-        "vscode-jsonrpc": "8.2.0",
-        "vscode-languageserver-types": "3.17.5"
-      }
-    },
     "node_modules/vscode-languageserver-textdocument": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
@@ -15729,7 +15675,11 @@
     "packages/nxtcm-rosa-hcp-wizard": {
       "name": "@redhat-cloud-services/nxtcm-rosa-hcp-wizard",
       "version": "6.0.0",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@monaco-editor/react": "^4.6.0",
+        "monaco-editor": "^0.34.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "handlebars": "^4.7.8",
     "ip-cidr": "^3.1.0",
     "js-yaml": "^4.1.0",
-    "monaco-yaml": "^5.4.1",
+    "monaco-yaml": "4.0.4",
     "progress": "^2.0.3",
     "react-hook-form": "^7.74.0",
     "yup": "^1.7.1"

--- a/packages/nxtcm-rosa-hcp-wizard/README.md
+++ b/packages/nxtcm-rosa-hcp-wizard/README.md
@@ -1,3 +1,68 @@
 # @redhat-cloud-services/nxtcm-rosa-hcp-wizard
 
-PatternFly wizard component for ROSA HCP cluster creation in ACM and OCM
+PatternFly wizard for ROSA HCP cluster creation in ACM and OCM.
+
+## YAML editor
+
+Pass `yaml` on `RosaHCPWizard` to enable **Edit in YAML** on the Review step and the YAML editor flow.
+
+```tsx
+<RosaHCPWizard yaml onSubmit={...} onCancel={...} wizardData={...} />
+```
+
+## Host integration: `configureRosaHcpMonaco`
+
+The YAML step uses PatternFly `CodeEditor`, which wraps `@monaco-editor/react`. By default that loader fetches Monaco from a **CDN** (jsDelivr). Host apps like ACM already bundle `monaco-editor` via webpack (often a **different version**). Two Monaco instances at runtime causes worker failures, console errors (`Script error.`, `Unexpected usage`), and a broken editor.
+
+Call the exported helper **once before the YAML editor can mount** so PatternFly uses the host’s bundled Monaco instead of the CDN copy:
+
+```tsx
+import { useEffect } from 'react';
+import {
+  RosaHCPWizard,
+  configureRosaHcpMonaco,
+} from '@redhat-cloud-services/nxtcm-rosa-hcp-wizard';
+
+export function RosaHCPWizardPage() {
+  useEffect(() => {
+    configureRosaHcpMonaco();
+  }, []);
+
+  return (
+    <RosaHCPWizard
+      yaml
+      title="Create ROSA HCP cluster"
+      onSubmit={async (data) => {
+        /* create cluster */
+      }}
+      onCancel={() => {
+        /* navigate away */
+      }}
+      wizardData={{
+        /* fetch hooks, validation, etc. */
+      }}
+    />
+  );
+}
+```
+
+Import from the published **`dist`** entry in production. Call `configureRosaHcpMonaco()` on every route that renders `RosaHCPWizard` with `yaml`.
+
+## Peer dependencies
+
+The host must provide (already satisfied in ACM today):
+
+| Package | Purpose |
+| --- | --- |
+| `monaco-editor` | `^0.34.1` — bundled by the host |
+| `@monaco-editor/react` | `^4.6.0` — used by PatternFly CodeEditor and `configureRosaHcpMonaco` |
+
+`monaco-yaml` is **not** shipped in the wizard bundle; it is optional and only loaded in Storybook/Vite dev for schema completion/hover. YAML validation in the wizard uses Ajv and works without it.
+
+## Local development (linked checkout)
+
+When developing against a sibling `nxtcm-components` checkout, the host needs a TypeScript path alias **and** a webpack `resolve.alias` for `@redhat-cloud-services/nxtcm-rosa-hcp-wizard`. Rebuild the wizard after changes:
+
+```bash
+npm run build -w @redhat-cloud-services/nxtcm-rosa-hcp-wizard
+```

--- a/packages/nxtcm-rosa-hcp-wizard/package.json
+++ b/packages/nxtcm-rosa-hcp-wizard/package.json
@@ -24,6 +24,10 @@
     "ui"
   ],
   "private": true,
+  "peerDependencies": {
+    "@monaco-editor/react": "^4.6.0",
+    "monaco-editor": "^0.34.1"
+  },
   "scripts": {
     "prepack": "cp ../../LICENSE LICENSE",
     "postpack": "rm -f LICENSE",

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/YamlEditor/RosaHcpYamlMonacoLoader.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/YamlEditor/RosaHcpYamlMonacoLoader.ts
@@ -1,36 +1,51 @@
 /* eslint-disable class-methods-use-this */
+import type { DiagnosticsOptions, SchemasSettings } from 'monaco-yaml';
 import { type MonacoEditor } from 'monaco-types';
-import { configureMonacoYaml, type MonacoYamlOptions, type SchemasSettings } from 'monaco-yaml';
 
 import rosaControlPlaneSchema from './schemas/rosaControlPlaneSchema.json';
 
-function isYamlWorkerConfigured(): boolean {
+function isMonacoYamlWorkerAvailable(): boolean {
+  // Webpack hosts (e.g. ACM) expose getWorkerUrl with the built-in yaml worker only.
+  // monaco-yaml must not be imported there — its module side effect registers a yaml worker
+  // that conflicts with the host worker and causes "Unexpected usage" / Unexpected token '<'.
   return typeof window !== 'undefined' && typeof window.MonacoEnvironment?.getWorker === 'function';
 }
 
+const defaultDiagnosticsOptions: DiagnosticsOptions = {
+  validate: false,
+  hover: true,
+  completion: true,
+  isKubernetes: true,
+  enableSchemaRequest: false,
+  schemas: [
+    {
+      uri: 'inmemory://rosa-hcp-control-plane-schema.json',
+      fileMatch: ['*'],
+      schema: rosaControlPlaneSchema as SchemasSettings['schema'],
+    },
+  ],
+};
+
 export class RosaHcpYamlMonacoLoader {
-  configure(monaco: MonacoEditor, options?: MonacoYamlOptions): () => void {
-    if (!isYamlWorkerConfigured()) {
+  configure(_monaco: MonacoEditor, options?: DiagnosticsOptions): () => void {
+    if (!isMonacoYamlWorkerAvailable()) {
       return () => undefined;
     }
 
-    const monacoYaml = configureMonacoYaml(monaco, {
-      validate: false,
-      hover: true,
-      completion: true,
-      isKubernetes: true,
-      enableSchemaRequest: false,
-      schemas: [
-        {
-          uri: 'inmemory://rosa-hcp-control-plane-schema.json',
-          fileMatch: ['*'],
-          schema: rosaControlPlaneSchema as SchemasSettings['schema'],
-        },
-      ],
-      ...options,
+    let disposed = false;
+
+    void import('monaco-yaml').then(({ setDiagnosticsOptions }) => {
+      if (disposed) {
+        return;
+      }
+      setDiagnosticsOptions({ ...defaultDiagnosticsOptions, ...options });
     });
+
     return () => {
-      monacoYaml.dispose();
+      disposed = true;
+      void import('monaco-yaml').then(({ setDiagnosticsOptions }) => {
+        setDiagnosticsOptions({ schemas: [] });
+      });
     };
   }
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/YamlEditor/monacoYamlSetup.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/YamlEditor/monacoYamlSetup.ts
@@ -1,17 +1,27 @@
-import editorWorkerUrl from 'monaco-editor/esm/vs/editor/editor.worker.js?url';
-import yamlWorkerUrl from 'monaco-yaml/yaml.worker.js?url';
+function hostProvidesMonacoWorkers(): boolean {
+  const env = window.MonacoEnvironment;
+  return typeof env?.getWorker === 'function' || typeof env?.getWorkerUrl === 'function';
+}
 
 export function setupMonacoEnvironmentIfNeeded(): void {
-  if (typeof window === 'undefined' || typeof window.MonacoEnvironment?.getWorker === 'function') {
+  if (typeof window === 'undefined' || hostProvidesMonacoWorkers()) {
     return;
   }
 
-  window.MonacoEnvironment = {
-    getWorker(_moduleId: string, label: string): Worker {
-      if (label === 'yaml') {
-        return new Worker(yamlWorkerUrl, { type: 'module' });
-      }
-      return new Worker(editorWorkerUrl, { type: 'module' });
-    },
-  };
+  // Dynamic imports only for Vite/Storybook — avoid pulling monaco-yaml into webpack hosts.
+  void (async () => {
+    const [{ default: editorWorkerUrl }, { default: yamlWorkerUrl }] = await Promise.all([
+      import('monaco-editor/esm/vs/editor/editor.worker.js?url'),
+      import('monaco-yaml/yaml.worker.js?url'),
+    ]);
+
+    window.MonacoEnvironment = {
+      getWorker(_moduleId: string, label: string): Worker {
+        if (label === 'yaml') {
+          return new Worker(yamlWorkerUrl, { type: 'module' });
+        }
+        return new Worker(editorWorkerUrl, { type: 'module' });
+      },
+    };
+  })();
 }

--- a/packages/nxtcm-rosa-hcp-wizard/src/index.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/index.ts
@@ -1,4 +1,5 @@
 export { RosaHCPWizard, default } from './ROSAHCPWizard';
+export { configureRosaHcpMonaco } from './monaco/configureRosaHcpMonaco';
 export * from './types';
 export * from './stringsProvider/rosaHcpWizardStrings';
 export {

--- a/packages/nxtcm-rosa-hcp-wizard/src/monaco/configureRosaHcpMonaco.ts
+++ b/packages/nxtcm-rosa-hcp-wizard/src/monaco/configureRosaHcpMonaco.ts
@@ -1,0 +1,16 @@
+import { loader } from '@monaco-editor/react';
+import * as monaco from 'monaco-editor';
+
+let configured = false;
+
+/**
+ * Point PatternFly CodeEditor at the host's bundled Monaco (avoids CDN duplicate).
+ * Call once before the ROSA HCP YAML editor mounts (e.g. when rendering RosaHCPWizard with `yaml`).
+ */
+export function configureRosaHcpMonaco(): void {
+  if (configured || !loader) {
+    return;
+  }
+  loader.config({ monaco });
+  configured = true;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ const libRollupExternal = [
   'js-yaml',
   'yaml',
   /^monaco-editor/,
+  /^@monaco-editor\/.*/,
   /^monaco-yaml/,
 ];
 


### PR DESCRIPTION
## Description

Fixes the ROSA HCP wizard YAML editor when embedded in ACM. PatternFly `CodeEditor` wraps `@monaco-editor/react`, which by default loads Monaco from a CDN (jsDelivr). ACM already bundles `monaco-editor` ^0.34.1 via webpack. Two Monaco instances at runtime cause worker failures, console errors (`Script error.`, `Unexpected usage`), and a broken editor.

This change:

- Exports **`configureRosaHcpMonaco()`** so host apps can point PatternFly's CodeEditor at the host's bundled Monaco before the YAML step mounts.
- Defers **`monaco-yaml`** to dynamic imports and skips worker/schema setup when the host already provides Monaco workers (detected via `MonacoEnvironment.getWorker` / `getWorkerUrl`).
- Downgrades **`monaco-yaml`** from 5.x to **4.0.4** to align with ACM's `monaco-editor` 0.34.x peer range.
- Declares **`monaco-editor`** and **`@monaco-editor/react`** as peer dependencies on the wizard package.
- Externalizes `@monaco-editor/*` in the Vite lib build so Monaco is not bundled into the wizard dist.
- Documents host integration, peer deps, and local linked-checkout workflow in `packages/nxtcm-rosa-hcp-wizard/README.md`.

NOTE: There shouldn't be any functional change to the YAML editor.

**Jira issue #** [FCN-549](https://redhat.atlassian.net/browse/FCN-549)

**Backport of** #


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [x] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. In Storybook/Vite dev (no host Monaco), confirm the YAML editor still works with dynamically loaded workers and optional `monaco-yaml` schema completion.

**Test Environment:**
- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

N/A — integration fix for host Monaco loading; no visible UI change when configured correctly.

### Before
<!-- Screenshot or description of the previous behavior -->
Broken YAML editor in ACM: duplicate Monaco from CDN, worker failures, console errors.

### After
<!-- Screenshot or description of the new behavior -->
YAML editor uses host-bundled Monaco via `configureRosaHcpMonaco()`; no duplicate instance.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [x] I have updated the documentation accordingly
- [x] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [x] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

Host apps that enable the YAML editor must call `configureRosaHcpMonaco()` once before mount and satisfy the new peer dependencies (`monaco-editor` ^0.34.1, `@monaco-editor/react` ^4.6.0). ACM already meets these; this is required integration, not an API break for existing non-YAML usage.


## Additional Notes

See `packages/nxtcm-rosa-hcp-wizard/README.md` for the full host integration guide, including the `configureRosaHcpMonaco()` example and linked-checkout rebuild steps.

`monaco-yaml` remains optional — used only in Storybook/Vite dev for schema completion/hover. Wizard YAML validation uses Ajv and does not require it in production hosts.


## Reviewer Guidelines

### Focus Areas
- `packages/nxtcm-rosa-hcp-wizard/src/monaco/configureRosaHcpMonaco.ts` — host Monaco wiring
- `packages/nxtcm-rosa-hcp-wizard/src/Steps/YamlEditor/RosaHcpYamlMonacoLoader.ts` — dynamic `monaco-yaml` import and host worker detection
- `packages/nxtcm-rosa-hcp-wizard/src/Steps/YamlEditor/monacoYamlSetup.ts` — defer worker setup for webpack hosts
- `packages/nxtcm-rosa-hcp-wizard/README.md` — integration contract for ACM consumers
- `vite.config.ts` — `@monaco-editor/*` externalization
- `package.json` / lockfile — `monaco-yaml` 4.0.4 pin

### Questions for Reviewers
- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-549]: https://redhat.atlassian.net/browse/FCN-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ