### PR TITLE
FCN-561: replace custom CSS with PF v6 tokens in legacy dashboard widgets

### DIFF
--- a/packages/nxtcm-dashboard/src/CVECard/CVECard.module.scss
+++ b/packages/nxtcm-dashboard/src/CVECard/CVECard.module.scss
@@ -1,3 +1,8 @@
+.container {
+  height: 100%;
+  padding: var(--pf-t--global--spacer--md);
+}
+
 .description {
   font-size: var(--pf-t--global--font--size--sm);
 }

--- a/packages/nxtcm-dashboard/src/CVECard/CVECard.tsx
+++ b/packages/nxtcm-dashboard/src/CVECard/CVECard.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, FlexItem, Skeleton } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Skeleton, Title } from '@patternfly/react-core';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import React from 'react';
@@ -45,13 +45,12 @@ export const CVECard: React.FC<CVECardProps> = ({
   const showSkeleton = !!isLoading;
 
   return (
-    <Flex
-      direction={{ default: 'column' }}
-      style={{ height: '100%', padding: '1rem' }}
-      className={className}
-    >
-      {/* TODO: consider making this a heading */}
-      <FlexItem>{title}</FlexItem>
+    <Flex direction={{ default: 'column' }} className={`${styles.container} ${className ?? ''}`}>
+      <FlexItem>
+        <Title headingLevel="h3" size="md">
+          {title}
+        </Title>
+      </FlexItem>
       <FlexItem flex={{ default: 'flex_1' }}>
         {showSkeleton ? (
           <FlexItem>
@@ -116,7 +115,11 @@ export const CVECard: React.FC<CVECardProps> = ({
                           alignItems={{ default: 'alignItemsCenter' }}
                           spaceItems={{ default: 'spaceItemsXs' }}
                         >
-                          <Icon color={config.iconColor} className={styles.severityIcon} />
+                          <Icon
+                            color={config.iconColor}
+                            className={styles.severityIcon}
+                            aria-hidden="true"
+                          />
                           <span className={countClassName}>{data.count}</span>
                         </Flex>
                       </FlexItem>

--- a/packages/nxtcm-dashboard/src/ClusterRecommendations/Critical.module.scss
+++ b/packages/nxtcm-dashboard/src/ClusterRecommendations/Critical.module.scss
@@ -1,7 +1,12 @@
+.container {
+  padding: var(--pf-t--global--spacer--md);
+}
+
 .danger {
-  padding-top: var(--pf-t--global--spacer--xl) !important;
+  padding-top: var(--pf-t--global--spacer--xl);
   color: var(--pf-t--global--text--color--status--danger--default);
   font-size: var(--pf-t--global--font--size--heading--h2);
+
   svg {
     color: var(--pf-t--global--icon--color--status--danger--default);
   }

--- a/packages/nxtcm-dashboard/src/ClusterRecommendations/Critical.tsx
+++ b/packages/nxtcm-dashboard/src/ClusterRecommendations/Critical.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Button, Content, Flex, FlexItem, Title } from '@patternfly/react-core';
 import { CriticalRiskIcon } from '@patternfly/react-icons';
 
 import styles from './Critical.module.scss';
@@ -9,15 +9,19 @@ export type CriticalProps = {
 };
 
 export const Critical = ({ count, onViewRecommendations }: CriticalProps) => (
-  <Flex direction={{ default: 'column' }} style={{ padding: '1rem' }}>
+  <Flex direction={{ default: 'column' }} className={styles.container}>
     <FlexItem>
-      <h3>Critical recommendations</h3>
+      <Title headingLevel="h3" size="md">
+        Critical recommendations
+      </Title>
     </FlexItem>
     <FlexItem>
-      <p>Conditions that cause issues have been detected actively detected on your systems.</p>
+      <Content component="p">
+        Conditions that cause issues have been actively detected on your systems.
+      </Content>
       <Flex direction={{ default: 'column' }} alignItems={{ default: 'alignItemsCenter' }}>
         <FlexItem className={styles.danger}>
-          <CriticalRiskIcon /> {count}
+          <CriticalRiskIcon aria-hidden="true" /> {count}
         </FlexItem>
         <FlexItem>Critical recommendations</FlexItem>
         {count > 0 && (

--- a/packages/nxtcm-dashboard/src/ClusterRecommendations/RecommendationByCategory.module.scss
+++ b/packages/nxtcm-dashboard/src/ClusterRecommendations/RecommendationByCategory.module.scss
@@ -1,37 +1,22 @@
+.container {
+  padding: var(--pf-t--global--spacer--md);
+}
+
 .bar {
   padding-top: var(--pf-t--global--spacer--xl);
+  width: 100%;
+
   div {
     display: inline-block;
   }
-  width: 100%;
+}
+
+.barSegment {
+  display: inline-block;
 }
 
 .legend {
   svg {
-    margin-right: 0.2em;
+    margin-right: var(--pf-t--global--spacer--xs);
   }
-}
-
-.serviceAvailability {
-  //background-color: var(--pf-v6-chart-color-blue-300);
-  background-color: #92c5f9;
-  color: #92c5f9;
-}
-
-.performance {
-  // background-color: var(--pf-v6-chart-color-blue-100);
-  background-color: #0066cc;
-  color: #0066cc;
-}
-
-.security {
-  // background-color: var(--pf-v6-chart-color-yellow-300);
-  background-color: #ffcc17;
-  color: #ffcc17;
-}
-
-.faultTolerance {
-  // background-color: var(--pf-v6-chart-color-yellow-100);
-  background-color: #b98412;
-  color: #b98412;
 }

--- a/packages/nxtcm-dashboard/src/ClusterRecommendations/RecommendationByCategory.tsx
+++ b/packages/nxtcm-dashboard/src/ClusterRecommendations/RecommendationByCategory.tsx
@@ -1,5 +1,6 @@
-import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Title } from '@patternfly/react-core';
 import { SquareFullIcon } from '@patternfly/react-icons';
+import { ChartThemeColor, getTheme } from '@patternfly/react-charts/victory';
 
 import styles from './RecommendationByCategory.module.scss';
 
@@ -13,6 +14,13 @@ export type RecommendationByCategoryProps = {
   onCategoryClick: (category: Category) => void;
 };
 
+const categories: { key: Category; label: string }[] = [
+  { key: 'serviceAvailability', label: 'Service availability' },
+  { key: 'performance', label: 'Performance' },
+  { key: 'security', label: 'Security' },
+  { key: 'faultTolerance', label: 'Fault tolerance' },
+];
+
 export const RecommendationByCategory = ({
   serviceAvailability,
   performance,
@@ -20,58 +28,48 @@ export const RecommendationByCategory = ({
   faultTolerance,
   onCategoryClick,
 }: RecommendationByCategoryProps) => {
+  const counts: Record<Category, number> = {
+    serviceAvailability,
+    performance,
+    security,
+    faultTolerance,
+  };
   const total = serviceAvailability + performance + security + faultTolerance;
+
+  const blueTheme = getTheme(ChartThemeColor.blue);
+  const categoryColors = (blueTheme.chart?.colorScale?.slice(0, 4) ?? []) as string[];
+
   return (
-    <Flex direction={{ default: 'column' }} style={{ padding: '1rem' }}>
+    <Flex direction={{ default: 'column' }} className={styles.container}>
       <FlexItem>
-        <h3>Recommendation by Category</h3>
+        <Title headingLevel="h3" size="md">
+          Recommendation by Category
+        </Title>
       </FlexItem>
       <FlexItem flex={{ default: 'flex_1' }}>
         <Flex className={styles.legend}>
-          <FlexItem>
-            <SquareFullIcon className={styles.serviceAvailability} />
-            <Button onClick={() => onCategoryClick('serviceAvailability')} variant="link">
-              Service availability: {serviceAvailability}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <SquareFullIcon className={styles.performance} />
-            <Button onClick={() => onCategoryClick('performance')} variant="link">
-              Performance: {performance}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <SquareFullIcon className={styles.security} />
-            <Button onClick={() => onCategoryClick('security')} variant="link">
-              Security: {security}
-            </Button>
-          </FlexItem>
-          <FlexItem>
-            <SquareFullIcon className={styles.faultTolerance} />
-            <Button onClick={() => onCategoryClick('faultTolerance')} variant="link">
-              Fault tolerance: {faultTolerance}
-            </Button>
-          </FlexItem>
+          {categories.map((cat, idx) => (
+            <FlexItem key={cat.key}>
+              <SquareFullIcon style={{ color: categoryColors[idx] }} aria-hidden="true" />
+              <Button onClick={() => onCategoryClick(cat.key)} variant="link" isInline>
+                {cat.label}: {counts[cat.key]}
+              </Button>
+            </FlexItem>
+          ))}
         </Flex>
-        <div className={styles.bar}>
-          <div
-            className={styles.serviceAvailability}
-            style={{ width: `${(serviceAvailability / total) * 100}%` }}
-          >
-            &nbsp;
-          </div>
-          <div className={styles.performance} style={{ width: `${(performance / total) * 100}%` }}>
-            &nbsp;
-          </div>
-          <div className={styles.security} style={{ width: `${(security / total) * 100}%` }}>
-            &nbsp;
-          </div>
-          <div
-            className={styles.faultTolerance}
-            style={{ width: `${(faultTolerance / total) * 100}%` }}
-          >
-            &nbsp;
-          </div>
+        <div className={styles.bar} role="img" aria-label="Recommendation category distribution">
+          {categories.map((cat, idx) => {
+            const pct = total > 0 ? (counts[cat.key] / total) * 100 : 0;
+            return (
+              <div
+                key={cat.key}
+                className={styles.barSegment}
+                style={{ width: `${pct}%`, backgroundColor: categoryColors[idx] }}
+              >
+                &nbsp;
+              </div>
+            );
+          })}
         </div>
       </FlexItem>
     </Flex>

--- a/packages/nxtcm-dashboard/src/NotificationsPanel/NotificationsPanel.module.scss
+++ b/packages/nxtcm-dashboard/src/NotificationsPanel/NotificationsPanel.module.scss
@@ -1,7 +1,7 @@
 .header {
   display: flex;
   align-items: center;
-  gap: var(--pf-v6-global--spacer--sm);
+  gap: var(--pf-t--global--spacer--sm);
 }
 
 .headerTitle {
@@ -13,26 +13,14 @@
 }
 
 .notificationTitle {
-  color: var(--pf-v6-global--link--Color);
+  color: var(--pf-t--global--text--color--link--default);
 }
 
 .clickableRow {
   cursor: pointer;
 }
 
-.paginationContainer {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  padding: var(--pf-v6-global--spacer--sm) var(--pf-v6-global--spacer--md);
-  border-top: var(--pf-v6-global--BorderWidth--sm) solid var(--pf-v6-global--BorderColor--100);
-  gap: var(--pf-v6-global--spacer--sm);
-}
-
-.paginationText {
-  font-size: var(--pf-t--global--font--size--body--sm);
-}
-
-.paginationButton {
-  padding: var(--pf-v6-global--spacer--xs) var(--pf-v6-global--spacer--sm);
+.paginationWrapper {
+  padding-top: var(--pf-t--global--spacer--sm);
+  border-top: 1px solid var(--pf-t--global--border--color--default);
 }

--- a/packages/nxtcm-dashboard/src/NotificationsPanel/NotificationsPanel.tsx
+++ b/packages/nxtcm-dashboard/src/NotificationsPanel/NotificationsPanel.tsx
@@ -1,9 +1,10 @@
 import {
-  Button,
   EmptyState,
   EmptyStateBody,
   Flex,
   FlexItem,
+  Pagination,
+  PaginationVariant,
   Panel,
   PanelHeader,
   PanelMain,
@@ -13,7 +14,7 @@ import {
 } from '@patternfly/react-core';
 import BellIcon from '@patternfly/react-icons/dist/esm/icons/bell-icon';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './NotificationsPanel.module.scss';
 
 export type NotificationType = 'Security' | 'Advisor' | 'Update risks' | 'Status';
@@ -44,12 +45,21 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
   isLoading,
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
+  const [perPage, setPerPage] = useState(itemsPerPage);
 
   const totalItems = notifications?.length ?? 0;
-  const totalPages = Math.ceil(totalItems / itemsPerPage);
+  const totalPages = Math.max(1, Math.ceil(totalItems / perPage));
 
-  const startIndex = (currentPage - 1) * itemsPerPage;
-  const endIndex = Math.min(startIndex + itemsPerPage, totalItems);
+  useEffect(() => {
+    setPerPage(itemsPerPage);
+  }, [itemsPerPage]);
+
+  useEffect(() => {
+    setCurrentPage((prev) => Math.min(prev, totalPages));
+  }, [totalPages]);
+
+  const startIndex = (currentPage - 1) * perPage;
+  const endIndex = Math.min(startIndex + perPage, totalItems);
   const currentNotifications =
     notifications && (enablePagination ? notifications.slice(startIndex, endIndex) : notifications);
 
@@ -59,18 +69,6 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
     }
     if (onNotificationClick) {
       onNotificationClick(notification);
-    }
-  };
-
-  const handleNextPage = () => {
-    if (currentPage < totalPages) {
-      setCurrentPage(currentPage + 1);
-    }
-  };
-
-  const handlePrevPage = () => {
-    if (currentPage > 1) {
-      setCurrentPage(currentPage - 1);
     }
   };
 
@@ -84,7 +82,7 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
             </span>
           </div>
           <div className={styles.headerBadge}>
-            <BellIcon />
+            <BellIcon aria-hidden="true" />
             &nbsp;
             <Skeleton width="24px" height="16px" />
           </div>
@@ -132,7 +130,7 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
   const renderBody = () => {
     if (currentNotifications && currentNotifications.length > 0) {
       return (
-        <Table variant="compact" borders={false}>
+        <Table variant="compact" borders={false} aria-label="Notifications">
           <Thead>
             <Tr>
               <Th>Notification</Th>
@@ -190,7 +188,7 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
           </span>
         </div>
         <div className={styles.headerBadge}>
-          <BellIcon />
+          <BellIcon aria-hidden="true" />
           &nbsp;
           <span data-testid="notification-count">{totalItems}</span>
         </div>
@@ -198,29 +196,20 @@ export const NotificationsPanel: React.FC<NotificationsPanelProps> = ({
       <PanelMain>
         <PanelMainBody>
           {renderBody()}
-          {enablePagination && totalPages > 1 && (
-            <div className={styles.paginationContainer}>
-              <span className={styles.paginationText}>
-                {startIndex + 1} - {endIndex} of {totalItems}
-              </span>
-              <Button
-                variant="plain"
-                aria-label="Previous page"
-                isDisabled={currentPage === 1}
-                onClick={handlePrevPage}
-                className={styles.paginationButton}
-              >
-                &#9650;
-              </Button>
-              <Button
-                variant="plain"
-                aria-label="Next page"
-                isDisabled={currentPage === totalPages}
-                onClick={handleNextPage}
-                className={styles.paginationButton}
-              >
-                &#9660;
-              </Button>
+          {enablePagination && totalItems > perPage && (
+            <div className={styles.paginationWrapper}>
+              <Pagination
+                itemCount={totalItems}
+                perPage={perPage}
+                page={currentPage}
+                onSetPage={(_evt, page) => setCurrentPage(page)}
+                onPerPageSelect={(_evt, newPerPage) => {
+                  setPerPage(newPerPage);
+                  setCurrentPage(1);
+                }}
+                variant={PaginationVariant.bottom}
+                isCompact
+              />
             </div>
           )}
         </PanelMainBody>

--- a/packages/nxtcm-dashboard/src/StorageCard/StorageCard.module.scss
+++ b/packages/nxtcm-dashboard/src/StorageCard/StorageCard.module.scss
@@ -1,8 +1,3 @@
-.storageCard {
-  min-width: 400px;
-  max-width: 600px;
-}
-
 .content {
   display: flex;
   gap: var(--pf-t--global--spacer--lg);
@@ -10,35 +5,10 @@
   padding: var(--pf-t--global--spacer--md) 0;
 }
 
-.circularProgress {
-  position: relative;
+.chartWrapper {
   width: 200px;
   height: 200px;
   flex-shrink: 0;
-}
-
-.progressCircle {
-  transition: stroke-dashoffset 0.3s ease;
-}
-
-.percentageLabel {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  text-align: center;
-}
-
-.percentage {
-  font-size: var(--pf-t--global--font--size--2xl);
-  font-weight: var(--pf-t--global--font--weight--bold);
-  color: var(--pf-t--global--text--color--regular);
-}
-
-.sublabel {
-  font-size: var(--pf-t--global--font--size--sm);
-  color: var(--pf-t--global--text--color--subtle);
-  margin-top: var(--pf-t--global--spacer--xs);
 }
 
 .details {
@@ -76,26 +46,15 @@
   display: flex;
   align-items: center;
   gap: var(--pf-t--global--spacer--sm);
-  font-size: var(--pf-t--global--font--size--body);
+  font-size: var(--pf-t--global--font--size--body--default);
 }
 
-.dot {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
+.legendDot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
   flex-shrink: 0;
-}
-
-.rosaDot {
-  background-color: #0066cc;
-}
-
-.aroDot {
-  background-color: #73bcf7;
-}
-
-.osdDot {
-  background-color: #004080;
 }
 
 .label {
@@ -108,16 +67,6 @@
   color: var(--pf-t--global--text--color--regular);
 }
 
-.viewMore {
-  background: none;
-  border: none;
-  color: var(--pf-t--global--color--brand--default);
-  cursor: pointer;
-  padding-right: var(--pf-t--global--spacer--md);
-  font-size: var(--pf-t--global--font--size--body);
-  text-decoration: none;
-
-  &:hover {
-    text-decoration: underline;
-  }
+.viewLink {
+  padding-top: var(--pf-t--global--spacer--md);
 }

--- a/packages/nxtcm-dashboard/src/StorageCard/StorageCard.spec.tsx
+++ b/packages/nxtcm-dashboard/src/StorageCard/StorageCard.spec.tsx
@@ -145,12 +145,10 @@ test.describe('StorageCard', () => {
     await expect(availableContainer).toContainText(`${preciseData.available.toFixed(2)} TiB`);
   });
 
-  test('should render SVG circular progress indicator', async ({ mount, page }) => {
+  test('should render utilization chart', async ({ mount, page }) => {
     await mount(<StorageCard storageData={mockStorageData} />);
-    const svgElement = page.locator('svg');
-    await expect(svgElement).toBeVisible();
-    await expect(svgElement).toHaveAttribute('width', '200');
-    await expect(svgElement).toHaveAttribute('height', '200');
+    const chart = page.getByRole('img', { name: 'Storage utilization chart' });
+    await expect(chart).toBeVisible();
   });
 
   test('should display total storage label correctly', async ({ mount }) => {

--- a/packages/nxtcm-dashboard/src/StorageCard/StorageCard.tsx
+++ b/packages/nxtcm-dashboard/src/StorageCard/StorageCard.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Flex, FlexItem, Skeleton } from '@patternfly/react-core';
+import { Button, Flex, FlexItem, Skeleton } from '@patternfly/react-core';
+import {
+  ChartDonutUtilization,
+  ChartLabel,
+  ChartThemeColor,
+  getTheme,
+} from '@patternfly/react-charts/victory';
 import styles from './StorageCard.module.scss';
 
 export interface StorageData {
@@ -21,14 +27,19 @@ export interface StorageCardProps {
   isLoading?: boolean;
 }
 
-/**
- * storage card displays storage usage statistics across different cluster types
- * with a visual percentage indicator
- */
-export const StorageCard: React.FC<StorageCardProps> = ({ storageData, onViewMore, isLoading }) => {
-  const showSkeleton = !!isLoading;
+const chartLabelFill = 'var(--pf-t--chart--global--label--fill, #1f1f1f)';
 
-  if (showSkeleton) {
+const clusterTypes: { key: keyof Omit<StorageData, 'available'>; label: string }[] = [
+  { key: 'rosaClusters', label: 'ROSA clusters' },
+  { key: 'aroClusters', label: 'ARO Clusters' },
+  { key: 'osdClusters', label: 'OSD Clusters' },
+];
+
+export const StorageCard: React.FC<StorageCardProps> = ({ storageData, onViewMore, isLoading }) => {
+  const blueTheme = getTheme(ChartThemeColor.blue);
+  const legendColors = (blueTheme.chart?.colorScale?.slice(0, 3) ?? []) as string[];
+
+  if (isLoading) {
     return (
       <Flex className={styles.content}>
         <FlexItem>
@@ -61,48 +72,30 @@ export const StorageCard: React.FC<StorageCardProps> = ({ storageData, onViewMor
   if (!storageData) return null;
   const { rosaClusters, aroClusters, osdClusters, available } = storageData;
 
-  // calculate totals
   const totalUsed = rosaClusters + aroClusters + osdClusters;
   const totalStorage = totalUsed + available;
-  const usagePercentage = Math.round((totalUsed / totalStorage) * 100);
-
-  // calculate stroke offset for circular progress (circumference = 2 * π * r)
-  const radius = 80;
-  const circumference = 2 * Math.PI * radius;
-  const strokeOffset = circumference - (usagePercentage / 100) * circumference;
+  const usagePercentage = totalStorage > 0 ? Math.round((totalUsed / totalStorage) * 100) : 0;
 
   return (
     <>
       <div className={styles.content}>
-        {/* circular progress indicator */}
-        <div className={styles.circularProgress}>
-          <svg width="200" height="200" viewBox="0 0 200 200">
-            {/* background circle */}
-            <circle cx="100" cy="100" r={radius} fill="none" stroke="#d2d2d2" strokeWidth="16" />
-            {/* progress circle */}
-            <circle
-              cx="100"
-              cy="100"
-              r={radius}
-              fill="none"
-              stroke="#0066cc"
-              strokeWidth="16"
-              strokeDasharray={circumference}
-              strokeDashoffset={strokeOffset}
-              strokeLinecap="round"
-              transform="rotate(-90 100 100)"
-              className={styles.progressCircle}
-            />
-          </svg>
-          <div className={styles.percentageLabel}>
-            <div className={styles.percentage} data-testid="percentage">
-              {usagePercentage}%
-            </div>
-            <div className={styles.sublabel}>of {totalStorage.toFixed(2)} TiB used</div>
-          </div>
+        <div className={styles.chartWrapper}>
+          <ChartDonutUtilization
+            ariaDesc="Storage utilization"
+            ariaTitle="Storage utilization chart"
+            constrainToVisibleArea
+            data={{ x: 'Storage used', y: usagePercentage }}
+            height={200}
+            subTitle={`of ${totalStorage.toFixed(2)} TiB used`}
+            title={`${usagePercentage}%`}
+            titleComponent={<ChartLabel style={{ fill: chartLabelFill, fontSize: 22 }} />}
+            subTitleComponent={<ChartLabel style={{ fill: chartLabelFill, fontSize: 14 }} />}
+            width={200}
+            padding={{ top: 20, bottom: 20, left: 20, right: 20 }}
+            name="storage-donut"
+          />
         </div>
 
-        {/* storage details */}
         <div className={styles.details}>
           <div className={styles.totalStorage}>
             <div className={styles.totalValue} data-testid="total-used">
@@ -112,27 +105,15 @@ export const StorageCard: React.FC<StorageCardProps> = ({ storageData, onViewMor
           </div>
 
           <div className={styles.breakdown}>
-            <div className={styles.breakdownItem}>
-              <span className={`${styles.dot} ${styles.rosaDot}`}></span>
-              <span className={styles.label}>ROSA clusters:</span>
-              <span className={styles.value} data-testid="rosa-clusters">
-                {rosaClusters.toFixed(2)} TiB
-              </span>
-            </div>
-            <div className={styles.breakdownItem}>
-              <span className={`${styles.dot} ${styles.aroDot}`}></span>
-              <span className={styles.label}>ARO Clusters:</span>
-              <span className={styles.value} data-testid="aro-clusters">
-                {aroClusters.toFixed(2)} TiB
-              </span>
-            </div>
-            <div className={styles.breakdownItem}>
-              <span className={`${styles.dot} ${styles.osdDot}`}></span>
-              <span className={styles.label}>OSD Clusters:</span>
-              <span className={styles.value} data-testid="osd-clusters">
-                {osdClusters.toFixed(2)} TiB
-              </span>
-            </div>
+            {clusterTypes.map((type, idx) => (
+              <div key={type.key} className={styles.breakdownItem}>
+                <span className={styles.legendDot} style={{ backgroundColor: legendColors[idx] }} />
+                <span className={styles.label}>{type.label}:</span>
+                <span className={styles.value} data-testid={type.key}>
+                  {storageData[type.key].toFixed(2)} TiB
+                </span>
+              </div>
+            ))}
             <div className={styles.breakdownItem}>
               <span className={styles.label}>Available:</span>
               <span className={styles.value} data-testid="available">
@@ -143,11 +124,11 @@ export const StorageCard: React.FC<StorageCardProps> = ({ storageData, onViewMor
         </div>
       </div>
       {onViewMore && (
-        <div className={styles.viewLink}>
-          <button onClick={onViewMore} className={styles.viewMore}>
+        <FlexItem className={styles.viewLink}>
+          <Button variant="link" isInline onClick={onViewMore}>
             View more
-          </button>
-        </div>
+          </Button>
+        </FlexItem>
       )}
     </>
   );

--- a/packages/nxtcm-dashboard/src/Subscriptions/Subscriptions.module.scss
+++ b/packages/nxtcm-dashboard/src/Subscriptions/Subscriptions.module.scss
@@ -1,70 +1,52 @@
 .subscriptions {
-  padding: 1rem;
+  padding: var(--pf-t--global--spacer--md);
   height: 100%;
 }
 
 .header {
-  margin-bottom: 0.5rem;
+  margin-bottom: var(--pf-t--global--spacer--sm);
 }
 
 .title {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: var(--pf-t--global--font--size--body--default);
+  font-weight: var(--pf-t--global--font--weight--body--bold);
   color: var(--pf-t--global--text--color--regular);
   margin: 0;
 }
 
 .chevron {
   color: var(--pf-t--global--text--color--regular);
-  font-size: 0.875rem;
+  font-size: var(--pf-t--global--font--size--sm);
 }
 
 .description {
-  font-size: 0.875rem;
+  font-size: var(--pf-t--global--font--size--sm);
   color: var(--pf-t--global--text--color--regular);
-  margin-bottom: 1rem;
+  margin-bottom: var(--pf-t--global--spacer--md);
 }
 
 .metrics {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+  margin-top: var(--pf-t--global--spacer--md);
+  margin-bottom: var(--pf-t--global--spacer--md);
 }
 
 .count {
-  font-size: 2.5rem;
-  font-weight: 300;
-  line-height: 1;
+  font-size: var(--pf-t--global--font--size--4xl);
+  font-weight: var(--pf-t--global--font--weight--body--default);
+  line-height: var(--pf-t--global--font--line-height--body);
   color: var(--pf-t--global--text--color--regular);
-}
-
-.clickableCount {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
-  color: var(--pf-t--global--color--link--default);
-  transition: color 0.2s ease;
-
-  &:hover {
-    color: var(--pf-t--global--color--link--hover);
-    text-decoration: underline;
-  }
-
-  &:active {
-    color: var(--pf-t--global--color--link--clicked);
-  }
 }
 
 .icon {
   color: var(--pf-t--global--text--color--regular);
-  font-size: 1rem;
+  font-size: var(--pf-t--global--font--size--body--default);
 }
 
 .label {
-  font-size: 0.875rem;
+  font-size: var(--pf-t--global--font--size--sm);
   color: var(--pf-t--global--text--color--regular);
 }
 
 .viewLink {
-  padding-top: 1rem;
+  padding-top: var(--pf-t--global--spacer--md);
 }

--- a/packages/nxtcm-dashboard/src/Subscriptions/Subscriptions.tsx
+++ b/packages/nxtcm-dashboard/src/Subscriptions/Subscriptions.tsx
@@ -76,8 +76,10 @@ export const Subscriptions = ({
           <FlexItem>
             {onSubscriptionsClick ? (
               <Button
-                variant="plain"
-                className={`${styles.count} ${styles.clickableCount}`}
+                variant="link"
+                isInline
+                className={styles.count}
+                aria-label={`View ${subscriptionCount ?? 0} subscriptions`}
                 onClick={onSubscriptionsClick}
               >
                 {subscriptionCount}
@@ -91,7 +93,7 @@ export const Subscriptions = ({
               alignItems={{ default: 'alignItemsCenter' }}
               spaceItems={{ default: 'spaceItemsXs' }}
             >
-              <FolderIcon className={styles.icon} />
+              <FolderIcon className={styles.icon} aria-hidden="true" />
               <span className={styles.label}>Subscriptions</span>
             </Flex>
           </FlexItem>
@@ -106,8 +108,10 @@ export const Subscriptions = ({
           <FlexItem>
             {onInstancesClick ? (
               <Button
-                variant="plain"
-                className={`${styles.count} ${styles.clickableCount}`}
+                variant="link"
+                isInline
+                className={styles.count}
+                aria-label={`View ${instanceCount ?? 0} instances`}
                 onClick={onInstancesClick}
               >
                 {instanceCount ?? 0}
@@ -121,7 +125,7 @@ export const Subscriptions = ({
               alignItems={{ default: 'alignItemsCenter' }}
               spaceItems={{ default: 'spaceItemsXs' }}
             >
-              <ServerIcon className={styles.icon} />
+              <ServerIcon className={styles.icon} aria-hidden="true" />
               <span className={styles.label}>Instances</span>
             </Flex>
           </FlexItem>

--- a/packages/nxtcm-dashboard/src/UpgradeRisks/UpgradeRisks.module.scss
+++ b/packages/nxtcm-dashboard/src/UpgradeRisks/UpgradeRisks.module.scss
@@ -1,37 +1,28 @@
-.upgradeRisksCard {
-  max-width: 400px;
-  min-width: 300px;
-
-  :global(.pf-v6-c-card__header) {
-    padding-bottom: 0;
-  }
-}
-
 .cardTitle {
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: var(--pf-t--global--font--size--body--default);
+  font-weight: var(--pf-t--global--font--weight--body--bold);
   color: var(--pf-t--global--text--color--regular);
 }
 
 .totalSection {
-  padding: 1rem;
+  padding: var(--pf-t--global--spacer--md);
 }
 
 .totalNumber {
-  font-size: 2.5rem;
-  font-weight: 300;
-  line-height: 1;
+  font-size: var(--pf-t--global--font--size--4xl);
+  font-weight: var(--pf-t--global--font--weight--body--default);
+  line-height: var(--pf-t--global--font--line-height--body);
   color: var(--pf-t--global--text--color--regular);
 }
 
 .totalLabel {
-  font-size: 0.875rem;
+  font-size: var(--pf-t--global--font--size--sm);
   color: var(--pf-t--global--text--color--subtle);
 }
 
 .riskIcon {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: var(--pf-t--global--icon--size--lg);
+  height: var(--pf-t--global--icon--size--lg);
 
   svg {
     width: 100%;
@@ -52,9 +43,9 @@
 }
 
 .riskCount {
-  font-size: 1.5rem;
-  font-weight: 400;
-  line-height: 1;
+  font-size: var(--pf-t--global--font--size--2xl);
+  font-weight: var(--pf-t--global--font--weight--body--default);
+  line-height: var(--pf-t--global--font--line-height--body);
   color: var(--pf-t--global--text--color--regular);
 }
 
@@ -63,5 +54,5 @@
 }
 
 .viewLink {
-  padding: 1rem 0;
+  padding: var(--pf-t--global--spacer--md) 0;
 }

--- a/packages/nxtcm-dashboard/src/UpgradeRisks/UpgradeRisks.tsx
+++ b/packages/nxtcm-dashboard/src/UpgradeRisks/UpgradeRisks.tsx
@@ -107,7 +107,7 @@ export const UpgradeRisks = ({
             spaceItems={{ default: 'spaceItemsXs' }}
           >
             <FlexItem className={styles.riskIcon}>
-              <ExclamationCircleIcon className={styles.criticalIcon} />
+              <ExclamationCircleIcon className={styles.criticalIcon} aria-hidden="true" />
             </FlexItem>
             <FlexItem className={styles.riskCount} data-testid="criticalCount">
               {criticalCount ?? 0}
@@ -128,7 +128,7 @@ export const UpgradeRisks = ({
             spaceItems={{ default: 'spaceItemsXs' }}
           >
             <FlexItem className={styles.riskIcon}>
-              <ExclamationTriangleIcon className={styles.warningIcon} />
+              <ExclamationTriangleIcon className={styles.warningIcon} aria-hidden="true" />
             </FlexItem>
             <FlexItem className={styles.riskCount} data-testid="warningCount">
               {warningCount ?? 0}
@@ -149,7 +149,7 @@ export const UpgradeRisks = ({
             spaceItems={{ default: 'spaceItemsXs' }}
           >
             <FlexItem className={styles.riskIcon}>
-              <InfoCircleIcon className={styles.infoIcon} />
+              <InfoCircleIcon className={styles.infoIcon} aria-hidden="true" />
             </FlexItem>
             <FlexItem className={styles.riskCount} data-testid="infoCount">
               {infoCount ?? 0}


### PR DESCRIPTION
## Description

7 legacy dashboard widgets (StorageCard, RecommendationByCategory, Critical, Subscriptions, UpgradeRisks, NotificationsPanel, CVECard) were using custom CSS instead of PatternFly v6 design tokens and components. This aligns them with the PF v6 best practices the new dashboard widgets already follow, and with the team's decision (Jun 18 standup) to avoid custom CSS where possible.

**Jira issue #** https://redhat.atlassian.net/browse/FCN-561

## Type of Change

- [x] Code refactoring (no functional changes)
- [x] UI/UX improvement

## What changed

**StorageCard** — replaced hand-drawn SVG circular progress with `ChartDonutUtilization`, removed 5 hardcoded hex colors (legend dots now use `getTheme(ChartThemeColor.blue)`), replaced custom viewMore button with PF `Button variant="link" isInline`, added division-by-zero guard

**RecommendationByCategory** — replaced 4 hardcoded hex colors (PF vars were literally commented out above them) with `getTheme()`, replaced inline `style={{ padding }}` with SCSS class, replaced raw `<h3>` with PF `Title`, added `role="img"` and `aria-label` on bar visualization

**Critical** — replaced inline `style={{ padding: '1rem' }}` with SCSS class using PF token, replaced raw `<h3>` with PF `Title`, replaced raw `<p>` with PF `Content`, added `aria-hidden` on decorative icon

**Subscriptions** — replaced 14 raw rem values with PF spacer/font tokens, replaced `Button variant="plain"` with custom CSS to `Button variant="link" isInline`, added `aria-hidden` on decorative icons, added `aria-label` on count buttons for screen readers

**UpgradeRisks** — replaced 11 raw rem values with PF tokens, removed `:global(.pf-v6-c-card__header)` override, added `aria-hidden` on 3 decorative severity icons

**NotificationsPanel** — normalized all tokens from `--pf-v6-global--` to `--pf-t--global--`, replaced custom HTML pagination (triangle entities) with PF `Pagination` component, added page clamping when dataset shrinks to avoid false empty state, added `aria-label` on table

**CVECard** — moved inline `style={{ height, padding }}` to SCSS with PF tokens, replaced raw title text with PF `Title headingLevel="h3"`, added `aria-hidden` on severity icons

## Testing

### Manual Testing

**Test Steps:**
1. Open Storybook, navigate to each of the 7 widget stories
2. Toggle between light and dark mode using the toolbar
3. Verify all widgets render correctly in both themes, no broken colors or layouts

**Test Environment:**
- [x] Tested locally
- [x] Tested in Storybook

### Automated Testing

**E2E Run:**
- [x] Playwright Tests: 297/297 dashboard CT tests passed, 365/365 wizard CT tests passed

**Unit Tests:**
- [x] All unit tests pass (302/302 wizard unit tests)

## Screenshots/Recordings

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/7fece21f-ee6b-412e-a9a1-4e5863d21036" />
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/69731cfd-cdce-4fac-850f-48e9d9abdd46" />

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/c7bf2638-e75c-4dfb-8dc7-f2c8e6886566" />
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/0a6121f9-04cd-4193-8653-82491ab7c66e" />

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/2075deca-2849-4d9d-b750-a0afb8dde6ef" />
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/9472cc95-7abb-455a-b98d-f29c51dd2688" />

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/e8c91789-a56d-43c9-a8ab-231e31a0b486" />
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/e916a67d-45ac-4695-b3c2-16878d1741d1" />

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/b1452970-e092-4334-994f-0f79e676051d" />
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/00dd1183-6c85-4615-84fc-937dda3a3b2c" />

<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/0df46deb-a4ac-417b-aa67-88ed9eaf87d0" />
<img width="1200" height="800" alt="image" src="https://github.com/user-attachments/assets/0535b935-fc19-414e-9a6c-fd7f359ccdf5" />




## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [x] I have checked for and fixed any linting errors (npm run lint)
- [x] Code formatting is correct (npm run prettier:fix)

### Accessibility
- [x] My changes follow accessibility best practices
- [x] Proper ARIA labels and roles are used where needed
- [x] Color contrast meets WCAG standards

### Dependencies
- [x] No dependency changes needed

## Breaking Changes

**Does this PR introduce breaking changes?**
- [x] No
