### PR TITLE
FCN-540 Set YAML button inline with header

### DIFF
--- a/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.tsx
@@ -3,8 +3,6 @@ import {
   Alert,
   AlertVariant,
   Button,
-  Flex,
-  FlexItem,
   Split,
   SplitItem,
   Stack,
@@ -91,17 +89,21 @@ export const Review = ({ vpcList, onOpenYamlEditor }: ReviewProps) => {
   const rosaStrings = useRosaHcpWizardStrings();
   const { review } = rosaStrings;
 
+  const Label = (
+    <Split hasGutter>
+      <SplitItem isFilled>{review.sectionLabel}</SplitItem>
+      {onOpenYamlEditor ? (
+        <SplitItem>
+          <Button variant="secondary" icon={<PencilAltIcon />} onClick={onOpenYamlEditor}>
+            {review.editInYaml}
+          </Button>
+        </SplitItem>
+      ) : null}
+    </Split>
+  );
+
   return (
-    <Section label={review.sectionLabel} id={STEP_IDS.REVIEW}>
-      {onOpenYamlEditor && (
-        <Flex justifyContent={{ default: 'justifyContentFlexEnd' }} className="pf-v6-u-mb-md">
-          <FlexItem>
-            <Button variant="secondary" icon={<PencilAltIcon />} onClick={onOpenYamlEditor}>
-              {review.editInYaml}
-            </Button>
-          </FlexItem>
-        </Flex>
-      )}
+    <Section label={Label} id={STEP_IDS.REVIEW}>
       <Alert
         variant={AlertVariant.info}
         title={

--- a/packages/nxtcm-rosa-hcp-wizard/src/components/Section.tsx
+++ b/packages/nxtcm-rosa-hcp-wizard/src/components/Section.tsx
@@ -4,7 +4,7 @@ import React, { ReactNode } from 'react';
 
 type SectionProps = {
   id?: string;
-  label: string;
+  label: string | ReactNode;
   description?: ReactNode;
   children?: ReactNode;
   labelHelpTitle?: string;
@@ -12,7 +12,9 @@ type SectionProps = {
 };
 
 export const Section: React.FunctionComponent<SectionProps> = (props) => {
-  const id = props.id ?? props.label?.toLowerCase().split(' ').join('-') ?? '';
+  const id =
+    props.id ??
+    (typeof props.label === 'string' ? props.label.toLowerCase().split(' ').join('-') : '');
 
   return (
     <section id={id} className="pf-v6-c-form__group" role="group">
@@ -21,7 +23,7 @@ export const Section: React.FunctionComponent<SectionProps> = (props) => {
           <SplitItem isFilled>
             <Stack>
               <Split hasGutter>
-                <div className="pf-v6-c-form__section-title">
+                <div className="pf-v6-c-form__section-title pf-v6-u-w-100">
                   {props.label}
                   {props.id && (
                     <LabelHelp


### PR DESCRIPTION
## Description
Moves the **Edit in YAML** button on the ROSA HCP wizard Review step inline with the section header instead of rendering it on its own full-width row below the title.

- **`Review.tsx`**: Builds the section label as a `Split` layout — review title on the left, YAML button on the right — and passes it to `Section` via the `label` prop. Removes the separate `Flex` row that previously pushed the button onto its own line.
- **`Section.tsx`**: Accepts `string | ReactNode` for `label` so callers can supply rich header content. Derives the fallback `id` from string labels only. Adds `pf-v6-u-w-100` to the section title so inline `Split` layouts span the full header width.

**Jira issue #** [FCN-540](https://redhat.atlassian.net/browse/FCN-540)

**Backport of** #


## Type of Change
<!-- Mark the relevant option(s) with an 'x' -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [ ] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing
<!-- Describe how you tested your changes manually -->

**Test Steps:**
1. Open the ROSA HCP wizard and navigate to the Review step.
2. Confirm the **Edit in YAML** button appears on the same row as the Review section title (right-aligned), not on a separate full-width row below it.
3. Click **Edit in YAML** and verify the YAML editor still opens when `onOpenYamlEditor` is provided.
4. Spot-check other wizard steps that use `Section` with a string label — headers should look unchanged.

**Test Environment:**
- [ ] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)
      <!-- Provide link to test run if available -->

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<!-- For UI changes, before/after screenshots are highly recommended -->

### Before
<!-- Screenshot or description of the previous behavior -->
Edit in YAML button rendered below the Review section title on its own row, spanning the full width of the step.

### After
<!-- Screenshot or description of the new behavior -->
Edit in YAML button sits inline with the Review section title, aligned to the right of the header row.
<img width="1161" height="306" alt="Screenshot 2026-06-19 at 9 01 31 AM" src="https://github.com/user-attachments/assets/f1484bbd-4ca3-415a-8034-11fce5b7b5fb" />


## Checklist
<!-- Ensure you've completed the following before requesting review -->

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [ ] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [ ] I have updated the documentation accordingly
- [ ] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [x] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [ ] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes
<!-- If this PR introduces breaking changes, describe them here -->
<!-- Include migration steps for users -->

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No

<!-- If yes, describe what breaks and how to migrate: -->


## Additional Notes
<!-- Add any additional context, concerns, or discussion points -->


## Reviewer Guidelines
<!-- Guidance for reviewers -->

### Focus Areas
<!-- Specific areas where you'd like reviewer attention -->
- `packages/nxtcm-rosa-hcp-wizard/src/Steps/Review/Review.tsx` — inline YAML button layout via `Split`
- `packages/nxtcm-rosa-hcp-wizard/src/components/Section.tsx` — `ReactNode` label support and full-width section title

### Questions for Reviewers
<!-- Any specific questions or concerns you'd like reviewers to address -->
- 

---
<!-- Thank you for contributing to nxtcm-components! -->


[FCN-540]: https://redhat.atlassian.net/browse/FCN-540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ