### PR TITLE
FCN-560 - Add CI check for consistent peer dep versions across workspaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check peer dependency version consistency
+        run: node scripts/check-peer-dep-versions.mjs
+
       - name: Run ESLint
         run: npm run lint
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "semver": "^7.7.4",
-    "yaml": "^2.8.1"
+    "yaml": "^2.8.3"
   },
   "scripts": {
     "start": "vite",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "test:ct:debug": "playwright test -c playwright-ct.config.ts --debug",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "check:peers": "node scripts/check-peer-dep-versions.mjs",
     "allthethings": "npm run prettier:fix && npm run lint:fix && npm run type-check && npm run test && npm run test:ct",
     "prepare": "husky"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     },
     {
       "description": "Group PatternFly packages across all workspaces",
-      "matchPackagePatterns": ["@patternfly/*"],
+      "matchPackageNames": ["@patternfly/**"],
       "groupName": "patternfly"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,16 @@
       "description": "Disable all major updates",
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "description": "Group PatternFly packages across all workspaces",
+      "matchPackagePatterns": ["@patternfly/*"],
+      "groupName": "patternfly"
+    },
+    {
+      "description": "Group React packages across all workspaces",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"],
+      "groupName": "react"
     }
   ],
   "reviewers": ["nitin-dhevar", "kdoberst", "davidaznaur", "jloss-redhat", "vishsanghishetty", "brandonthanhnguyen"],

--- a/scripts/check-peer-dep-versions.mjs
+++ b/scripts/check-peer-dep-versions.mjs
@@ -5,8 +5,10 @@
  * package.json. exits with code 1 if any shared dep has a different version
  * range than what the root declares.
  *
- * source of truth: root peerDependencies + devDependencies.
- * only checks deps that exist in BOTH root and workspace peerDependencies.
+ * source of truth: root devDependencies (wins) merged over root peerDependencies.
+ * only flags a dep if it exists in both the root (peer or dev) AND a workspace's
+ * peerDependencies. if the same package appears in both root peer and dev with
+ * different ranges, the devDependencies range takes precedence.
  */
 
 import { readFileSync } from 'node:fs';

--- a/scripts/check-peer-dep-versions.mjs
+++ b/scripts/check-peer-dep-versions.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+/**
+ * compares peerDependency versions in workspace packages against the root
+ * package.json. exits with code 1 if any shared dep has a different version
+ * range than what the root declares.
+ *
+ * source of truth: root peerDependencies + devDependencies.
+ * only checks deps that exist in BOTH root and workspace peerDependencies.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const rootVersions = {
+  ...rootPkg.peerDependencies,
+  ...rootPkg.devDependencies,
+};
+
+const workspaces = rootPkg.workspaces || [];
+const errors = [];
+
+for (const wsPath of workspaces) {
+  const pkgPath = join(wsPath, 'package.json');
+  let wsPkg;
+
+  try {
+    wsPkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+  } catch {
+    continue;
+  }
+
+  const peerDeps = wsPkg.peerDependencies;
+  if (!peerDeps) continue;
+
+  for (const [dep, version] of Object.entries(peerDeps)) {
+    if (rootVersions[dep] && rootVersions[dep] !== version) {
+      errors.push(`  ${wsPath}: ${dep} is "${version}" but root has "${rootVersions[dep]}"`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Peer dependency version mismatch detected:\n');
+  console.error(errors.join('\n'));
+  console.error('\nUpdate workspace peerDependencies to match the root package.json.');
+  process.exit(1);
+} else {
+  console.log('Peer dependency versions are consistent across all workspaces.');
+}

--- a/scripts/check-peer-dep-versions.mjs
+++ b/scripts/check-peer-dep-versions.mjs
@@ -27,7 +27,9 @@ for (const wsPath of workspaces) {
 
   try {
     wsPkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
-  } catch {
+  } catch (err) {
+    console.warn(`  warning: could not read ${pkgPath} (${err.message})`);
+    errors.push(`  ${wsPath}: package.json is unreadable or missing`);
     continue;
   }
 

--- a/scripts/check-peer-dep-versions.mjs
+++ b/scripts/check-peer-dep-versions.mjs
@@ -5,10 +5,14 @@
  * package.json. exits with code 1 if any shared dep has a different version
  * range than what the root declares.
  *
- * source of truth: root devDependencies (wins) merged over root peerDependencies.
- * only flags a dep if it exists in both the root (peer or dev) AND a workspace's
- * peerDependencies. if the same package appears in both root peer and dev with
- * different ranges, the devDependencies range takes precedence.
+ * source of truth (merge order, last wins):
+ *   1. root peerDependencies
+ *   2. root dependencies
+ *   3. root devDependencies
+ *
+ * only flags a dep if it exists in both the root AND a workspace's
+ * peerDependencies. if the same package appears in multiple root sections
+ * with different ranges, the devDependencies range takes precedence.
  */
 
 import { readFileSync } from 'node:fs';
@@ -17,6 +21,7 @@ import { join } from 'node:path';
 const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'));
 const rootVersions = {
   ...rootPkg.peerDependencies,
+  ...rootPkg.dependencies,
   ...rootPkg.devDependencies,
 };
 

--- a/scripts/check-peer-dep-versions.mjs
+++ b/scripts/check-peer-dep-versions.mjs
@@ -5,28 +5,57 @@
  * package.json. exits with code 1 if any shared dep has a different version
  * range than what the root declares.
  *
- * source of truth (merge order, last wins):
- *   1. root peerDependencies
- *   2. root dependencies
- *   3. root devDependencies
+ * validation steps:
+ *   1. check root internal consistency: peerDependencies vs devDependencies
+ *   2. compare workspace peerDependencies against root peerDependencies
  *
- * only flags a dep if it exists in both the root AND a workspace's
- * peerDependencies. if the same package appears in multiple root sections
- * with different ranges, the devDependencies range takes precedence.
+ * source of truth for workspace comparison (merge order, last wins):
+ *   1. root dependencies
+ *   2. root devDependencies
+ *   3. root peerDependencies (takes precedence - this is the public contract)
+ *
+ * rationale: if root declares a peerDependency, that's what workspaces AND
+ * consuming apps must satisfy. root devDependencies should match peerDeps
+ * to ensure we develop against the same versions we ask consumers to provide.
  */
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const rootPkg = JSON.parse(readFileSync('package.json', 'utf8'));
+const errors = [];
+
+// Step 1: Check root internal consistency (peer vs dev)
+const peerDeps = rootPkg.peerDependencies || {};
+const devDeps = rootPkg.devDependencies || {};
+
+for (const [dep, peerVersion] of Object.entries(peerDeps)) {
+  if (devDeps[dep] && devDeps[dep] !== peerVersion) {
+    errors.push(
+      `  root: ${dep} is "${peerVersion}" in peerDependencies but "${devDeps[dep]}" in devDependencies`
+    );
+  }
+}
+
+if (errors.length > 0) {
+  console.error('Root peer/dev dependency version mismatch detected:\n');
+  console.error(errors.join('\n'));
+  console.error('\nUpdate root package.json so peerDependencies and devDependencies match.');
+  console.error(
+    'We develop against devDependencies but ask consumers to satisfy peerDependencies.'
+  );
+  process.exit(1);
+}
+
+// Step 2: Build source of truth (peerDependencies take precedence)
 const rootVersions = {
-  ...rootPkg.peerDependencies,
   ...rootPkg.dependencies,
   ...rootPkg.devDependencies,
+  ...rootPkg.peerDependencies,
 };
 
 const workspaces = rootPkg.workspaces || [];
-const errors = [];
+errors.length = 0; // reset for workspace checks
 
 for (const wsPath of workspaces) {
   const pkgPath = join(wsPath, 'package.json');


### PR DESCRIPTION
## Description

Add a CI check that catches PF/React peer dependency version drift between workspace packages and the root package.json. When renovate bumps a version in root but not in a workspace's peerDependencies, CI will now fail with a clear error.

The check runs in two steps:
1. **Root consistency** — verifies that any package appearing in both `peerDependencies` and `devDependencies` has the same range. This ensures we develop against the same versions we ask consumers to provide.
2. **Workspace alignment** — compares each workspace's `peerDependencies` against the root source of truth (`dependencies` + `devDependencies` + `peerDependencies`, with peer taking final precedence).

Also adds renovate package grouping rules so PF and React updates land in a single PR across all workspaces, preventing renovate-caused drift in the first place. Fixes an existing `yaml` mismatch on main (peer had `^2.8.1`, dev had `^2.8.3`).

Follow-up from FCN-356 code review where Roberto noted versions could drift.

**Jira issue #** [FCN-560](https://redhat.atlassian.net/browse/FCN-560)

**Backport of** N/A


## Type of Change

- [x] Infrastructure/build change
- [x] Configuration change


## What's included

1. **`scripts/check-peer-dep-versions.mjs`** — CI script with two-step validation:
   - Step 1: Root internal consistency check (fails if `peerDependencies` and `devDependencies` declare different ranges for the same package)
   - Step 2: Workspace alignment check (fails if any workspace peerDep differs from root)
   - Source of truth merge order: `dependencies` → `devDependencies` → `peerDependencies` (peer wins)
2. **`.github/workflows/ci.yml`** — adds the check as a step in the lint job (runs after lockfile git-dep check).
3. **`renovate.json`** — groups `@patternfly/*` and `react`/`react-dom` packages so renovate updates them together across all workspaces in a single PR.
4. **`package.json`** — adds `check:peers` npm script for local use; fixes `yaml` peerDep range to match devDep (`^2.8.1` → `^2.8.3`).


## Testing

### Manual Testing

**Test Steps:**
1. Run `node scripts/check-peer-dep-versions.mjs` with aligned versions — passes
2. Temporarily set dashboard `react` peerDep to `^19.0.0` (root has `^18.2.0`) — script exits 1 with clear error
3. Fork CI validation (both scenarios):
   - Pass: https://github.com/vishsanghishetty/nxtcm-components/pull/4
   - Fail: https://github.com/vishsanghishetty/nxtcm-components/pull/3

**Root peer-vs-dev consistency check (Brandon #2 / Kim #2):**
```
# simulated root yaml peer ^2.7.0 vs dev ^2.8.3

$ node scripts/check-peer-dep-versions.mjs
Root peer/dev dependency version mismatch detected:

  root: yaml is "^2.7.0" in peerDependencies but "^2.8.3" in devDependencies

Update root package.json so peerDependencies and devDependencies match.
We develop against devDependencies but ask consumers to satisfy peerDependencies.
```

**Root `dependencies` included in source of truth (Brandon #1):**
```
# simulated a dashboard peerDep that only exists in root dependencies
# (e.g. @patternfly/react-icons ^6.0.0 vs root dependencies ^6.3.1)

$ node scripts/check-peer-dep-versions.mjs
Peer dependency version mismatch detected:

  packages/nxtcm-dashboard: @patternfly/react-icons is "^6.0.0" but root has "^6.3.1"

Update workspace peerDependencies to match the root package.json.
```

**`npm run check:peers` for local use (Kim #4):**
```
$ npm run check:peers

> nxtcm-components@6.0.0 check:peers
> node scripts/check-peer-dep-versions.mjs

Peer dependency versions are consistent across all workspaces.
```

4. Renovate config validated: valid JSON, correct schema, group rules have required `matchPackageNames` + `groupName` fields

**Test Environment:**
- [x] Tested locally

### Automated Testing

**Unit Tests:**
- [x] All unit tests pass (npm run test — 302 tests)
- [x] ESLint, Prettier, TypeScript all pass

**Integration Tests:**
- N/A


## Screenshots/Recordings

N/A — infrastructure change, no UI.


## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors

### Documentation
- [x] Script has JSDoc explaining its purpose, validation steps, and merge order

### Dependencies
- [x] No new dependencies added


## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No


[FCN-560]: https://redhat.atlassian.net/browse/FCN-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ