### PR TITLE
Add Jira Skills for epics, checking acceptance criteria, and creating estimates

### DIFF
--- a/.agents/skills/jira-acceptance-criteria-check/CONVENTIONS.md
+++ b/.agents/skills/jira-acceptance-criteria-check/CONVENTIONS.md
@@ -1,0 +1,82 @@
+# Jira skills — shared conventions
+
+Canonical definitions referenced by all Jira skills. **Do not reword rules here** — other Jira skills link here to avoid drift.
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **`classified_type`** | Work-type slug from [JIRA_TYPE/](JIRA_TYPE/README.md) discovery (e.g. `story`, `task`, `bug`, `spike`). Used for scoring, templates, and breakdown tables. |
+| **Planning slug** | Same as `classified_type` — the type assigned from rubric content, which may differ from Jira `issuetype`. |
+| **Synthetic input** | Draft ticket bodies not yet in Jira — parsed per [DRAFT_INPUT.md](DRAFT_INPUT.md); no Jira fetch. |
+| **Discovery gate** | Hard stop that asks for missing facts before fetch, draft, or scripts run. Each skill defines its own gate (§0 or step 1). |
+| **Route lock** | After the user picks CLI or MCP for historical fetch, stay on that path for the rest of the run — no silent fallback. |
+| **Needs review** | Report bucket: score 1–3 **with** a draft ([REPORT.md](REPORT.md)). |
+| **Needs Refinement** | Report bucket: score 1–3 **without** a draft (not enough context to suggest honestly). |
+
+---
+
+## Paths and artifacts
+
+| Symbol / file | Definition |
+|---------------|------------|
+| **`{workspace}`** | **Default:** active Cursor workspace root as an **absolute path**. **Override:** only when the user names a directory in the current thread — then use that path for the whole run. Do not infer from skill install path or prior chats. |
+| **`{report-dir}`** | Parent directory of the resolved `.jira-historical-report.json` (absolute path). |
+| **`.jira-historical-issues.json`** | Raw Jira fetch with changelog — produced by [jira-get-historical-items](../jira-get-historical-items/SKILL.md). |
+| **`.jira-historical-report.json`** | Processed historical report — consumed by [jira-get-stats](../jira-get-stats/SKILL.md) and [jira-get-estimates](../jira-get-estimates/SKILL.md). |
+| **Report lookup** (no user path) | 1) `{workspace}/.jira-historical-report.json` → 2) `~/.cursor/skills/.jira-historical-report.json` — first existing file wins. |
+
+---
+
+## Jira site defaults
+
+| | Value |
+|--|--------|
+| Site | `redhat.atlassian.net` |
+| Cloud ID (MCP) | `2b9e35e3-6bd3-4cec-b838-f4249ee02432` |
+| Story points field (FCN) | `customfield_10028` |
+
+Load `meta.storyPointsField` from a historical report when present; otherwise use `customfield_10028`.
+
+---
+
+## MCP transport
+
+| Rule | Detail |
+|------|--------|
+| **MCP server** | `user-atlassian-mcp-server` |
+| **Before calling** | Read tool schema JSON in the MCP descriptors folder |
+| **Auth** | On **401**: `mcp_auth` for `user-atlassian-mcp-server`, retry once |
+| **No `acli`** | Atlassian CLI is not a fallback for any active Jira skill |
+| **Pagination** | When `searchJiraIssuesUsingJql` returns `nextPageToken`, repeat with the token until all issues are fetched or the skill’s cap is reached |
+
+Common tools: `getAccessibleAtlassianResources`, `searchJiraIssuesUsingJql`, `getJiraIssue`, `createJiraIssue`, `editJiraIssue`, `addCommentToJiraIssue`.
+
+---
+
+## Section labels in skill docs
+
+| Label | Role |
+|-------|------|
+| **Hard rules** | Orchestrator constraints — what the agent must / must not do |
+| **Anti-patterns** | Content and slicing mistakes (epic authoring skills) |
+| **Pitfalls** | Troubleshooting when something goes wrong at runtime |
+
+---
+
+## Skill index
+
+| Skill | Use when |
+|-------|----------|
+| [jira-epic-create](../jira-epic-create/SKILL.md) | Draft a paste-ready epic description |
+| [jira-epic-breakdown](../jira-epic-breakdown/SKILL.md) | Split an epic into child stories/tasks/spikes |
+| [jira-acceptance-criteria-check](SKILL.md) | Score ticket quality; draft improvements |
+| [jira-get-historical-items](../jira-get-historical-items/SKILL.md) | Fetch closed work + build cycle-time report |
+| [jira-get-stats](../jira-get-stats/SKILL.md) | Summarize an existing historical report (read-only) |
+| [jira-get-estimates](../jira-get-estimates/SKILL.md) | Recommend story points from historical data |
+
+**Typical pipeline:** historical-items → stats or estimates. **Authoring pipeline:** epic-create → epic-breakdown → acceptance-criteria-check (optional).
+
+**Supersedes:** [OLD/jira-cycle-time-report](../OLD/jira-cycle-time-report/SKILL.md) — use jira-get-historical-items instead.

--- a/.agents/skills/jira-acceptance-criteria-check/DRAFT.md
+++ b/.agents/skills/jira-acceptance-criteria-check/DRAFT.md
@@ -1,0 +1,48 @@
+# Draft suggested content
+
+For issues scored **1–3** only ([SCORING.md](SCORING.md)). Produces suggested ticket body content for [REPORT.md](REPORT.md) **Needs review** section.
+
+---
+
+## When to draft
+
+| Score | Action |
+|-------|--------|
+| **1–3** | Attempt a draft using [GENERAL.md](GENERAL.md) + type file **Description template** |
+| **4–5** | Skip |
+
+If drafting would require **guessing or extrapolating** product behavior, **do not draft** — the issue goes to **Needs Refinement**.
+
+---
+
+## Enrichment (optional fetch)
+
+When Jira text is thin, fetch extra context before drafting:
+
+- **Parent** issue and **comments** on the issue ([JIRA.md](JIRA.md) / **jira-items**)
+- **Workspace repo** — read only files plausibly related to the ticket (same feature area, config, docs)
+
+Use prior Jira comments that start with **Suggested …** as context; still produce an **updated** draft for this run.
+
+When enrichment finds such a comment, **record it** for that key so [POST_JIRA.md](POST_JIRA.md) can skip duplicate posts.
+
+---
+
+## How to format
+
+Use the **Description template** from the type file for `classified_type` (`JIRA_TYPE/{slug}.md`):
+
+1. Open that file’s **Description template** section.
+2. Draft every `###` heading listed there (skip optional sections unless you have real content).
+3. Follow that type file’s rubric for bullets, nesting, and what “done” content looks like — do not assume sections from another type.
+
+Match template **`###` headings**. Use `*` bullets for lists; nest with **2 spaces per level** where the type file’s guidance calls for grouping.
+
+---
+
+## Rules
+
+- **Do not invent** behavior, APIs, or UX not supported by Jira text, parent, comments, or repo evidence.
+- Draft **verifiable outcomes** per the type file’s template and scoring rubric — not implementation task lists unless that type file allows it.
+- Omit optional template sections unless you have real content.
+- Record whether a draft was produced — [REPORT.md](REPORT.md) uses that for **Needs review** vs **Needs Refinement**.

--- a/.agents/skills/jira-acceptance-criteria-check/DRAFT_INPUT.md
+++ b/.agents/skills/jira-acceptance-criteria-check/DRAFT_INPUT.md
@@ -1,0 +1,63 @@
+# Synthetic / draft input (no Jira fetch)
+
+Use when issues **do not exist in Jira yet** or the user pasted draft bodies — e.g. **jira-epic-breakdown** pre-delivery review, or “score these drafts” in chat.
+
+**Skip [JIRA.md](JIRA.md) fetch** when synthetic input is already available in the same turn or from an earlier step in the conversation.
+
+---
+
+## When to use
+
+| Source | Action |
+|--------|--------|
+| **jira-epic-breakdown** step 5 (internal) | Build synthetic list from drafted child items — see [jira-epic-breakdown/REVIEW.md](../jira-epic-breakdown/REVIEW.md) |
+| User pasted ticket bodies | Parse into synthetic issues (summary, type, description per item) |
+| User says “score drafts” / “check these before Jira” | Synthetic mode — do not fetch Jira unless user also gives keys |
+
+When the user gives **Jira keys** or **JQL**, use [JIRA.md](JIRA.md) instead.
+
+---
+
+## Synthetic issue shape
+
+Each issue must have:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `summary` | Yes | Title line |
+| `description` | Yes | Full ticket body per its type template — may be empty only for title-only checks |
+| `declared_type` or `issuetype` | Yes | Type slug — must match a rubric under [JIRA_TYPE/](JIRA_TYPE/README.md) |
+| `draft_id` or `key` | Optional | Breakdown `#` or placeholder `DRAFT-1` — use in report when no Jira key exists |
+
+For classify: treat `declared_type` as Jira `issuetype` when comparing to **Jira issuetype aliases** in each type file’s metadata ([JIRA_TYPE/README.md](JIRA_TYPE/README.md)).
+
+---
+
+## Downstream steps
+
+After building the synthetic list, continue [SKILL.md](SKILL.md) from **step 2 Classify** — same classify, score, draft, and report rules as Jira-fetched issues.
+
+### Report labels for drafts
+
+When issues have no Jira key:
+
+- Use `DRAFT-<#> - Summary` or `#<n> - Summary` in report lines (match jira-epic-breakdown numbering).
+- Do **not** link to `redhat.atlassian.net/browse/...` for draft-only ids.
+
+### Drafting (scores 1–3)
+
+For **jira-epic-breakdown** internal review, revising the breakdown output takes priority over a separate jira-acceptance-criteria-check report file. Follow [jira-epic-breakdown/REVIEW.md](../jira-epic-breakdown/REVIEW.md) § Revise weak drafts.
+
+When the user invoked **jira-acceptance-criteria-check** directly on pasted drafts (not via jira-epic-breakdown), follow normal [REPORT.md](REPORT.md) output.
+
+---
+
+## Hard rules
+
+| Do | Do not |
+|----|--------|
+| Score substance in the draft body | Require Jira keys for draft review |
+| Use epic/parent context from the same conversation when revising | Post Jira comments for draft-only ids |
+| Record `declared_type` vs `classified_type` mismatch | Assume declared type is always correct |
+
+**Jira comments:** [POST_JIRA.md](POST_JIRA.md) applies only to **real Jira keys**. Draft-only runs skip the post prompt.

--- a/.agents/skills/jira-acceptance-criteria-check/GENERAL.md
+++ b/.agents/skills/jira-acceptance-criteria-check/GENERAL.md
@@ -1,0 +1,46 @@
+# General — good description
+
+Cross-type quality bar for the **ticket description** (context outside the acceptance criteria list). Apply before type-specific rules in the rubric file for `classified_type` under [JIRA_TYPE/](JIRA_TYPE/README.md).
+
+A strong description lets reviewers and implementers understand the work **without inferring intent from AC alone**.
+
+---
+
+## WHAT
+
+The description states **what** is changing or being done at a high level:
+
+- The outcome, feature, fix, or deliverable in plain language
+- Enough scope context that the team knows **what is in** the ticket (not a detailed spec — that can live in AC or linked docs)
+
+**Weak:** title-only ticket, vague “improve X,” or AC with no surrounding context.
+
+**Strong:** a short narrative or bullets that name the work area and the intended change so someone new to the ticket grasps the ask in one read.
+
+---
+
+## WHY
+
+The description states **why** this work is requested:
+
+- User pain, business need, bug impact, dependency, compliance, or other driver
+- Enough motivation that prioritization and tradeoffs make sense
+
+**Weak:** no problem statement; only a task list or implementation notes with no reason.
+
+**Strong:** the reader can answer “why are we doing this?” without opening Slack or the epic.
+
+---
+
+## How to use in scoring
+
+When judging description quality (see [SCORING.md](SCORING.md)):
+
+| Dimension | Question |
+|-----------|----------|
+| **WHAT** | Is it clear what work this ticket covers? |
+| **WHY** | Is it clear why this work matters? |
+
+Score **Partial** when one dimension is thin or implied; **Missing** when absent; **Met** when both are clearly stated in the description.
+
+

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA.md
@@ -1,0 +1,87 @@
+# Jira fetch
+
+Fetch work items for **jira-acceptance-criteria-check** via **Atlassian MCP only** — no CLI fallback.
+
+Shared MCP rules: [CONVENTIONS.md](CONVENTIONS.md). This file adds AC-specific input defaults.
+
+**Draft / synthetic input (no Jira):** When issues are not in Jira yet — e.g. **jira-epic-breakdown** pre-delivery review — use [DRAFT_INPUT.md](DRAFT_INPUT.md) instead of this file.
+
+**Site:** `redhat.atlassian.net`
+
+**Output:** Do **not** dump the raw fetch to the user. Hold the resolved JQL and issue payloads in memory for later steps in [SKILL.md](SKILL.md) (classify → score → draft → report). Mention fetch failures only when the workflow must stop.
+
+---
+
+## 1. Resolve scope → JQL
+
+**Input** (same turn or immediate follow-up):
+
+| Input | Action |
+|-------|--------|
+| Issue keys (e.g. `FCN-232`, `FCN-1 FCN-2`) | `key in (FCN-232, …)` — keys beat filters when both are given |
+| Full JQL string | Use after a quick sanity check |
+| Natural language | Translate to a single JQL string (e.g. assigned to me, under epic FCN-100, my open stories in fcn) |
+
+**Default JQL** when the user gives **no filter hints** (team-specific example — adapt project and fields to the user’s site):
+
+```text
+project = fcn AND status in ("To Do") AND type in (Story, Task, Spike) AND "Story Points" is EMPTY
+```
+
+**Common JQL fragments** (combine with `AND`; rename fields if Jira errors — sites differ):
+
+| Intent | Example |
+|--------|---------|
+| Assigned to me | `assignee = currentUser()` |
+| Assigned to someone | `assignee = "user.name"` (or account id) |
+| Direct parent | `parent = FCN-100` |
+| Epic link (classic) | `"Epic Link" = FCN-100` |
+| Hierarchy (some sites) | `issue in childIssuesOf("FCN-100")` |
+
+If the ask is **ambiguous** (e.g. “my team’s tickets” with no project), ask **one** short clarifying question before searching.
+
+---
+
+## 2. Resolve fields
+
+| User says | Fetch |
+|-----------|--------|
+| *(default)* | `key`, `summary`, `description` |
+| Names other fields | Those fields instead of or in addition to the default |
+
+**Pipeline note:** For jira-acceptance-criteria-check runs, always also fetch **`issuetype`** — [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) needs it. Do not echo raw issue bodies in chat during fetch; later steps consume them.
+
+---
+
+## 3. Transport — MCP only
+
+1. Read MCP tool schemas under `user-atlassian-mcp-server` before calling.
+2. If only **`mcp_auth`** is listed → call `mcp_auth` for `user-atlassian-mcp-server` with `{}`, then re-check tools.
+3. `getAccessibleAtlassianResources` → `cloudId` for `redhat.atlassian.net`.
+4. **One key:** `getJiraIssue` with requested fields; `responseContentFormat: "markdown"` for description when available.
+5. **Many / JQL:** `searchJiraIssuesUsingJql` with the resolved JQL, `cloudId` for `redhat.atlassian.net`, and requested `fields`. When the response includes `nextPageToken`, repeat the search with that token until all issues are fetched or you hit a reasonable cap — do not silently truncate large result sets.
+
+**If MCP fails** (server missing, tools unavailable after auth, or fetch error):
+
+- **Stop** the skill. Do not classify or score without data.
+- **Tell the user** how to fix:
+  - Cursor → **Settings → MCP** — ensure the **Atlassian** MCP server is enabled.
+  - Complete auth when prompted (`mcp_auth` for `user-atlassian-mcp-server`).
+  - Retry the skill after MCP is connected.
+
+There is **no** acli or other CLI fallback for this skill.
+
+---
+
+## 4. Hand off to downstream steps
+
+Record internally (for the agent, not the user report):
+
+| Item | Use |
+|------|-----|
+| Resolved JQL | Traceability in report header if needed |
+| Transport | `MCP` |
+| Issue list | `key`, `summary`, `description`, `issuetype` (+ any extra requested fields) |
+| Gaps | Empty description, pagination truncated, field rename workarounds |
+
+Pass the issue list to **classify** ([CLASSIFY.md](JIRA_TYPE/CLASSIFY.md)). Enrichment (parent, comments) for low-scored items happens later in [DRAFT.md](DRAFT.md), not here.

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/BUG.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/BUG.md
@@ -1,0 +1,166 @@
+# Bug — evaluation criteria
+
+Apply when `classified_type` is **bug** (this file).
+
+## Type metadata
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `bug` |
+| **Definition** | **Broken functionality.** Prevents the user from performing a task they would normally be able to perform. |
+| **Jira issuetype aliases** | Bug |
+| **Quick signals** | broken, regression, fails, error, cannot, unexpected, works in X not Y |
+| **Comment prefix** | Suggested Acceptance Criteria |
+
+Description **WHAT** and **WHY** → [GENERAL.md](../GENERAL.md). This file adds the **description template** and rubric for **how to reproduce** and **expected** behavior ([SCORING.md](../SCORING.md)). Bugs do **not** use an acceptance criteria section — fix verification is **repro gone + expected behavior restored**.
+
+---
+
+## Description template
+
+A well-formed bug in Jira uses these sections (markdown `###` headings or equivalent in the ticket body):
+
+### Description
+
+Describes the **what** and **why** ([GENERAL.md](../GENERAL.md)) — what is broken, who is affected, and why it matters (user blocked, regression, severity).
+
+### How to reproduce
+
+Step-by-step instructions to **repeatedly** reproduce the bug. Numbered steps; include prerequisites (role, data, feature flags, starting page) so QA and devs get the same result.
+
+### Expected
+
+What **should** happen — the correct behavior when the user follows the repro steps.
+
+### Actual
+
+What **does** happen instead — the observable failure (error message, wrong screen, silent failure, etc.). Include this section when it is not already obvious from the description alone.
+
+**Example skeleton** (paste into Jira; replace placeholders):
+
+```markdown
+### Description
+
+<What is broken, who is impacted, and why it matters.>
+
+### How to reproduce
+
+1. <Prerequisite or starting state>
+2. <Action>
+3. <Action>
+
+### Expected
+
+<Correct behavior — what the user should see or be able to do.>
+
+### Actual
+
+<What happens instead — error, wrong state, blocked action.>
+```
+
+---
+
+## How to reproduce (evaluation)
+
+Judge whether someone **not** on the authoring team can reproduce the bug reliably.
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **Repeatability** | Same steps yield the same failure most of the time | “Sometimes fails” with no pattern |
+| **Step clarity** | Numbered, ordered, one action per step | Vague “use the app and see error” |
+| **Starting state** | Role, account, data, URL, or feature state stated | Assumes tacit team knowledge |
+| **Environment** | Browser/OS/version, cluster, or build called out when relevant | Omits environment though bug is env-specific |
+| **Minimal path** | Shortest path to the failure | Long unrelated setup |
+| **Evidence** | Screenshot, HAR, console snippet, or log line when helpful | No anchor for intermittent issues |
+
+**Missing repro:** If there are no steps, score repro as **Missing** — the bug cannot be verified or closed with confidence.
+
+---
+
+## Expected (evaluation)
+
+Judge whether **correct** behavior is defined clearly enough to know when the fix is done.
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **Observable outcome** | States what the user sees, can do, or what data shows | “Should work correctly” |
+| **Scoped to repro** | Expected result matches the steps above | Generic product spec unrelated to repro |
+| **Complete path** | Success includes navigation, messaging, or state change if relevant | Only happy path implied |
+| **Contrast with actual** | Reader can tell expected vs actual without guessing | Expected duplicates description noise |
+
+For bugs, **expected behavior often replaces acceptance criteria** — “done” means repro steps produce the expected result.
+
+---
+
+## Actual (evaluation)
+
+When an **Actual** section (or equivalent in the description) is present:
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **Specific failure** | Named error, wrong UI, missing control, incorrect data | “Doesn’t work” |
+| **User-visible** | Describes what the user experiences | Internal-only stack trace with no user impact |
+| **Aligned with repro** | Failure happens at the last step (or noted step) | Mismatch between steps and failure |
+
+If **actual** is only implied, score **Partial** when the gap is inferable; **Missing** when the failure mode is unclear.
+
+---
+
+## Description (bug-specific)
+
+Beyond [GENERAL.md](../GENERAL.md):
+
+- **Impact:** Is it clear **what task** the user cannot complete?
+- **Regression:** If this used to work, is that stated (version, release, or “regression since …”)?
+- **Scope:** Is the bug bounded (one flow) vs “whole app broken” without evidence?
+
+---
+
+## Scoring
+
+Use with [GENERAL.md](../GENERAL.md) and [SCORING.md](../SCORING.md). Produce **one 1–5** for how well this bug’s **content** supports fix and verification.
+
+### What to judge
+
+| Layer | Source |
+|-------|--------|
+| Description — WHAT + WHY (+ impact) | [GENERAL.md](../GENERAL.md), [Description (bug-specific)](#description-bug-specific) |
+| How to reproduce | [How to reproduce (evaluation)](#how-to-reproduce-evaluation) |
+| Expected | [Expected (evaluation)](#expected-evaluation) |
+| Actual | [Actual (evaluation)](#actual-evaluation) — when present or inferable |
+
+### Weak vs strong (score drivers)
+
+| Area | Weak (pulls toward 1–3) | Strong (pulls toward 4–5) |
+|------|-------------------------|---------------------------|
+| Description | Impact unclear | What is broken and why it matters |
+| How to reproduce | Missing or not repeatable | Numbered steps with starting state |
+| Expected / actual | “Should work” only | Observable correct vs broken behavior |
+
+### Balance and caps
+
+- No repro steps → **cap at 2** (cannot verify fix).
+- Repro + expected but vague actual → **typically 3–4** if failure mode is inferable.
+- Clear WHAT/WHY with no repro → **cap at 2–3**.
+
+### Calibration examples
+
+| Score | Example |
+|-------|---------|
+| **5** | Impact clear + numbered repro + specific expected and actual. |
+| **4** | Good repro + expected; actual slightly thin but failure is obvious from steps. |
+| **3** | Repro works but expected vague, or actual missing and only partly inferable. |
+| **2** | Description of broken behavior only; no repro steps. |
+| **1** | Title-only or no indication of failure mode. |
+
+---
+
+## Fix verification (not a Jira section)
+
+When drafting suggestions ([DRAFT.md](../DRAFT.md)) or closing a bug, verification is:
+
+1. Follow **how to reproduce** — failure no longer occurs.
+2. Observe **expected** behavior.
+3. Spot-check related paths only when the fix could reasonably regress neighbors.
+
+Do not replace missing repro/expected with a list of story-style AC unless the ticket was misclassified.

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/CLASSIFY.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/CLASSIFY.md
@@ -1,0 +1,85 @@
+# Classify issue type
+
+For each issue from [JIRA.md](../JIRA.md) or [DRAFT_INPUT.md](../DRAFT_INPUT.md), assign exactly one **`classified_type`** slug. The slug picks the scoring rubric — one type file under [JIRA_TYPE/](.).
+
+**Do not assume** a fixed set of types or what any type *means*. Discover type files on every run ([README.md](README.md) § Discovery). **Definitions live only in each type file’s Type metadata** — not in this file or other skill files.
+
+---
+
+## 1. Discover available types
+
+1. List `*.md` in this directory (`JIRA_TYPE/`).
+2. **Exclude** `CLASSIFY.md` and `README.md`.
+3. For each remaining file, read its **Type metadata** section:
+   - **Slug** — normalized type id (must match filename stem rules in [README.md](README.md))
+   - **Definition** — **authoritative** description of what work belongs to this type (team-specific; edit the type file to match your Jira practice)
+   - **Jira issuetype aliases** — labels that map to this slug (case-insensitive)
+   - **Quick signals** — tie-breaker tokens (optional)
+   - **Summary prefix hints** — optional; summary tokens that suggest this slug (e.g. `Spike:`)
+
+Hold the full set of slugs and metadata in memory for steps 2–4.
+
+If **no** type files exist → **stop** and tell the user to add at least one type rubric under `JIRA_TYPE/`.
+
+---
+
+## 2. Read Jira `issuetype`
+
+Record the raw value as **`jira_issuetype`**.
+
+Normalize (trim, case-insensitive) and match against **Jira issuetype aliases** from every discovered type.
+
+| Outcome | Meaning |
+|---------|---------|
+| **One match** | Jira type implies that slug — candidate for content comparison in step 4 |
+| **Multiple matches** | Rare — prefer the alias match whose **Definition** best fits summary + description |
+| **No match** | Jira type is unknown to configured rubrics — classify from **content only** in step 3; note the raw issuetype when recording mismatch or ambiguity |
+
+---
+
+## 3. Read summary and description
+
+Compare ticket **content** against the **Definition** and **Quick signals** of **every** discovered type. Pick the slug whose metadata best fits summary + description.
+
+When issuetype is missing or unknown, this step alone determines `classified_type`.
+
+When signals are weak, prefer the type whose **Definition** best matches **what “done” looks like** for this ticket — using only the discovered definitions, not assumptions from other skill files.
+
+**Summary prefix hints:** when a type’s metadata lists prefix hints, a matching summary token can strongly suggest that slug even when issuetype differs — still record **mismatch** when Jira issuetype does not align.
+
+---
+
+## 4. Decide: match or mismatch
+
+| Outcome | Meaning |
+|---------|---------|
+| **Match** | Jira `issuetype` (when mappable) and content both fit the same slug per that type’s **Definition** |
+| **Mismatch** | Jira `issuetype` maps to one slug, but content fits a **different** slug’s **Definition** better |
+
+Do **not** use hardcoded cross-type rules here. Compare definitions from the discovered type files only.
+
+When issuetype is unknown, set **`type_match`** to **match** if content clearly fits one slug; otherwise pick the best-fit slug and note ambiguity in `type_mismatch_note`.
+
+---
+
+## 5. Record the result (internal — for scoring and report)
+
+For each issue, keep:
+
+| Field | Value |
+|-------|--------|
+| **`jira_issuetype`** | Raw value from Jira |
+| **`classified_type`** | Slug from discovered types — used for scoring and drafts |
+| **`classified_type_file`** | Resolved path, e.g. `JIRA_TYPE/STORY.md` |
+| **`type_match`** | `match` or `mismatch` |
+| **`type_mismatch_note`** | One short phrase when `mismatch` — cite Jira type vs content-fit slug (e.g. `Jira Story; content fits task definition better`) |
+
+**Scoring rubric:** Always use **`classified_type`** and open that type file — not Jira issuetype alone.
+
+**Report:** When `type_match` is **mismatch**, show **Recommend change to \<classified_type\>** under the item title in [REPORT.md](../REPORT.md) (`- KEY - Summary` in Ready/Needs Refinement; `## KEY - Summary` in Needs review). Use the slug label. Omit when `type_match` is **match**.
+
+---
+
+## Hand off
+
+Pass **`classified_type`**, **`classified_type_file`**, **`type_match`**, and **`jira_issuetype`** to **score** and [REPORT.md](../REPORT.md). Report buckets are by **score**, not by issue type.

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/README.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/README.md
@@ -1,0 +1,85 @@
+# JIRA_TYPE — work-type rubrics
+
+This directory holds **one markdown file per work type**. The skill discovers types at runtime — it does **not** assume a fixed set of story / task / bug / spike.
+
+**Glossary:** `classified_type` = the slug discovered from a type file (e.g. `story`). Same as **planning slug** in [jira-epic-breakdown](../../jira-epic-breakdown/CLASSIFY.md). Full shared terms → [CONVENTIONS.md](../CONVENTIONS.md).
+
+**Bundled defaults:** `STORY.md`, `TASK.md`, `BUG.md`, `SPIKE.md`. Teams may add, rename, or remove type files (e.g. `SUB_TASK.md`, `EPIC.md`) to match their Jira setup.
+
+---
+
+## What each type means (authoritative source)
+
+**Only** the **Definition** (and optional **Quick signals**, **Summary prefix hints**) in each type file’s **Type metadata** defines what that type is.
+
+- Other skill files (`SKILL.md`, `CLASSIFY.md`, `SCORING.md`, `REPORT.md`, etc.) **never** define or assume type semantics — they discover files and delegate to the matching rubric.
+- Teams use Jira differently (e.g. **Story** = any non-routine work, **Task** = routine maintenance). **Edit the type file’s Definition** to match your project; do not change orchestration files for that.
+
+Everything else in a type file (description template, scoring rubric, section headings) describes **how to evaluate and draft** tickets **of that type** — still team-configurable, but separate from the one-line **Definition** of what the type is for.
+
+---
+
+## Discovery
+
+Before classify, score, draft, or report:
+
+1. List `*.md` in this directory.
+2. **Exclude** `CLASSIFY.md` and `README.md` — they are orchestration docs, not types.
+3. Each remaining file is one type. Its **slug** is the filename stem, lowercased, with `-` and spaces → `_` (e.g. `SUB_TASK.md` → `sub_task`, `Story.md` → `story`).
+4. Read the **Type metadata** section at the top of each type file: **Definition** (what this type means), **Jira issuetype aliases**, **Quick signals**, optional **Summary prefix hints**, optional **Comment prefix**.
+
+**Resolve type file from slug:** `JIRA_TYPE/{SLUG}.md` using the same stem rules in reverse — try exact stem match on case-insensitive filename if needed (e.g. slug `story` → `STORY.md`).
+
+---
+
+## Adding a type
+
+1. Copy an existing type file or start from the skeleton below.
+2. Name the file for the type (e.g. `SUB_TASK.md`).
+3. Fill in **Type metadata** and the **Description template** / **Scoring** sections.
+4. No changes to `SKILL.md` are required — classify will pick it up on the next run.
+
+### Type file skeleton
+
+```markdown
+# Sub-task — evaluation criteria
+
+Apply when `classified_type` is **sub_task** (this file).
+
+## Type metadata
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `sub_task` |
+| **Definition** | <One sentence: what kind of work this type represents for your team.> |
+| **Jira issuetype aliases** | Sub-task, Subtask |
+| **Quick signals** | <comma-separated tokens that often appear in summary/description> |
+| **Summary prefix hints** | <optional — e.g. Sub-task:, [Sub-task]> |
+| **Comment prefix** | Suggested Acceptance Criteria |
+
+Description **WHAT** and **WHY** → [GENERAL.md](../GENERAL.md). This file adds the description template and scoring rubric ([SCORING.md](../SCORING.md)).
+
+---
+
+## Description template
+
+### Description
+
+...
+
+## Scoring
+
+...
+```
+
+---
+
+## Classification
+
+Follow [CLASSIFY.md](CLASSIFY.md): compare Jira `issuetype` + ticket content against **every** discovered type’s metadata and rubric intent, then assign the **best-fit slug** as `classified_type`.
+
+When Jira `issuetype` maps to one slug but content fits another better → `type_match: mismatch` and recommend the content-fit slug in the report.
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/SPIKE.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/SPIKE.md
@@ -1,0 +1,166 @@
+# Spike — evaluation criteria
+
+Apply when `classified_type` is **spike** (this file).
+
+## Type metadata
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `spike` |
+| **Definition** | **Pure research.** No deliverable beyond a recommendation or learning output. Usually informs follow-up tasks or stories — not shippable product behavior as the main “done.” |
+| **Jira issuetype aliases** | Spike |
+| **Quick signals** | spike, research, POC, investigate, compare options, feasibility, timebox, recommendation |
+| **Summary prefix hints** | Spike:, [Spike] |
+| **Comment prefix** | Suggested Spike Goals |
+
+Spikes are **research work**: investigating approaches, new knowledge, proofs of concept, comparing options, or reducing uncertainty. They are **not** a substitute for a delivery story unless the ticket explicitly frames **learning** as the main “done,” not production feature behavior.
+
+This file adds the **description template** and rubric for **outcomes**, **scope and boundaries**, and **timebox** ([SCORING.md](../SCORING.md)). Spikes do **not** use acceptance criteria — completion is **bounded research + stated outcomes delivered**.
+
+---
+
+## Description template
+
+A well-formed spike in Jira uses these sections (markdown `###` headings or equivalent in the ticket body):
+
+### Description
+
+What will be **learned or done** during the spike, and **why** it matters — what risk, gap, or decision this unblocks and why now ([GENERAL.md](../GENERAL.md) applies to the **why**; the **what** here is the investigation or exploration, not a user-facing feature).
+
+### Outcomes
+
+What the team will **get out of the work** — artifacts, answers, or decisions that help the project move forward (e.g. recommendation, comparison matrix, ADR, feasibility verdict, list of follow-up stories). Not story-style “user can click…” acceptance tests.
+
+### Scope and boundaries
+
+What is **in scope** and **out of scope** for this spike — explicit limits so the work does not drift into unscoped build or production delivery.
+
+### Timebox
+
+How much **time** will be spent (hours, days, end of sprint, or calendar cap). A bounded window sets depth expectations and defines when to stop and hand off.
+
+**Example skeleton** (paste into Jira; replace placeholders):
+
+```markdown
+### Description
+
+<What we will learn or explore, and why it matters now.>
+
+### Outcomes
+
+* <Decision, artifact, or answer the team will have when the spike ends>
+* <How this unblocks the next story, task, or architectural choice>
+
+### Scope and boundaries
+
+**In scope:** <Questions, systems, or options we will investigate>
+**Out of scope:** <Production features, full implementation, unrelated areas>
+
+### Timebox
+
+<e.g. 2 days, 8 hours, complete by end of sprint 42>
+```
+
+---
+
+## Description (evaluation)
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **What will be learned/done** | Names the investigation, comparison, or unknown being closed | “Look into X” with no concrete activity |
+| **Why** | Clear driver — blocks roadmap, reduces risk, answers architecture choice | No reason to prioritize now |
+| **Why now** | Urgency or dependency stated when relevant | Could be deferred with no loss |
+| **Not a disguised story** | Framed as research and learning | Only user-facing AC with no research outputs |
+
+---
+
+## Outcomes (evaluation)
+
+Judge what the team will **get** when the spike ends — how it helps the project move forward.
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **Named deliverables** | Written findings, ADR, comparison, POC notes, demo branch, benchmarks | Activity only (“meetings,” “read docs”) with no handoff |
+| **Decisions enabled** | States which choices or stories can start after the spike | Vague “we’ll know more” |
+| **Verifiable complete** | Reviewer can tell the spike is done without shipped product behavior | Same bullets as a story’s acceptance criteria |
+| **Actionable handoff** | Follow-up work is identifiable (even if tickets are filed later) | No link to what happens next |
+| **Clarity** | One outcome per bullet; tight lines | Long narrative paragraphs |
+
+**Missing outcomes:** If the ticket only lists implementation tasks or UI AC, score outcomes as **Missing** — reframe toward research outputs ([DRAFT.md](../DRAFT.md)).
+
+---
+
+## Scope and boundaries (evaluation)
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **In scope** | Specific questions, systems, APIs, or options under investigation | “Everything about X” |
+| **Out of scope** | Explicit exclusions (production code, full UI build, unrelated teams) | No limits — spike can grow without bound |
+| **Depth vs breadth** | Fits the timebox — focused slice | Too large for stated time |
+| **Build guardrails** | POC/throwaway code allowed; production delivery called out as follow-up | Spike hides a full feature build |
+
+Where comparison is relevant, scope should hint **how** options will be judged (constraints, success signals) without turning into implementation AC.
+
+---
+
+## Timebox (evaluation)
+
+| Criterion | Good | Weak |
+|-----------|------|------|
+| **Explicit limit** | Hours, days, sprint boundary, or calendar date | Open-ended |
+| **Realistic** | Matches scope and outcomes | Two hours for a multi-system POC |
+| **Stop rule** | Implied or stated — what “done enough” means at timebox end | No stopping point |
+| **Handoff on inconclusive** | Acceptable to document “no clear winner” and next steps | Only success path defined |
+
+---
+
+## Scoring
+
+Use with [GENERAL.md](../GENERAL.md) and [SCORING.md](../SCORING.md). Produce **one 1–5** for how well this spike’s **content** defines bounded research.
+
+### What to judge
+
+| Layer | Source |
+|-------|--------|
+| Description — what will be learned/done + why | [Description (evaluation)](#description-evaluation) |
+| Outcomes | [Outcomes (evaluation)](#outcomes-evaluation) |
+| Scope and boundaries | [Scope and boundaries (evaluation)](#scope-and-boundaries-evaluation) |
+| Timebox | [Timebox (evaluation)](#timebox-evaluation) |
+
+### Weak vs strong (score drivers)
+
+| Area | Weak (pulls toward 1–3) | Strong (pulls toward 4–5) |
+|------|-------------------------|---------------------------|
+| Description | “Look into X” | What will be learned and why now |
+| Outcomes | Story-style UI AC only | Artifacts, decisions, or answers that unblock next work |
+| Scope and boundaries | Unbounded | Clear in/out of scope |
+| Timebox | Open-ended | Explicit time limit |
+
+### Balance and caps
+
+- **Disguised story/task** (only shippable feature AC, no research outputs) → **cap at 2–3** until reframed.
+- Description + timebox but no outcomes → **cap at 3**.
+- Outcomes + description but no timebox → **cap at 3–4** depending on scope clarity.
+
+### Calibration examples
+
+| Score | Example |
+|-------|---------|
+| **5** | Clear learn/done + why, named outcomes, in/out scope, explicit timebox. |
+| **4** | Solid on all four; timebox or scope slightly soft. |
+| **3** | Good description but missing timebox or vague outcomes. |
+| **2** | Description only; no outcomes or timebox. |
+| **1** | Empty or indistinguishable from a delivery story with no research framing. |
+
+---
+
+## Completion (not a Jira section)
+
+When drafting suggestions ([DRAFT.md](../DRAFT.md)) or closing a spike, verification is:
+
+1. **Timebox** respected (or explicitly extended with reason).
+2. **Outcomes** listed in the ticket are delivered or documented as partial with gaps named.
+3. **Scope** was honored — no unscoped production feature shipped as “spike complete.”
+4. Team can file or refine **follow-up stories/tasks** from the findings.
+
+Do not replace missing outcomes or timebox with story-style acceptance criteria unless the ticket was misclassified.

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/STORY.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/STORY.md
@@ -1,0 +1,132 @@
+# Story — evaluation criteria
+
+Apply when `classified_type` is **story** (this file).
+
+## Type metadata
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `story` |
+| **Definition** | **End-user changes.** Work impacts the user interface or how users (or other systems) interact with the application. Usually feature changes or additions; rarely removal of user-facing features. *(Bundled default for this skill install — edit to match your team, e.g. if Story means any non-routine work.)* |
+| **Jira issuetype aliases** | Story, User Story |
+| **Quick signals** | user, UI, screen, flow, wizard, button, display, feature, integration visible to user |
+| **Comment prefix** | Suggested Acceptance Criteria |
+
+Description **WHAT** and **WHY** → [GENERAL.md](../GENERAL.md). This file adds the **description template**, story-specific checks, and **acceptance criteria** rubric for scoring ([SCORING.md](../SCORING.md)).
+
+---
+
+## Description template
+
+A well-formed story description in Jira uses these sections (markdown `###` headings or equivalent in the ticket body):
+
+### Description or User Story
+
+Describes the **what** and **why** ([GENERAL.md](../GENERAL.md)).
+
+### Acceptance Criteria
+
+The full acceptance criteria — testable bullets judged against the rubric in [Acceptance criteria](#acceptance-criteria) below.
+
+### Mock ups / Design
+
+Description and/or a link to design docs — for example a Figma link, prototype, or spec. Required for large or complex UI (see [Description (story-specific)](#description-story-specific)); may be brief or **N/A** for trivial UI tweaks.
+
+### Out of Scope
+
+This section doesn't need to be filled out.  When it is filled out is specifies any thing that is not covered by this story.  Not that this shouldn't replace acceptance criteria. The purpose of this section is for clarification or to answer commonly asked questions.
+
+### Implementation Notes
+
+This section doesn't need to be filled out.  When it is filled out it contains high level implementation approaches, notes, or items a developer will need to know when coding.
+
+**Example skeleton** (paste into Jira; replace placeholders):
+
+```markdown
+### Description or User Story
+
+<What is changing and why it matters.>
+
+### Acceptance Criteria
+
+* <Verifiable outcome 1>
+* <Verifiable outcome 2>
+
+### Mock ups / Design
+
+<Figma link, screenshot reference, or N/A — small UI tweak>
+```
+
+---
+
+## Description (story-specific)
+
+**UI complexity and design references:** For **large or complex** user interface changes (new flows, new screens, major layout or interaction shifts), the ticket links to **mockups, prototypes, or design specs** (Figma, screenshots, design-system references, or similar). Trivial UI tweaks may not need them; ambiguous or broad UI work without a visual or spec anchor should be flagged.
+
+When scoring UI design refs in the report: **`Met`** · **`Partial`** · **`Missing`** · **`N/A`** (non-UI or trivial tweak).
+
+---
+
+## Acceptance criteria
+
+**Testability:** Each criterion must be verifiably clear, allowing QA to create specific, objective pass/fail test cases.
+
+**User-Centricity:** Focus on what the user experiences or achieves, not how the code is written.
+
+**What vs how (outcomes vs implementation):** AC should specify **what** must be true when the work is accepted—observable outcomes, user-visible behavior, and constraints on experience. Avoid prescribing **how** to implement (specific layers, refactors, internal APIs, file moves) except where the ticket defines an explicit integration **contract**; then state that contract as the **what** at the boundary (e.g. what data the host provides), not arbitrary engineering steps.
+
+**Clarity, conciseness & length:** One **verifiable outcome** per bullet, as a **tight line** (not a paragraph). Prefer precise pass/fail wording over narrative; keep background, rationale, and long edge-case notes in the story body or linked docs. Plain language so the list stays **scannable** for QA, product, and engineering.
+
+**Grouping & nesting:** **Related** criteria can sit under one **parent** bullet so readers see structure (e.g. one flow: loading state → error/retry → success branches; or one integration contract with sub-bullets for each observable rule). Each nested line stays a **separate** testable outcome; nesting shows **relationship**, not one long run-on sentence.
+
+**Completeness:** Cover functional requirements, edge cases, error handling (e.g., empty states, invalid input), and performance thresholds where relevant.
+
+**Happy path vs error coverage:** AC should not stop at “it works when everything goes right.” For anything that can fail (validation, permissions, network/API errors, empty lists, timeouts), the AC should state the **expected user-visible outcome**—not only on success.
+
+**Boundary Definition:** Clearly outline what is included in the scope to prevent scope creep.
+
+**Functional Precision:** Does the AC specify UI interactions (e.g., "On click," "On hover," "Upon form submission")?
+
+**Visual/Responsive Requirements:** Does it mention specific states (Active, Disabled, Loading) if applicable?
+
+**Validation & Error Handling:** Does it define what happens when a user enters invalid data into a web form or if an API call fails? Are error messages, inline field feedback, and disabled/submit states specified where relevant?
+
+**Navigation:** Is the "Success Path" clear (e.g., "User is redirected to the Dashboard")? If a step can fail, is it clear whether the user stays on the page, sees an error region, or gets a retry path?
+
+---
+
+## Scoring
+
+Use with [GENERAL.md](../GENERAL.md) and [SCORING.md](../SCORING.md). Produce **one 1–5** for how well this story’s **content** fits a deliverable user-facing ticket.
+
+### What to judge
+
+| Layer | Source |
+|-------|--------|
+| Description — WHAT + WHY | [GENERAL.md](../GENERAL.md) |
+| Acceptance criteria | [Acceptance criteria](#acceptance-criteria) above |
+| UI design refs | [Description (story-specific)](#description-story-specific) — **only** for large or complex UI |
+
+### Weak vs strong (score drivers)
+
+| Area | Weak (pulls toward 1–3) | Strong (pulls toward 4–5) |
+|------|-------------------------|---------------------------|
+| Description | No WHAT/WHY | Problem and change are clear |
+| Acceptance criteria | Missing, vague, or implementation-only | Testable, user-visible outcomes; errors and key states covered |
+| UI design (large/complex UI only) | No mockup/Figma/spec when UI work is broad | Link or spec anchor present |
+
+### Balance and caps
+
+- Great AC with thin or missing WHAT/WHY → **cap at 3**.
+- Clear WHAT/WHY with no testable AC → **cap at 2–3**.
+- Large/complex UI with no design anchor → unlikely above **3** until link or spec exists.
+
+### Calibration examples
+
+| Score | Example |
+|-------|---------|
+| **5** | Clear WHY/WHAT + AC covers happy path, loading, and errors; Figma linked for a new wizard step. |
+| **4** | Solid WHY/WHAT + testable AC; one edge case or error path unnamed. |
+| **3** | WHY present but AC stops at happy path only; or WHAT clear but AC is thin. |
+| **2** | Bullets are implementation tasks, not testable outcomes; or summary-only with vague AC. |
+| **1** | Empty description; no usable AC. |

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/STORY.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/STORY.md
@@ -28,7 +28,7 @@ Describes the **what** and **why** ([GENERAL.md](../GENERAL.md)).
 
 The full acceptance criteria — testable bullets judged against the rubric in [Acceptance criteria](#acceptance-criteria) below.
 
-### Mock ups / Design
+### Mockups / Design
 
 Description and/or a link to design docs — for example a Figma link, prototype, or spec. Required for large or complex UI (see [Description (story-specific)](#description-story-specific)); may be brief or **N/A** for trivial UI tweaks.
 
@@ -52,7 +52,7 @@ This section doesn't need to be filled out.  When it is filled out it contains h
 * <Verifiable outcome 1>
 * <Verifiable outcome 2>
 
-### Mock ups / Design
+### Mockups / Design
 
 <Figma link, screenshot reference, or N/A — small UI tweak>
 ```

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/TASK.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/TASK.md
@@ -30,11 +30,11 @@ The full acceptance criteria — testable bullets judged against the rubric in [
 
 ### Out of Scope
 
-This section doesn't need to be filled out.  When it is filled out is specifies any thing that is not covered by this story.  Not that this shouldn't replace acceptance criteria. The purpose of this section is for clarification or to answer commonly asked questions.
+This section doesn't need to be filled out. When it is filled out, it specifies anything that is not covered by this task. Note that this shouldn't replace acceptance criteria. The purpose of this section is for clarification or to answer commonly asked questions.
 
 ### Implementation Notes
 
-This section doesn't need to be filled out.  When it is filled out it contains high level implementation approaches, notes, or items a developer will need to know when coding.
+This section doesn't need to be filled out. When it is filled out it contains high-level implementation approaches, notes, or items a developer will need to know when coding.
 
 **Example skeleton** (paste into Jira; replace placeholders):
 

--- a/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/TASK.md
+++ b/.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/TASK.md
@@ -1,0 +1,103 @@
+# Task — evaluation criteria
+
+Apply when `classified_type` is **task** (this file).
+
+## Type metadata
+
+| Field | Value |
+|-------|-------|
+| **Slug** | `task` |
+| **Definition** | **Structural or coding work without a user interface.** There is a clear deliverable — code change, config change, report, tooling, infra, etc. *(Bundled default for this skill install — edit to match your team, e.g. if Task means routine or operational work.)* |
+| **Jira issuetype aliases** | Task |
+| **Quick signals** | refactor, config, pipeline, dependency bump, report, script, infra, API contract (no UI) |
+| **Comment prefix** | Suggested Acceptance Criteria |
+
+Description **WHAT** and **WHY** → [GENERAL.md](../GENERAL.md). This file adds the **description template**, task-specific checks, and **acceptance criteria** rubric for scoring ([SCORING.md](../SCORING.md)).
+
+---
+
+## Description template
+
+A well-formed task description in Jira uses these sections (markdown `###` headings or equivalent in the ticket body):
+
+### Description
+
+Describes the **what** and **why** ([GENERAL.md](../GENERAL.md)).
+
+### Acceptance Criteria
+
+The full acceptance criteria — testable bullets judged against the rubric in [Acceptance criteria](#acceptance-criteria) below.
+
+### Out of Scope
+
+This section doesn't need to be filled out.  When it is filled out is specifies any thing that is not covered by this story.  Not that this shouldn't replace acceptance criteria. The purpose of this section is for clarification or to answer commonly asked questions.
+
+### Implementation Notes
+
+This section doesn't need to be filled out.  When it is filled out it contains high level implementation approaches, notes, or items a developer will need to know when coding.
+
+**Example skeleton** (paste into Jira; replace placeholders):
+
+```markdown
+### Description or User Story
+
+<What is changing and why it matters.>
+
+### Acceptance Criteria
+
+* <Verifiable outcome 1>
+* <Verifiable outcome 2>
+
+```
+
+---
+
+## Acceptance criteria
+
+**Testability:** Each criterion must be verifiably clear, allowing QA or team members to determine when the work is complete.
+
+
+**What vs how (outcomes vs implementation):** AC should specify **what** must be true when the work is accepted. Avoid prescribing **how** to implement (specific layers, refactors, internal APIs, file moves) except where the ticket defines an explicit integration **contract**; then state that contract as the **what** at the boundary (e.g. what data the host provides), not arbitrary engineering steps.
+
+**Clarity, conciseness & length:** One **verifiable outcome** per bullet, as a **tight line** (not a paragraph). Prefer precise pass/fail wording over narrative; keep background, rationale, and long edge-case notes in the story body or linked docs. Plain language so the list stays **scannable** for QA, product, and engineering.
+
+**Grouping & nesting:** **Related** criteria can sit under one **parent** bullet so readers see structure (e.g. one flow: loading state → error/retry → success branches; or one integration contract with sub-bullets for each observable rule). Each nested line stays a **separate** testable outcome; nesting shows **relationship**, not one long run-on sentence.
+
+**Completeness:** Cover functional requirements, edge cases, error handling (e.g., empty states, invalid input), and performance thresholds where relevant.
+
+**Boundary Definition:** Clearly outline what is included in the scope to prevent scope creep.
+
+---
+
+## Scoring
+
+Use with [GENERAL.md](../GENERAL.md) and [SCORING.md](../SCORING.md). Produce **one 1–5** for how well this task’s **content** fits a non-UI deliverable ticket.
+
+### What to judge
+
+| Layer | Source |
+|-------|--------|
+| Description — WHAT + WHY | [GENERAL.md](../GENERAL.md) |
+| Acceptance criteria | [Acceptance criteria](#acceptance-criteria) above |
+
+### Weak vs strong (score drivers)
+
+| Area | Weak (pulls toward 1–3) | Strong (pulls toward 4–5) |
+|------|-------------------------|---------------------------|
+| Description | No WHAT/WHY | Deliverable and reason are clear |
+| Acceptance criteria | Missing or not verifiable | Clear done conditions for the deliverable |
+
+### Balance and caps
+
+- Great AC with thin or missing WHAT/WHY → **cap at 3**.
+- Clear WHAT/WHY with no verifiable AC → **cap at 2–3**.
+
+### Calibration examples
+
+| Score | Example |
+|-------|---------|
+| **5** | Clear WHAT/WHY + AC states observable done state for config/report/code change. |
+| **4** | Solid WHAT/WHY + AC covers main outcome; one edge case unnamed. |
+| **3** | Intent clear but AC incomplete or partly untestable. |
+| **2** | Description only, or AC is a task list without verifiable outcomes. |
+| **1** | Empty description; summary-only. |

--- a/.agents/skills/jira-acceptance-criteria-check/POST_JIRA.md
+++ b/.agents/skills/jira-acceptance-criteria-check/POST_JIRA.md
@@ -98,4 +98,4 @@ Preserve markdown (`*`, `**`, nesting). Omit the `## KEY - Summary` title line (
 
 When input came from [DRAFT_INPUT.md](DRAFT_INPUT.md) with **no** real Jira keys → **never** ask to post; **never** call MCP for comments.
 
-When a run mixes Jira keys and draft ids → ask only about postable Jira keys; skip draft ids silently in the count unless the user asks.
+When a run mixes Jira keys and draft IDs → ask only about postable Jira keys; skip draft IDs silently in the count unless the user asks.

--- a/.agents/skills/jira-acceptance-criteria-check/POST_JIRA.md
+++ b/.agents/skills/jira-acceptance-criteria-check/POST_JIRA.md
@@ -1,0 +1,101 @@
+# Post suggestions to Jira (optional)
+
+After [REPORT.md](REPORT.md) delivers the check output, offer to save **Needs review** suggestions as Jira comments via **MCP only**.
+
+---
+
+## When to ask
+
+Ask **only when all** are true:
+
+| Condition | Notes |
+|-----------|-------|
+| Step 5 report is complete | Chat (1 issue) or `jira-acceptance-criteria-check-report.md` + chat pointer (2+) |
+| At least one **Needs review** item | Score **1–3** **and** a draft was produced ([DRAFT.md](DRAFT.md)) |
+| At least one postable key | Real Jira key (e.g. `FCN-232`) — not `DRAFT-*`, `#n`, or synthetic-only ids ([DRAFT_INPUT.md](DRAFT_INPUT.md)) |
+
+If **no** item qualifies → **do not ask**; end the skill after the report.
+
+**Prompt (one short question):**
+
+> Post **N** suggestion(s) as Jira comment(s) using MCP? (yes / no)
+
+Replace **N** with the count of postable **Needs review** keys. If the user restricts keys in their reply (“only FCN-100”), honor that subset.
+
+**Do not post** unless the user clearly agrees (**yes**, **y**, **post**, **save**, etc.). **No** or silence → stop; no Jira writes.
+
+---
+
+## Which issues to post
+
+| Include | Exclude |
+|---------|---------|
+| **Needs review** — score 1–3 with suggested `###` sections | **Ready** (4–5) |
+| Real Jira keys from this run | **Needs Refinement** (1–3 without draft) |
+| User-approved subset when they name keys | Synthetic / draft-only ids |
+
+---
+
+## Skip duplicate comments
+
+Before posting a key, check whether this run already found an existing Jira comment that **starts with** the type file’s **Comment prefix** from **Type metadata** ([JIRA_TYPE/README.md](JIRA_TYPE/README.md)).
+
+**Fallback** when a type omits **Comment prefix** — infer from that type file’s **Description template** headings only:
+
+| Template signal | Prefix |
+|-----------------|--------|
+| Includes **Acceptance Criteria** (or equivalent) | `Suggested Acceptance Criteria` |
+| Primary sections are outcomes / goals / research deliverables (not AC) | `Suggested Goals` |
+| Other | `Suggested Description` |
+
+**Source:** comment data from [DRAFT.md](DRAFT.md) enrichment in this run — **do not** re-fetch just to double-check.
+
+If a prior suggested comment exists for a key → **skip** that key. Tell the user Jira already has a suggested comment; they can edit or delete it in Jira if they want a new one.
+
+If **every** postable key is skipped → summarize; run **no** `addCommentToJiraIssue` calls.
+
+---
+
+## MCP transport
+
+1. Read MCP tool schemas under `user-atlassian-mcp-server` before calling.
+2. If only **`mcp_auth`** is listed → call `mcp_auth` for `user-atlassian-mcp-server` with `{}`, then re-check tools.
+3. Resolve `cloudId` via `getAccessibleAtlassianResources` (or pass `redhat.atlassian.net` per tool docs).
+4. For each key **not** skipped, call **`addCommentToJiraIssue`**:
+   - `issueIdOrKey`: the Jira key
+   - `commentBody`: built per [Comment body](#comment-body) below
+   - `contentFormat`: `"markdown"`
+
+**On MCP failure** (auth, server missing, API error): report the **full error** for that key. Tell the user to fix MCP in **Settings → MCP** (Atlassian server enabled; complete `mcp_auth` if prompted) and re-run the post step if they want.
+
+After **each** successful post, confirm in chat: key + “comment posted”. On failure, show the error and continue or stop per user preference.
+
+---
+
+## Comment body
+
+Build one `commentBody` per key from the **Needs review** content for that issue in this run’s report (chat or `jira-acceptance-criteria-check-report.md`).
+
+**Header (lines 1–2):**
+
+Line 1: **Comment prefix** from the issue’s type file **Type metadata** ([JIRA_TYPE/README.md](JIRA_TYPE/README.md)); use [Skip duplicate comments](#skip-duplicate-comments) fallbacks if missing.
+
+Line 2 (all types): `Created with AI`
+
+Then **one blank line**, then the issue block from the report:
+
+- **Score: N** and **Score note** when present
+- **Recommend change to \<type\>** when `type_match` is **mismatch**
+- All suggested **`###` sections** and their bullets/content
+
+**Do not** drop sections to save space — post the same suggestion the user saw in the check output.
+
+Preserve markdown (`*`, `**`, nesting). Omit the `## KEY - Summary` title line (the key is the issue); include everything else from the item block through the last `###` section.
+
+---
+
+## Synthetic / draft-only runs
+
+When input came from [DRAFT_INPUT.md](DRAFT_INPUT.md) with **no** real Jira keys → **never** ask to post; **never** call MCP for comments.
+
+When a run mixes Jira keys and draft ids → ask only about postable Jira keys; skip draft ids silently in the count unless the user asks.

--- a/.agents/skills/jira-acceptance-criteria-check/README.md
+++ b/.agents/skills/jira-acceptance-criteria-check/README.md
@@ -1,0 +1,176 @@
+# jira-acceptance-criteria-check
+
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that classifies Jira work items by type, scores description and type-specific content 1–5, drafts suggested ticket content for low scores, and reports **Ready** / **Needs review** / **Needs Refinement**. One issue → chat; two or more → markdown file. Optionally posts Needs review drafts to Jira via MCP.
+
+Use before sprint planning or backlog grooming — not a one-off “looks fine” pass.
+
+## Requirements
+
+### Atlassian Jira MCP (required)
+
+This skill **requires** the **Atlassian MCP server** (`user-atlassian-mcp-server`) to be enabled and authenticated in Cursor.
+
+| Capability | MCP required? |
+|------------|---------------|
+| Fetch issues (keys or JQL) | **Yes** ([JIRA.md](JIRA.md)) |
+| Post suggestion comments after the report | **Yes** ([POST_JIRA.md](POST_JIRA.md)) |
+| Classify, score, draft, report | Works on fetched or pasted data once issues are in scope |
+
+**Setup:**
+
+1. Cursor → **Settings → MCP** — enable the **Atlassian** server.
+2. Complete auth when prompted (`mcp_auth` for `user-atlassian-mcp-server`).
+3. Confirm tools such as `getJiraIssue`, `searchJiraIssuesUsingJql`, and `addCommentToJiraIssue` are available.
+
+Without MCP, the skill **cannot** fetch Jira issues or post suggestions. Pasted draft bodies ([DRAFT_INPUT.md](DRAFT_INPUT.md)) can still be scored in isolation, but that is not the primary workflow.
+
+---
+
+## What it does
+
+The agent follows [SKILL.md](SKILL.md) in order:
+
+1. **Get issues** — Jira keys or JQL via **MCP only**, or synthetic/pasted drafts without Jira
+2. **Classify** — discover work types from `JIRA_TYPE/` and assign the best-fit slug per ticket
+3. **Score** — one holistic **1–5** per issue (description WHAT/WHY + type-specific rubric)
+4. **Draft** (scores 1–3 only) — suggested ticket body sections when enough context exists; skip guessing
+5. **Report** — bucket into Ready (4–5), Needs review (1–3 with draft), Needs Refinement (1–3 without draft)
+6. **Post suggestions** (optional) — ask once; post Needs review drafts as Jira comments via MCP if you agree
+
+**One issue** → full report in chat. **Two or more** → writes `jira-acceptance-criteria-check-report.md` in the workspace; chat gets a short pointer.
+
+Type mismatch (Jira issuetype vs ticket content) is flagged as **Recommend change to \<slug\>** — scoring and drafts use the content-fit type.
+
+---
+
+## How to use it
+
+### Install the skill
+
+Copy this folder into a skills location Cursor reads:
+
+| Location | Scope |
+|----------|-------|
+| `~/.cursor/skills/jira-acceptance-criteria-check/` | Personal — all projects |
+| `.cursor/skills/jira-acceptance-criteria-check/` | Project — shared with the repo |
+
+Ensure **Atlassian MCP** is configured (see [Requirements](#requirements)).
+
+### Trigger in Cursor
+
+Ask the agent to run the skill — for example:
+
+- “Run jira-acceptance-criteria-check on `FCN-232`”
+- “Check acceptance criteria for my open stories in FCN”
+- “Score these draft tickets before I create them in Jira” (paste bodies — no fetch)
+- “JQL: `parent = FCN-100 AND status != Done` — acceptance criteria check”
+
+The skill is **user-invocable** (`SKILL.md` frontmatter). The description helps the agent auto-select it for ticket-quality tasks.
+
+### Input options
+
+| Input | Behavior |
+|-------|----------|
+| Issue keys | `key in (…)` search |
+| JQL | Use as-is (sanity-checked) |
+| Natural language | Agent translates to JQL |
+| Pasted draft bodies | Synthetic mode — no Jira fetch ([DRAFT_INPUT.md](DRAFT_INPUT.md)) |
+| **jira-epic-breakdown** output | Internal review uses the same rubrics before Jira create |
+
+After the report, if there are **Needs review** items on real Jira keys, the agent asks whether to post suggestions as comments (**yes** / **no**).
+
+---
+
+## Directory layout
+
+```
+jira-acceptance-criteria-check/
+├── SKILL.md              # Orchestrator — workflow and companion index
+├── README.md             # This file
+├── JIRA.md               # Fetch issues (MCP only)
+├── DRAFT_INPUT.md        # Synthetic / pasted drafts (no Jira)
+├── GENERAL.md            # Cross-type description bar (WHAT + WHY)
+├── SCORING.md            # How to combine into one 1–5 score
+├── DRAFT.md              # Draft rules for scores 1–3
+├── REPORT.md             # Output shape and buckets
+├── POST_JIRA.md          # Optional MCP comment posts
+└── JIRA_TYPE/            # ← customize: one rubric file per work type
+    ├── README.md         # Discovery, adding types, authoritative Definition
+    ├── CLASSIFY.md       # Classify orchestration (no type semantics here)
+    ├── STORY.md          # Bundled default
+    ├── TASK.md           # Bundled default
+    ├── BUG.md            # Bundled default
+    └── SPIKE.md          # Bundled default
+```
+
+---
+
+## How to modify it
+
+### Do not edit (orchestration)
+
+These files are **type-agnostic**. They discover `JIRA_TYPE/` rubrics and delegate — they do **not** define what Story, Task, Bug, or Spike mean:
+
+- `SKILL.md`
+- `JIRA.md`, `DRAFT_INPUT.md`
+- `GENERAL.md`, `SCORING.md`, `DRAFT.md`, `REPORT.md`, `POST_JIRA.md`
+- `JIRA_TYPE/CLASSIFY.md`, `JIRA_TYPE/README.md` (orchestration within the type folder)
+
+### Customize (your Jira practice)
+
+| What to change | Where | Why |
+|----------------|-------|-----|
+| **What each type means** | `JIRA_TYPE/{TYPE}.md` → **Type metadata** → **Definition** | Teams use Story/Task differently (e.g. Story = any non-routine work, Task = routine ops). This is the **only** authoritative source for type meaning. |
+| **Jira issuetype mapping** | Same file → **Jira issuetype aliases** | Map your site’s labels to each slug |
+| **Ticket template & scoring** | Same file → **Description template**, **Scoring** | Section headings, rubric, calibration examples |
+| **Add a type** | New `JIRA_TYPE/SUB_TASK.md` (etc.) | See [JIRA_TYPE/README.md](JIRA_TYPE/README.md) — no `SKILL.md` edit needed |
+| **Remove a type** | Delete the type file | Discovery picks up the remaining set on the next run |
+
+**Example — another team’s Story definition:** edit `JIRA_TYPE/STORY.md`:
+
+```markdown
+| **Definition** | Any non-routine deliverable work (frontend, backend, or cross-cutting). Routine maintenance belongs in Task. |
+```
+
+Orchestration files stay unchanged.
+
+### Bundled defaults
+
+This install ships **STORY**, **TASK**, **BUG**, and **SPIKE** rubrics tuned for one team’s practice (e.g. Story ≈ user-facing change, Task ≈ non-UI deliverable). Treat them as **starting templates** — edit **Definition** and rubrics to match your Jira project.
+
+---
+
+## Score scale (summary)
+
+| Score | Bucket | Meaning |
+|-------|--------|---------|
+| **4–5** | Ready | Description and type-specific content are strong |
+| **1–3** + draft | Needs review | Gaps identified; suggested sections provided |
+| **1–3** no draft | Needs Refinement | Not enough context to suggest honestly |
+
+Full scale and combination rules → [SCORING.md](SCORING.md). Per-type weak/strong signals live **only** in the matching `JIRA_TYPE/*.md` file.
+
+---
+
+## Related skills
+
+| Skill | Relationship |
+|-------|----------------|
+| [jira-epic-breakdown](../jira-epic-breakdown/SKILL.md) | Decomposes epics; runs this skill’s rubrics on drafts before delivery |
+| [CONVENTIONS.md](CONVENTIONS.md) | Shared paths, MCP rules, skill index |
+
+---
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|----------------|
+| Fetch fails | Atlassian MCP enabled and authenticated; retry `mcp_auth` |
+| No issues returned | JQL too narrow; verify keys exist and you have access |
+| Post step skipped | No Needs review items, draft-only ids, or duplicate suggestion comment already on issue |
+| Wrong type assigned | Edit **Definition** / **Quick signals** in the relevant `JIRA_TYPE/*.md` file |
+| Comment post fails | Fix Atlassian MCP auth and retry |
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-acceptance-criteria-check/REPORT.md
+++ b/.agents/skills/jira-acceptance-criteria-check/REPORT.md
@@ -13,7 +13,7 @@ Replace keys and summaries with real values. Do **not** wrap the whole report in
 | Issue count | Destination | Section headers (`# Ready`, etc.) |
 |-------------|-------------|-----------------------------------|
 | **1** | **Chat** — full report content | **Omit** — no `# Ready` / `# Needs review` / `# Needs Refinement` wrappers |
-| **2+** | **Markdown file** in the workspace — `jira-acceptance-criteria-check-report.md` | **Include** — see [Report shape](#report-shape) |
+| **2+** | **`{workspace}/jira-acceptance-criteria-check-report.md`** (absolute path) | **Include** — see [Report shape](#report-shape) |
 
 **Multiple issues — chat:** Post only a short pointer in chat (file path, JQL, issue count, fetch transport, one-line summary of bucket counts). Do **not** paste the full report body into chat.
 

--- a/.agents/skills/jira-acceptance-criteria-check/REPORT.md
+++ b/.agents/skills/jira-acceptance-criteria-check/REPORT.md
@@ -1,0 +1,180 @@
+# Report output
+
+Replace keys and summaries with real values. Do **not** wrap the whole report in a code fence.
+
+**Inputs per issue:** `score`, `score_justification`, `classified_type`, `jira_issuetype`, `type_match` from [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) + [SCORING.md](SCORING.md); suggested content from [DRAFT.md](DRAFT.md) when applicable.
+
+**Grouping:** One unified report — **not** split by issue type. Each issue appears in **exactly one** section below.
+
+---
+
+## Where to write output
+
+| Issue count | Destination | Section headers (`# Ready`, etc.) |
+|-------------|-------------|-----------------------------------|
+| **1** | **Chat** — full report content | **Omit** — no `# Ready` / `# Needs review` / `# Needs Refinement` wrappers |
+| **2+** | **Markdown file** in the workspace — `jira-acceptance-criteria-check-report.md` | **Include** — see [Report shape](#report-shape) |
+
+**Multiple issues — chat:** Post only a short pointer in chat (file path, JQL, issue count, fetch transport, one-line summary of bucket counts). Do **not** paste the full report body into chat.
+
+**Single issue — chat:** Post the full item content (score note, mismatch line, suggested sections as applicable). Omit section bucket headers even when the item would normally land under Ready, Needs review, or Needs Refinement.
+
+---
+
+## Bucket rules
+
+| Section | Score | Draft ([DRAFT.md](DRAFT.md)) |
+|---------|-------|------------------------------|
+| **Ready** | **4 or 5** | — |
+| **Needs review** | **1–3** | Suggested description and type-specific sections **were** created |
+| **Needs Refinement** | **1–3** | **Not enough information** to suggest description or other sections |
+
+Empty section → `*None.*`
+
+---
+
+## Type mismatch line
+
+When [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) sets **`type_match`** to **`mismatch`**, show **below** the item title (any section):
+
+**Recommend change to \<classified_type\>**
+
+Use the slug from **`classified_type`** (e.g. **Recommend change to \<slug\>**).
+
+`<classified_type>` is the type the **content** fits — what scoring and drafts used. Omit this line when `type_match` is **match**.
+
+---
+
+## Suggested content (Needs review only)
+
+Use the **Description template** from the issue’s **`classified_type`** file (`JIRA_TYPE/{slug}.md`):
+
+1. Open that type file.
+2. Draft only the `###` headings listed under **Description template** — no sections from other types.
+
+Under each item title, after the optional type-mismatch line, paste the draft using **`###` headings** matching that template. Use `*` bullets where the template uses lists. Follow [DRAFT.md](DRAFT.md) for nesting and do-not-invent rules.
+
+Optional: one line **Score: N** and/or **Score note:** … from `score_justification` before suggested sections.
+
+---
+
+## Report shape
+
+**Multiple issues (2+)** — write `jira-acceptance-criteria-check-report.md` using this structure.
+
+Optional metadata block at the top (when useful):
+
+- JQL or scope used
+- Issue count
+- Fetch transport ([JIRA.md](JIRA.md))
+
+Then **three sections** separated by horizontal rules (`---` on its own line):
+
+1. `---` after metadata (before `# Ready`)
+2. `---` between **Ready** and **Needs review**
+3. `---` between **Needs review** and **Needs Refinement**
+
+Section titles are **H1** (`# Ready`, `# Needs review`, `# Needs Refinement`).
+
+The example below shows **structure only**. `###` headings and mismatch lines must come from the issue’s type file — not from this sample.
+
+```markdown
+# Acceptance criteria check report
+
+**JQL:** `project = fcn AND …`
+**Issues:** 4
+**Transport:** MCP
+
+---
+
+# Ready
+
+- FCN-217 - Implement data ownership handoff between wizard form and YAML review step
+
+- FCN-999 - Backend config for feature flags
+  **Recommend change to task**
+
+---
+
+# Needs review
+
+## FCN-232 - Implement versions in ACM
+
+**Recommend change to story**
+
+**Score: 3**
+
+### Description or User Story
+
+<Suggested what and why.>
+
+### Acceptance Criteria
+
+* <Suggested verifiable outcome>
+* <Suggested verifiable outcome>
+  * <Nested sub-outcome if needed>
+
+### Mock ups / Design
+
+<Figma link or N/A>
+
+---
+
+## FCN-500 - Login fails after password reset
+
+### Description
+
+<Suggested what is broken and why.>
+
+### How to reproduce
+
+1. <Step>
+2. <Step>
+
+### Expected
+
+<Correct behavior>
+
+### Actual
+
+<Failure behavior>
+
+---
+
+# Needs Refinement
+
+- FCN-245 - Prerequisites page for ACM
+
+- ABC-3 - Summary only ticket with no context
+```
+
+**Single issue (1)** — same item formatting as above, but **omit** `# Ready` / `# Needs review` / `# Needs Refinement`, metadata `---` separators, and the report title block unless the user asked for JQL/transport context. Post directly in chat.
+
+---
+
+## Formatting rules
+
+### Ready and Needs Refinement
+
+- Line format: `- KEY - Summary` (leading `-`, space, key, ` - `, summary).
+- **Recommend change to …** on its own line directly under the item line when `type_match` is **mismatch** — bold the full phrase.
+- **Needs Refinement:** optionally add nested `*` bullets naming **what is missing** (from `score_justification`) when that helps the author; keep brief.
+
+### Needs review
+
+- Item title: **H2** — `## KEY - Summary` (link the key when helpful: `https://redhat.atlassian.net/browse/<KEY>`).
+- Place a horizontal rule (`---`) **between each** Needs review item (after the last `###` section of one item, before the next `## KEY - Summary`).
+- No horizontal rule after the final Needs review item (before the `---` that precedes `# Needs Refinement`).
+- **Recommend change to …** directly under the H2 when `type_match` is **mismatch** — bold the full phrase.
+- Suggested `###` sections immediately under the item (after mismatch line if any). Use template heading names from the **`classified_type`** file.
+
+### All sections
+
+- Do **not** split the report into blocks by issue type.
+- Link issues when helpful: `https://redhat.atlassian.net/browse/<KEY>`
+
+---
+
+## After the report
+
+When **Needs review** items exist (score 1–3 with a draft) on real Jira keys, step 6 in [SKILL.md](SKILL.md) asks whether to post suggestions as comments. See [POST_JIRA.md](POST_JIRA.md).

--- a/.agents/skills/jira-acceptance-criteria-check/SCORING.md
+++ b/.agents/skills/jira-acceptance-criteria-check/SCORING.md
@@ -1,0 +1,61 @@
+# Scoring
+
+How to produce **one score from 1 to 5** per issue for how well the ticket **content** fits its work type.
+
+**What the score measures:** description quality ([GENERAL.md](GENERAL.md)) **plus** type-specific content — judged using the **Scoring** section in the matching type file.
+
+**What the score does not measure (for now):** whether the ticket uses the correct template headings. See [What to ignore](#what-to-ignore).
+
+Type-specific dimensions, weak/strong signals, and calibration examples live **only** in discovered type files under [JIRA_TYPE/](JIRA_TYPE/README.md) — update or add a type file when a rubric changes.
+
+---
+
+## Before you score each issue
+
+1. Have **`classified_type`** from [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) and **`summary` + `description`** from [JIRA.md](JIRA.md) or [DRAFT_INPUT.md](DRAFT_INPUT.md).
+2. Read [GENERAL.md](GENERAL.md) (WHAT + WHY).
+3. Open the **Scoring** section in the type file for `classified_type` — resolve path via [JIRA_TYPE/README.md](JIRA_TYPE/README.md).
+4. Judge **substance** in the ticket body even when sections are merged, mislabeled, or buried in comments.
+
+---
+
+## How to combine into one score
+
+1. Evaluate **description** (WHAT + WHY) and **type-specific content** together — **one** holistic **1–5**, not separate scores per section.
+2. Use the **full range** (1–5) so results sort meaningfully; avoid defaulting everything to 3.
+3. Apply the **balance rule:** a **5** requires both a clear description **and** strong type-specific content. One without the other caps the score — see the type file for typical caps.
+4. Write a short **justification**: main gaps (below 5) or why it is strong (4–5).
+
+---
+
+## Scale (1–5)
+
+| Score | Meaning |
+|-------|---------|
+| **5** | **High fit.** Description and type-specific content **clearly meet** that type’s rubric. Minimal clarification needed. |
+| **4** | **Good fit.** Mostly complete; only **minor** gaps (small ambiguity, one thin area). |
+| **3** | **Partial fit.** Intent is visible but **important** pieces are missing, vague, or untestable. |
+| **2** | **Weak fit.** Large holes in description **or** type-specific content. |
+| **1** | **Poor fit.** Title-only, wrong kind of content for the type, or too little text to understand the work. |
+
+Use the type file’s **Scoring** section to decide which gaps map to 2 vs 3 vs 4 — each type defines its own weak/strong signals and examples.
+
+---
+
+## What to ignore
+
+- Template **section headings** (`### Description`, `### Acceptance Criteria`, etc.) — missing headings do **not** lower the score if the content is present elsewhere.
+- **Optional** template sections named in the type file’s **Description template** unless absence leaves a real content gap.
+- Jira **issuetype** vs content mismatch — recorded in [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) for the report; **not** an automatic score penalty.
+
+---
+
+## Record per issue
+
+| Field | Content |
+|-------|---------|
+| `score` | 1–5 |
+| `score_justification` | Short paragraph or bullets |
+| `classified_type` | From classify step |
+
+Type-specific scoring rules → **only** in the type file for that `classified_type`.

--- a/.agents/skills/jira-acceptance-criteria-check/SKILL.md
+++ b/.agents/skills/jira-acceptance-criteria-check/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: jira-acceptance-criteria-check
+description: >-
+  Fetches Jira work items, classifies by work type using rubrics in JIRA_TYPE/,
+  scores description and type-specific content 1–5, drafts suggested ticket content
+  for low scores when enough context exists, and reports Ready / Needs review /
+  Needs Refinement (chat for one issue; markdown file for two or more). After the
+  report, optionally posts Needs review suggestions (scores 1–3 with a draft) as
+  Jira comments via MCP when the user agrees. Supports synthetic draft input from
+  jira-epic-breakdown or pasted bodies without Jira fetch.
+user-invocable: true
+---
+
+# Acceptance criteria check
+
+Evaluate Jira tickets for description quality and type-specific content per the rubric for `classified_type`. **Optional Jira comment writes** only after the report and only when the user agrees ([POST_JIRA.md](POST_JIRA.md)).
+
+---
+
+## Companion files
+
+| Step | File |
+|------|------|
+| Shared conventions (all Jira skills) | [CONVENTIONS.md](CONVENTIONS.md) |
+| Fetch | [JIRA.md](JIRA.md) · [DRAFT_INPUT.md](DRAFT_INPUT.md) (synthetic / pre-Jira drafts) |
+| Classify | [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) · [JIRA_TYPE/](JIRA_TYPE/README.md) (discover types) |
+| Description (all types) | [GENERAL.md](GENERAL.md) |
+| Type rubrics | `JIRA_TYPE/*.md` — one file per type (excludes `CLASSIFY.md`, `README.md`) |
+| Score | [SCORING.md](SCORING.md) |
+| Draft (scores 1–3) | [DRAFT.md](DRAFT.md) |
+| Report | [REPORT.md](REPORT.md) |
+| Step 6 — Post suggestions (optional) | [POST_JIRA.md](POST_JIRA.md) |
+
+| `classified_type` | Type file |
+|-------------------|-----------|
+| *(slug)* | `JIRA_TYPE/{slug}.md` — discover slugs per [JIRA_TYPE/README.md](JIRA_TYPE/README.md) |
+
+**Bundled defaults:** story · task · bug · spike ([STORY.md](JIRA_TYPE/STORY.md), [TASK.md](JIRA_TYPE/TASK.md), [BUG.md](JIRA_TYPE/BUG.md), [SPIKE.md](JIRA_TYPE/SPIKE.md)). Teams may add types (e.g. `SUB_TASK.md`) without editing this skill.
+
+---
+
+## Workflow
+
+### 1. Get issues
+
+**Jira keys or JQL** → follow [JIRA.md](JIRA.md) (**MCP only**).
+
+**Draft bodies with no Jira keys** (e.g. **jira-epic-breakdown** pre-delivery review, pasted tickets) → follow [DRAFT_INPUT.md](DRAFT_INPUT.md). **Do not fetch Jira** when synthetic input is already in scope.
+
+**Stop** if MCP fetch fails — tell the user how to fix Atlassian MCP setup; do not continue.
+
+**Stop** if Jira search returns **zero issues** — tell the user no items matched; do not classify, score, or report empty buckets.
+
+**Stop** if synthetic input has zero parseable issues — say so; do not continue.
+
+Otherwise hold the issue list internally for steps 2–5. Do not dump raw fetch output unless the user asked.
+
+---
+
+### 2. Classify each item
+
+For **each** issue from step 1:
+
+1. Discover type rubrics in [JIRA_TYPE/](JIRA_TYPE/README.md).
+2. Follow [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md).
+
+Record per issue: `jira_issuetype`, `classified_type`, `classified_type_file`, `type_match`, and mismatch fields when applicable.
+
+---
+
+### 3. Score each item
+
+For **each** issue:
+
+1. Read [GENERAL.md](GENERAL.md) (WHAT + WHY).
+2. Open the type file for `classified_type` (from classify step) and read its **Scoring** section.
+3. Follow [SCORING.md](SCORING.md) to assign **one score 1–5** and a short `score_justification`.
+
+Score **substance**, not template headings ([SCORING.md](SCORING.md) — what to ignore).
+
+---
+
+### 4. Draft suggested content (scores 1–3 only)
+
+For each issue scored **1, 2, or 3**:
+
+1. Use [GENERAL.md](GENERAL.md) and the **Description template** in that issue’s type file.
+2. Follow [DRAFT.md](DRAFT.md) for enrichment, formatting, and sources.
+3. Produce suggested Jira body content using the type file’s **`###` section headings** from its **Description template**.
+
+**Do not guess or extrapolate.** If there is **not enough information** for honest, type-appropriate suggestions, **skip drafting** for that issue — it lands in **Needs Refinement** (not **Needs review**). See [REPORT.md](REPORT.md) bucket rules.
+
+Issues scored **4 or 5** — skip this step.
+
+---
+
+### 5. Report
+
+Follow [REPORT.md](REPORT.md):
+
+- **Ready** — scores 4–5  
+- **Needs review** — scores 1–3 with a draft  
+- **Needs Refinement** — scores 1–3 without a draft  
+
+**One issue** → full content in chat; **omit** section headers (`# Ready`, etc.).
+
+**Two or more issues** → write `jira-acceptance-criteria-check-report.md`; chat gets only a short pointer (path, JQL, counts).
+
+Include **Recommend change to \<type\>** when [CLASSIFY.md](JIRA_TYPE/CLASSIFY.md) reports a type mismatch.
+
+---
+
+### 6. Offer to post suggestions (optional)
+
+When step 5 included at least one **Needs review** item (score **1–3** with a draft) on a **real Jira key**, ask whether to save those suggestions as Jira comments.
+
+Follow [POST_JIRA.md](POST_JIRA.md):
+
+- **Ask** once after the report — do not post without clear user agreement.
+- **Post only** Needs review items (scores 1–3 **with** suggestions) — not Ready, not Needs Refinement.
+- **Use MCP** (`addCommentToJiraIssue`).
+- **Skip** synthetic/draft-only ids and keys that already have a prior `Suggested …` comment from this run’s enrichment.
+
+If nothing qualifies for posting, skip this step.

--- a/.agents/skills/jira-acceptance-criteria-check/SKILL.md
+++ b/.agents/skills/jira-acceptance-criteria-check/SKILL.md
@@ -119,6 +119,6 @@ Follow [POST_JIRA.md](POST_JIRA.md):
 - **Ask** once after the report — do not post without clear user agreement.
 - **Post only** Needs review items (scores 1–3 **with** suggestions) — not Ready, not Needs Refinement.
 - **Use MCP** (`addCommentToJiraIssue`).
-- **Skip** synthetic/draft-only ids and keys that already have a prior `Suggested …` comment from this run’s enrichment.
+- **Skip** synthetic/draft-only IDs and keys that already have a prior `Suggested …` comment from this run’s enrichment.
 
 If nothing qualifies for posting, skip this step.

--- a/.agents/skills/jira-epic-breakdown/CLASSIFY.md
+++ b/.agents/skills/jira-epic-breakdown/CLASSIFY.md
@@ -1,0 +1,38 @@
+# Classify issue type
+
+**Orchestration wrapper only** — all classification semantics live in **jira-acceptance-criteria-check**. Do not add type definitions here.
+
+Assign exactly one **`classified_type`** slug per child item.
+
+**What each type means:** read **Definition** (and **Quick signals**) from each file under [jira-acceptance-criteria-check/JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md). Do **not** use hardcoded story/task/bug/spike semantics from this file — those live in the type rubrics and are team-editable.
+
+**How to classify:** follow [CLASSIFY.md](../jira-acceptance-criteria-check/JIRA_TYPE/CLASSIFY.md) (discover types, compare definitions, record match/mismatch).
+
+**Ticket templates:** after classification, draft bodies from `jira-acceptance-criteria-check/JIRA_TYPE/{slug}.md` for that slug.
+
+**WHAT + WHY** for all types: [GENERAL.md](../jira-acceptance-criteria-check/GENERAL.md).
+
+**Epic slicing heuristics** (how big to cut work, API splits, UI journey) → [DECOMPOSE.md](DECOMPOSE.md) — separate from what a Jira issuetype *means*.
+
+---
+
+## Report type column
+
+In the breakdown table, show:
+
+- **Type** — `classified_type` slug from discovered rubrics
+- Optional note when Jira issuetype differs from planning slug — e.g. `spike → Story in Jira`
+
+### Jira issuetype when filing ([JIRA.md](JIRA.md) § Write)
+
+Use **Jira issuetype aliases** from each type file’s **Type metadata**. When a planning slug has no alias on your site, ask the user or match the closest Jira type.
+
+| Planning slug | Typical filing |
+|---------------|------------------|
+| *(any)* | `issueTypeName` from that type’s **Jira issuetype aliases**; summary rules from epic context or type **Summary prefix hints** |
+
+---
+
+## Hand off
+
+Pass `classified_type` per item to [TICKETS.md](TICKETS.md) for the correct template and sections.

--- a/.agents/skills/jira-epic-breakdown/DECOMPOSE.md
+++ b/.agents/skills/jira-epic-breakdown/DECOMPOSE.md
@@ -1,0 +1,187 @@
+# Decompose — slice the epic
+
+Turn one epic into **multiple child items** that together cover epic AC without overlap or gaps.
+
+---
+
+## Principles
+
+| Principle | Meaning |
+|-----------|---------|
+| **Cover the epic** | Every epic AC maps to ≥1 child item |
+| **Respect Out of scope** | Never slice work the epic explicitly excluded ([JIRA.md](JIRA.md)) |
+| **No gaps** | Union of child scopes completes the epic |
+| **Minimal overlap** | One owner per slice; use **depends on** instead of duplicating AC |
+| **Right size** | **One sprint or less per item** — split anything larger ([§ Sprint-sized items](#sprint-sized-items)) |
+| **Parallel when independent** | Separate items when chunks can be built or merged without blocking each other |
+| **Sequence honestly** | Publish package before integrate; prerequisites before wizard; submit before confirmation |
+
+---
+
+## Slicing strategies
+
+Use one or combine — pick what matches the epic:
+
+### 1. User journey (common for UI epics)
+
+One story per major step:
+
+- Entry / navigation
+- Prerequisites gate
+- Account or credential selection
+- Main experience (wizard, form)
+- Submit / handoff
+- Confirmation / completion
+
+Merge tiny adjacent steps (e.g. entry + nav) when one story is cleaner.
+
+Use **Mockups/Design** links in child story bodies when the epic supplies Figma for that slice.
+
+### 2. Layer (common for integration epics)
+
+| Layer | Typical type |
+|-------|----------------|
+| Shell UI (routes, layout, gates) | story |
+| Shared library publish / version | task |
+| Integration foundation (shared client, auth, callback shape) | task — one small item when many endpoints follow |
+| **Per API / data source** | task — **one item per endpoint** ([§ API and data-fetch splits](#api-and-data-fetch-splits)) |
+| Submit / persistence | task |
+| Docs / E2E harness | task — trace to **Test Plan** when epic lists them |
+
+### 2b. API and data-fetch splits
+
+When the epic wires **multiple backend calls** (REST, GraphQL, fetches, etc.):
+
+**Do not** combine all API wiring into one task if:
+
+- The combined work would **not finish in one sprint**, or
+- **Independent chunks** can be implemented and merged separately (different endpoints, wizard fields, or domains)
+
+**Do:**
+
+1. Identify each **distinct fetch or API** from epic AC, **Implementation notes**, or integration contract (e.g. OpenAPI, props types).
+2. Create **one task per fetch/API** (or per tight group only when truly inseparable in one PR).
+3. Add a **foundation task** first when shared code is needed (auth header, base client, `Resource` wrapper, error mapping) — keep it sprint-sized; do not hide endpoint work in foundation.
+4. Mark **depends on** only for real ordering — parallel API tasks after foundation when safe.
+5. Trace each API task to the same epic AC (e.g. AC5) — coverage is by **union** of items.
+
+**Naming:** `Wire <data> for <feature>` — e.g. `Wire regions OCM API for ROSA HCP wizard`.
+
+**Anti-pattern:** One task titled “Wire all OCM API data” covering 8+ endpoints.
+
+**Research:** When repo paths are named in **Implementation notes**, read the integration contract ([RESEARCH.md](../jira-epic-create/RESEARCH.md)) for the full fetch list before decomposing.
+
+### 3. Out-of-scope boundary
+
+When epic **Out of scope** lists related work or exclusions, **do not** re-slice owned scope:
+
+- Skip child items for excluded work entirely
+- Note `Excluded — epic Out of scope (FCN-200)` in report optional notes when helpful
+- This epic’s items only cover its AC
+
+### 4. Test Plan → tasks
+
+When epic **Test Plan** lists verification areas not fully covered by feature stories/tasks:
+
+- One integration/e2e **task** at end when epic implies harness or automated coverage
+- Trace as `TP` (Test Plan) in breakdown table
+- Do not duplicate every Test Plan bullet as its own ticket — group by test layer
+
+### 5. Spike first (only when needed)
+
+Add a spike **only** when **More information needed**, **Implementation notes**, or AC block estimation:
+
+- Place **before** dependent stories/tasks in suggested order
+- Spike outcomes name the follow-up tickets it unblocks
+- Trace as `MIN` when driven by open questions
+
+---
+
+## Sprint-sized items
+
+Every child item should be **completable within one sprint** by a developer (or pair).
+
+| Signal to split | Action |
+|-----------------|--------|
+| More than **~3–5 verifiable AC bullets** and multiple subsystems | Split by journey step, layer, or API |
+| Epic AC says “wire all X” but lists **many data sources** | One task **per API/fetch** ([§ API and data-fetch splits](#api-and-data-fetch-splits)) |
+| Description would need “and also … and also …” for unrelated deliverables | Separate items |
+| Item mixes UI + many backend integrations | Story for UI; tasks for each integration chunk |
+| Two engineers could work in parallel without conflict | Should usually be two items |
+
+**Merge** only when pieces are tiny, inseparable, or ship as one atomic UX step (e.g. entry route + page title).
+
+---
+
+## What not to split out
+
+| Avoid | Instead |
+|-------|---------|
+| One AC per microscopic ticket | Group related AC into one shippable item |
+| **One mega-task for all API calls** | **One task per endpoint/fetch** when sprint-sized or parallel ([§ API and data-fetch splits](#api-and-data-fetch-splits)) |
+| "Write unit tests" alone | Fold into story/task AC as one bullet, or one integration test task traced to Test Plan |
+| Per-component file tickets | One integration task per **API/resource**, not per source file |
+| Duplicate prerequisites + wizard if one team ships both | Single story with nested AC |
+| Tickets for **Out of scope** items | Skip — note exclusion in report |
+
+---
+
+## Dependencies
+
+Record **depends on** as item numbers or summaries:
+
+- Hard: B cannot start until A merges (package published, API module exists)
+- Soft: B should follow A (confirmation after submit) — note in order, optional depends-on
+
+Parallel when no shared blocker (e.g. docs task + UI story after integration API exists; **multiple API tasks** after foundation lands).
+
+---
+
+## Summary line (Jira title)
+
+Pattern: **`<Verb> <outcome> [context]`**
+
+Examples:
+
+- `Add ROSA HCP cluster creation route in ACM`
+- `Publish nxtcm-rosa-hcp-wizard for ACM consumption`
+- `Wire regions OCM API for ROSA HCP wizard`
+
+Avoid: `ROSA HCP work`, `Wizard part 2`, `Implement ticket`, **`Wire all OCM API data`** (split per [DECOMPOSE.md](DECOMPOSE.md) § API and data-fetch splits).
+
+**Spikes:** summary **must include** `Spike` — e.g. `Spike: Confirm CRD set with platform team`. Jira type is **Story**, not Spike ([CLASSIFY.md](CLASSIFY.md), [JIRA.md](JIRA.md) § Write).
+
+---
+
+## Trace to epic
+
+For each child item, list trace codes in the breakdown table:
+
+| Code | Source |
+|------|--------|
+| `AC1`, `AC2`, … | Epic acceptance criteria |
+| `IN` | Implementation notes (release coordination, repo boundary) |
+| `TP` | Test Plan |
+| `MIN` | More information needed → spike only |
+
+Every epic **AC#** must appear on ≥1 row. **Out of scope** items must **not** appear.
+
+---
+
+## Item count guidance
+
+| Epic size | Typical child count |
+|-----------|---------------------|
+| Narrow (single screen) | 2–4 |
+| Medium (integration + UI) | 5–10 |
+| Large (multi-team, **or per-API split**) | 10–20 |
+
+More than 20 → confirm epic scope or move work to related epics. **Per-API splits intentionally exceed 12** when the integration contract lists many fetches.
+
+---
+
+## Hand off
+
+Produce ordered list with: `#`, `type`, `summary`, `depends on`, `traces`, one-line **why this slice** (internal, optional in table).
+
+Pass to [TICKETS.md](TICKETS.md) for full bodies.

--- a/.agents/skills/jira-epic-breakdown/DECOMPOSE.md
+++ b/.agents/skills/jira-epic-breakdown/DECOMPOSE.md
@@ -44,7 +44,7 @@ Use **Mockups/Design** links in child story bodies when the epic supplies Figma 
 | Shell UI (routes, layout, gates) | story |
 | Shared library publish / version | task |
 | Integration foundation (shared client, auth, callback shape) | task — one small item when many endpoints follow |
-| **Per API / data source** | task — **one item per endpoint** ([§ API and data-fetch splits](#api-and-data-fetch-splits)) |
+| **Per API / data source** | task — **one item per endpoint** ([§ API and data-fetch splits](#2b-api-and-data-fetch-splits)) |
 | Submit / persistence | task |
 | Docs / E2E harness | task — trace to **Test Plan** when epic lists them |
 
@@ -104,7 +104,7 @@ Every child item should be **completable within one sprint** by a developer (or 
 | Signal to split | Action |
 |-----------------|--------|
 | More than **~3–5 verifiable AC bullets** and multiple subsystems | Split by journey step, layer, or API |
-| Epic AC says “wire all X” but lists **many data sources** | One task **per API/fetch** ([§ API and data-fetch splits](#api-and-data-fetch-splits)) |
+| Epic AC says “wire all X” but lists **many data sources** | One task **per API/fetch** ([§ API and data-fetch splits](#2b-api-and-data-fetch-splits)) |
 | Description would need “and also … and also …” for unrelated deliverables | Separate items |
 | Item mixes UI + many backend integrations | Story for UI; tasks for each integration chunk |
 | Two engineers could work in parallel without conflict | Should usually be two items |
@@ -118,7 +118,7 @@ Every child item should be **completable within one sprint** by a developer (or 
 | Avoid | Instead |
 |-------|---------|
 | One AC per microscopic ticket | Group related AC into one shippable item |
-| **One mega-task for all API calls** | **One task per endpoint/fetch** when sprint-sized or parallel ([§ API and data-fetch splits](#api-and-data-fetch-splits)) |
+| **One mega-task for all API calls** | **One task per endpoint/fetch** when sprint-sized or parallel ([§ API and data-fetch splits](#2b-api-and-data-fetch-splits)) |
 | "Write unit tests" alone | Fold into story/task AC as one bullet, or one integration test task traced to Test Plan |
 | Per-component file tickets | One integration task per **API/resource**, not per source file |
 | Duplicate prerequisites + wizard if one team ships both | Single story with nested AC |

--- a/.agents/skills/jira-epic-breakdown/DISCOVERY.md
+++ b/.agents/skills/jira-epic-breakdown/DISCOVERY.md
@@ -1,0 +1,59 @@
+# Discovery — epic input
+
+Collect the epic to decompose and any constraints. Prefer **conversation history** before asking.
+
+---
+
+## Required
+
+| Input | Used for |
+|-------|----------|
+| **Epic content** | Jira **key**, or **pasted** Description + Acceptance criteria (minimum) |
+
+If neither key nor pasted epic → **ask**:
+
+> Which epic should I break down? Provide a Jira key (e.g. `FCN-123`) or paste the epic Description and Acceptance criteria.
+
+---
+
+## Optional
+
+| Input | Used for |
+|-------|----------|
+| Repo paths | Sharper task boundaries ([DECOMPOSE.md](DECOMPOSE.md)) |
+| Team constraints | "Frontend vs backend split", "spike first for X" |
+| Output depth | Summary table only vs full ticket bodies (default: **both**) |
+| Skip draft review | User says **breakdown only** — skip [REVIEW.md](REVIEW.md); deliver table + bodies without review flags |
+| Exclude types | e.g. "no spikes" — honor unless epic has genuine research unknowns |
+| Existing child issues | **Only when user asks** to dedupe — not by default ([JIRA.md](JIRA.md) § Existing children) |
+
+---
+
+## Infer before asking
+
+1. **Same thread** — epic body from **jira-epic-create** in this conversation
+2. **Jira key** in prompt or branch name (`FCN-123`, `FCN-1234-rosa-hcp`)
+3. **User pasted** markdown with registry section headings from [jira-epic-create/TEMPLATE.md](../jira-epic-create/TEMPLATE.md) — at minimum **Description** and **Acceptance criteria**
+
+---
+
+## Discovery checklist
+
+Before decomposing:
+
+- [ ] Epic Description and AC are available (fetched or pasted)
+- [ ] Epic AC extracted as a traceable checklist
+- [ ] All registry sections with **Breakdown trace** ≠ `—` parsed when present ([JIRA.md](JIRA.md) § Parse epic description)
+- [ ] **Out of scope** (trace `—`) honored — exclusions not re-sliced
+- [ ] User constraints noted (if any)
+- [ ] Draft review: **on** (default) unless user asked for **breakdown only**
+- [ ] **Epic key** recorded when known — required before §7 Jira create ([SKILL.md](SKILL.md) §7)
+
+If epic AC is missing or empty, ask whether to decompose from Description only or wait for AC.
+
+---
+
+## Do not
+
+- Break down without epic text or key
+- Assume epic key from branch without user confirmation when ambiguous

--- a/.agents/skills/jira-epic-breakdown/JIRA.md
+++ b/.agents/skills/jira-epic-breakdown/JIRA.md
@@ -1,0 +1,158 @@
+# Jira — fetch epic
+
+Fetch the **parent epic** for decomposition via **Atlassian MCP only** — no CLI fallback (same bar as **jira-acceptance-criteria-check** [JIRA.md](../jira-acceptance-criteria-check/JIRA.md)).
+
+**Site:** `redhat.atlassian.net`
+
+**No Jira writes** during decomposition, review, or delivery. Creates happen only after §7 when the user chooses **Create in Jira** ([SKILL.md](SKILL.md) §7, § Write below).
+
+**Default:** do **not** search for existing child issues — assume children are **not** filed yet unless the user asks to dedupe (§ Existing children).
+
+---
+
+## Fields to fetch
+
+| Field | Use |
+|-------|-----|
+| `key` | Report header, child epic link |
+| `summary` | Context line |
+| `description` | All epic sections (see § Parse epic description) |
+| `issuetype` | Confirm issue is an epic (note if not) |
+| `parent` | Parent initiative — context only |
+
+---
+
+## Transport — MCP only
+
+1. Read MCP tool schemas under `user-atlassian-mcp-server` before calling.
+2. If only `mcp_auth` is listed → authenticate, re-check tools.
+3. `getAccessibleAtlassianResources` → `cloudId` for `redhat.atlassian.net`.
+4. `getJiraIssue` with `responseContentFormat: "markdown"`.
+
+**If MCP fails** (server missing, tools unavailable after auth, or fetch error):
+
+- Ask the user to paste the epic body **or** fix MCP (Cursor → **Settings → MCP** → enable Atlassian; `mcp_auth` for `user-atlassian-mcp-server`).
+- Do **not** use `acli`, Jira REST, or curl.
+
+There is **no** acli or other CLI fallback for this skill.
+
+---
+
+## Existing children (only when user asks)
+
+When the user wants to **dedupe** against work already filed, search:
+
+```text
+parent = <EPIC_KEY> OR "Epic Link" = <EPIC_KEY>
+```
+
+**MCP:** `searchJiraIssuesUsingJql` with the JQL above.
+
+List matches in **Already filed** ([TEMPLATE.md](TEMPLATE.md) §6). Do **not** run this search by default.
+
+---
+
+## Parse epic description
+
+Read [jira-epic-create/TEMPLATE.md](../jira-epic-create/TEMPLATE.md) § **Section registry** — extract sections in **Order** sequence using each guide’s **Heading** value.
+
+For each registry row:
+
+| Step | Action |
+|------|--------|
+| 1 | Read the **Guide** file’s **Section metadata** |
+| 2 | Parse content after that **Heading** until the next registry **Heading** or `---` |
+| 3 | Apply **Breakdown trace** (below) |
+
+### Breakdown trace codes
+
+| Trace | Registry sections (default) | Used for |
+|-------|----------------------------|----------|
+| `—` | Description, Mockups/Design, Out of scope | Context, Figma links, **hard exclusions** — do not create child items for Out of scope bullets |
+| `AC` | Acceptance criteria | Primary trace target — each `- [ ]` or `*` line → AC1, AC2, … |
+| `IN` | Implementation notes | API/repo boundaries; trace as `IN` |
+| `TP` | Test Plan | Test/docs tasks; trace as `TP` |
+| `MIN` | More information needed | Spike candidates; trace as `MIN` |
+
+When the team adds a registry section, read its **Breakdown trace** from the guide metadata — no parser edit required unless a new trace code is introduced.
+
+### Legacy headings (backward compatible)
+
+When an older epic lacks registry sections, also parse:
+
+| Legacy section | Maps to |
+|----------------|---------|
+| `## References` | Implementation notes context (repos, packages, Jira links) |
+| `## Technical notes` | Implementation notes |
+| `## Targeted due date` | Context only — not a trace target |
+
+If sections use headings not in the registry, best-effort parse; note ambiguity in report.
+
+---
+
+## Hand off
+
+Pass to [DECOMPOSE.md](DECOMPOSE.md):
+
+- Epic key, summary, link
+- Parsed AC list (numbered for traceability: AC1, AC2, …)
+- Parsed content for each registry section by **Breakdown trace** — especially **Out of scope** (hard exclusions), **Implementation notes**, **Test Plan**, **Mockups/Design**, **More information needed**
+
+---
+
+## Write — create child issues (after §7)
+
+Run only when the user chose **Create in Jira** in [SKILL.md](SKILL.md) §7.
+
+**MCP only** — `user-atlassian-mcp-server`. Do **not** use `acli`, Jira REST, or curl.
+
+| Do | Do not |
+|----|--------|
+| `createJiraIssue` per breakdown item via MCP | `acli`, Jira REST, or curl for any Jira call |
+| Set **parent** to the **epic key** on every child | Create without parent |
+| Read MCP tool schemas before calling | Fall back to another transport when MCP fails |
+
+**Prerequisites**
+
+1. **Epic key** is known — if not, ask the user ([SKILL.md](SKILL.md) §7).
+2. `mcp_auth` on **401**, retry once; if still failing, **stop** and leave breakdown in chat.
+
+**Cloud ID:** `2b9e35e3-6bd3-4cec-b838-f4249ee02432` or `redhat.atlassian.net`
+
+### Per-item create
+
+Create in **suggested order** from the breakdown table. For each row:
+
+| Planning type | Jira `issueTypeName` | Summary |
+|---------------|----------------------|---------|
+| story | `Story` | Breakdown summary as drafted |
+| task | `Task` | Breakdown summary as drafted |
+| bug | `Bug` | Breakdown summary as drafted |
+| spike | **`Story`** | **Must include `Spike`** — e.g. `Spike: <summary>` if not already present |
+
+**Project key:** prefix from epic key (e.g. `FCN-100` → `FCN`).
+
+```text
+createJiraIssue
+  cloudId, projectKey, issueTypeName: <Story|Task|Bug>
+  summary: "<title — Spike prefix for spikes>"
+  description: "<paste-ready ticket body from breakdown>"
+  contentFormat: "markdown"
+  additional_fields: { "parent": { "key": "<EPIC_KEY>" } }
+```
+
+If `parent` fails (site-specific epic link), use `getJiraIssueTypeMetaWithFields` for the correct parent/epic-link field.
+
+### After create
+
+Post a table in chat:
+
+| # | Key | Type | Summary |
+|---|-----|------|---------|
+| 1 | FCN-501 | Task | … |
+
+Link each key to `https://redhat.atlassian.net/browse/<KEY>`.
+
+- Note any items that were **Needs human review** in the breakdown — user may want to edit in Jira.
+- **Do not** auto-invoke jira-acceptance-criteria-check — wait for the user.
+- On partial failure, report which keys succeeded and which failed; do not silently skip.

--- a/.agents/skills/jira-epic-breakdown/README.md
+++ b/.agents/skills/jira-epic-breakdown/README.md
@@ -1,0 +1,211 @@
+# jira-epic-breakdown
+
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that decomposes a **Jira epic** into child work items — type, summary, dependencies, and **paste-ready ticket bodies** — with jira-acceptance-criteria-check-style review before delivery. Prints the full breakdown in chat, then asks whether to create children in Jira (MCP only) or do nothing.
+
+Use when an epic is ready to slice into stories, tasks, spikes, or bugs — not when you still need to draft the epic.
+
+---
+
+## Requirements
+
+### Atlassian Jira MCP
+
+| Capability | MCP required? | Fallback |
+|------------|---------------|----------|
+| Break down from **pasted** epic text | **No** | — |
+| Fetch epic from Jira | **Yes** | Paste epic manually if MCP unavailable |
+| **Create** child issues under the epic (after you choose §7) | **Yes** | None — all Jira access is **MCP only** |
+
+**Primary workflow:** discover epic → decompose → review drafts → deliver full breakdown in chat → ask whether to create in Jira or do nothing.
+
+You can run the full breakdown flow **without MCP** if you paste the epic body and choose **do nothing** at the Jira step. MCP is **required** when you give an epic **key** (fetch) or choose **Create in Jira** at §7 — there is no `acli` fallback.
+
+**Setup (when using Jira fetch or creates):**
+
+1. Cursor → **Settings → MCP** — enable the **Atlassian** server (`user-atlassian-mcp-server`).
+2. Complete auth when prompted (`mcp_auth` for `user-atlassian-mcp-server`).
+3. Confirm tools such as `getJiraIssue` and `createJiraIssue` are available.
+
+Without MCP, the agent can still break down from pasted text; failed fetch → ask you to paste the epic or fix auth.
+
+---
+
+## What it does
+
+The agent follows [SKILL.md](SKILL.md) in order:
+
+1. **Discover epic source** — Jira key and/or pasted epic body; optional repo paths and constraints ([DISCOVERY.md](DISCOVERY.md)).
+2. **Load epic content** — fetch via MCP or parse pasted markdown using [jira-epic-create/TEMPLATE.md](../jira-epic-create/TEMPLATE.md) § Section registry ([JIRA.md](JIRA.md)).
+3. **Decompose** — logical slices, API/data-fetch splits, dependencies, sprint-sized items ([DECOMPOSE.md](DECOMPOSE.md)).
+4. **Classify type** — one `classified_type` slug per item from [jira-acceptance-criteria-check/JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md) ([CLASSIFY.md](CLASSIFY.md)).
+5. **Draft ticket bodies** — per-type templates from JIRA_TYPE guides ([TICKETS.md](TICKETS.md), [WRITING.md](WRITING.md)).
+6. **Review drafts** — score and revise before delivery; flag items needing human review ([REVIEW.md](REVIEW.md)). Skipped only when you ask for **breakdown only**.
+7. **Deliver** — **always** post the full breakdown in chat: table, epic AC coverage, review flags, and ticket bodies ([TEMPLATE.md](TEMPLATE.md), [REPORT.md](REPORT.md)).
+8. **Jira next step** — ask: **Create in Jira** or **Do nothing**. Creates use **MCP only**; every child gets **parent** = epic key.
+
+**Discovery-only turns** happen when no epic key and no pasted description — the agent asks and does **not** decompose until you reply.
+
+**Hard rules:**
+
+- Every child item must **trace** to epic AC (`AC`), Implementation notes (`IN`), or Test Plan (`TP`) — not Out of scope.
+- Spikes file as Jira **`Story`** with **`Spike`** in the summary — not the Jira Spike issuetype.
+- **Epic key required** before creating children — ask if unknown.
+- **No Jira writes** in the same turn as delivery.
+
+---
+
+## How to use it
+
+### Install the skill
+
+Copy this folder into a skills location Cursor reads:
+
+| Location | Scope |
+|----------|-------|
+| `~/.cursor/skills/jira-epic-breakdown/` | Personal — all projects |
+| `.cursor/skills/jira-epic-breakdown/` | Project — shared with the repo |
+
+Enable **Atlassian MCP** when you want Jira fetch or create ([Requirements](#requirements)).
+
+### Trigger in Cursor
+
+Ask the agent to run the skill — for example:
+
+- “Break down epic FCN-123 into stories and tasks”
+- “Decompose this epic — [paste Description + Acceptance criteria]”
+- “Split FCN-456; frontend/backend split, no spikes”
+- “Break down only — table and bodies, skip review” (skips draft review step)
+
+The skill is **user-invocable** (`SKILL.md` frontmatter). The description helps the agent auto-select it for epic decomposition tasks.
+
+### What to have ready
+
+| Input | When |
+|-------|------|
+| **Epic key** or **pasted epic** (Description + AC minimum) | Always — agent asks if neither |
+| **Epic key** (confirmed) | Required before **Create in Jira** at §7 |
+| **Repo paths** | Optional — sharper task boundaries |
+| **Constraints** | Optional — team split, “spike first”, exclude bugs/spikes |
+| **Dedupe existing children** | Only when you ask — not run by default |
+
+### Epic from the same session
+
+If you just ran [jira-epic-create](../jira-epic-create/SKILL.md) in the same thread, the agent uses that epic body without re-asking. If jira-epic-create also wrote to Jira, the epic key carries forward for §7 creates.
+
+### After delivery
+
+The agent asks what to do with the child items:
+
+| Choice | Behavior |
+|--------|----------|
+| **Create in Jira** | MCP `createJiraIssue` per item in suggested order; parent = epic |
+| **Do nothing** | Breakdown stays in chat for manual filing |
+
+Optional follow-ups (only if **you** ask in a later turn):
+
+- [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) — score created tickets
+- Re-run breakdown after epic edits
+- Dedupe against existing children ([JIRA.md](JIRA.md) § Existing children)
+
+---
+
+## Output shape
+
+Each delivery includes ([TEMPLATE.md](TEMPLATE.md)):
+
+1. **Header** — epic key/link, item count, suggested order
+2. **Breakdown table** — type, summary, depends-on, epic trace (AC1, IN, TP, …)
+3. **Epic AC coverage** — every AC mapped to item numbers
+4. **Review flags** — ready vs needs human review (unless **breakdown only**)
+5. **Ticket bodies** — paste-ready markdown per item
+
+---
+
+## Directory layout
+
+```
+jira-epic-breakdown/
+├── SKILL.md              # Orchestrator — workflow and gates
+├── README.md             # This file
+├── DISCOVERY.md          # Epic input and constraints
+├── JIRA.md               # MCP-only fetch and creates; parse registry sections
+├── DECOMPOSE.md          # Slicing heuristics (journeys, API splits, sizing)
+├── CLASSIFY.md           # Issue type assignment → JIRA_TYPE rubrics
+├── TICKETS.md            # Per-type body drafting
+├── REVIEW.md             # Pre-delivery draft review (jira-acceptance-criteria-check style)
+├── TEMPLATE.md           # Chat output shape + quality check
+├── REPORT.md             # Delivery rules (full breakdown before §7 ask)
+└── WRITING.md            # Prose rules (same bar as jira-epic-create)
+```
+
+**External dependencies** (not in this folder):
+
+| Path | Role |
+|------|------|
+| [jira-epic-create/TEMPLATE.md](../jira-epic-create/TEMPLATE.md) | Epic section registry — parser for fetched/pasted epics |
+| [jira-acceptance-criteria-check/JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md) | Type definitions, classify rubrics, ticket templates |
+| [jira-acceptance-criteria-check/GENERAL.md](../jira-acceptance-criteria-check/GENERAL.md) | WHAT + WHY for all ticket types |
+
+---
+
+## How to modify it
+
+### Orchestration (edit carefully)
+
+These files define workflow gates and delivery order:
+
+- `SKILL.md` — step sequence, anti-patterns, §6/§7 rules
+- `REPORT.md`, `TEMPLATE.md` — mandatory delivery shape
+- `DISCOVERY.md`, `JIRA.md` — input and fetch/write transport
+
+### Customize decomposition behavior
+
+| What to change | Where | Why |
+|----------------|-------|-----|
+| **Slicing rules** (API splits, sprint sizing) | [DECOMPOSE.md](DECOMPOSE.md) | How work is cut — not what Jira types mean |
+| **Prose style** | [WRITING.md](WRITING.md) | Concise, PM-readable ticket bodies |
+| **Draft review bar** | [REVIEW.md](REVIEW.md) | Pre-delivery scoring and flags |
+| **Epic sections parsed** | [jira-epic-create/TEMPLATE.md](../jira-epic-create/TEMPLATE.md) § Section registry | Headings and **Breakdown trace** codes (`AC`, `IN`, `TP`, …) |
+| **Issue type definitions** | [jira-acceptance-criteria-check/JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md) | What story/task/bug/spike mean; ticket templates |
+| **Classify logic** | [jira-acceptance-criteria-check/JIRA_TYPE/CLASSIFY.md](../jira-acceptance-criteria-check/JIRA_TYPE/CLASSIFY.md) | How types are chosen |
+
+**Example — epic adds a new traceable section:**
+
+1. Add the section in [jira-epic-create/SECTIONS/](../jira-epic-create/SECTIONS/) and the registry with a **Breakdown trace** code.
+2. **jira-epic-breakdown** picks it up automatically via [JIRA.md](JIRA.md) § Parse epic description — no parser edit unless you introduce a new trace code.
+
+**Example — team redefines “task” vs “story”:**
+
+Edit the type rubrics under `jira-acceptance-criteria-check/JIRA_TYPE/` — not `jira-epic-breakdown/CLASSIFY.md` (that file delegates to JIRA_TYPE).
+
+---
+
+## Related skills
+
+| Skill | Relationship |
+|-------|----------------|
+| [jira-epic-create](../jira-epic-create/SKILL.md) | Upstream — draft epic; same-thread handoff; section registry is the parser source |
+| [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) | Shared JIRA_TYPE rubrics; optional follow-up after tickets are filed |
+| [jira-get-estimates](../jira-get-estimates/SKILL.md) | Optional — size child items from historical cycle time |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, skill index |
+
+---
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|----------------|
+| Agent asked create/do-nothing without showing items | §6 skipped — full breakdown must appear in chat first ([REPORT.md](REPORT.md)) |
+| Agent tried to create without epic key | Epic key required for §7 — paste key or fetch epic first |
+| Fetch or create failed | MCP required for all Jira access — no `acli` fallback; retry `mcp_auth` or paste epic |
+| Spike filed as wrong Jira type | Must be **Story** with `Spike` in summary ([JIRA.md](JIRA.md) § Write) |
+| Bug items for missing features | Net-new work → **story**, not bug ([SKILL.md](SKILL.md) anti-patterns) |
+| Child items don’t match epic sections | Registry **Heading** must match exactly — see [jira-epic-create/SECTIONS/](../jira-epic-create/SECTIONS/) |
+| Out-of-scope work in breakdown | **Out of scope** has trace `—` — hard exclusion, not sliced ([JIRA.md](JIRA.md)) |
+| One giant “wire all APIs” task | [DECOMPOSE.md](DECOMPOSE.md) § API and data-fetch splits |
+| Epic fetch fails | MCP auth or paste epic manually |
+| Wanted to skip review | Say **breakdown only** at discovery ([DISCOVERY.md](DISCOVERY.md)) |
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-epic-breakdown/REPORT.md
+++ b/.agents/skills/jira-epic-breakdown/REPORT.md
@@ -1,0 +1,71 @@
+# Report delivery
+
+---
+
+## Destination
+
+| Request | Output |
+|---------|--------|
+| Default | **Chat** — full [TEMPLATE.md](TEMPLATE.md) (header, table, coverage, **review flags**, ticket bodies) |
+| Titles / table only | Chat — header + table + coverage + review flags (when review ran) |
+| **breakdown only** | Skip [REVIEW.md](REVIEW.md); no review flags section |
+| Many epics in one session | One breakdown per epic, separated by `---` |
+| User asks for file | Write `jira-epic-breakdown-<KEY>.md` in workspace; chat gets path + summary |
+
+---
+
+## Chat intro (optional)
+
+One sentence:
+
+> Breakdown for [KEY]: N items in suggested order below.
+
+Do not dump raw Jira fetch unless user asked.
+
+**Review summary** (when step 5 ran): one line after the intro, e.g. `Review: 14 ready · 2 need human review · 1 need refinement`.
+
+---
+
+## Before delivery (internal)
+
+Step 5 ([REVIEW.md](REVIEW.md)) runs **before** any breakdown content appears in chat. Never create issues during review or delivery.
+
+---
+
+## Delivery order (mandatory)
+
+In **one chat message**, in this order:
+
+1. **Post the full breakdown** — [TEMPLATE.md](TEMPLATE.md) header, table, epic AC coverage, review flags (when review ran), and ticket bodies (unless user asked for titles only).
+2. **Then** ask §7 — **Create in Jira** vs **Do nothing right now** ([SKILL.md](SKILL.md) §7).
+
+The user must see every suggested item before choosing. **Never** ask §7 in a message that does not include the breakdown. **Never** use **AskQuestion** as a shortcut that hides the item list — the breakdown text comes **first** in the message; the ask comes **after**.
+
+Do not create issues in the same turn as delivery.
+
+Optional brief notes (when useful) — **after** the §7 ask, or in the breakdown body, not instead of it:
+
+- Items that could merge if one team owns them
+- Epic **Out of scope** items explicitly excluded from breakdown
+- Related epic scope listed in Out of scope — not duplicated
+- Spikes that might become tasks after research
+
+Do not add a second full breakdown.
+
+---
+
+## Optional follow-ups (after §7)
+
+| User asks | Action |
+|-----------|--------|
+| Re-check filed tickets | **jira-acceptance-criteria-check** on created keys |
+| Adjust types | Re-run classification for named items only |
+| Dedupe existing children | [JIRA.md](JIRA.md) § Existing children |
+
+---
+
+## Formatting
+
+- Use markdown headings for ticket bodies — not one giant code fence
+- Link epic and related keys: `https://redhat.atlassian.net/browse/<KEY>`
+- Keep table columns aligned for readability

--- a/.agents/skills/jira-epic-breakdown/REVIEW.md
+++ b/.agents/skills/jira-epic-breakdown/REVIEW.md
@@ -1,0 +1,129 @@
+# Draft review (pre-delivery)
+
+Run **after** ticket bodies are drafted (step 4) and **before** anything is shown to the user (step 6).
+
+Uses the same classify → score → draft rubrics as **jira-acceptance-criteria-check** steps 2–4 on **synthetic** draft items — **do not invoke** the acceptance-criteria-check skill or fetch Jira. **No Jira writes.**
+
+**Input mode:** [jira-acceptance-criteria-check/DRAFT_INPUT.md](../jira-acceptance-criteria-check/DRAFT_INPUT.md)
+
+---
+
+## Hard rules
+
+| Do | Do not |
+|----|--------|
+| Review **every** child draft before delivery | Print the breakdown before review finishes |
+| Revise drafts when epic context fills gaps (scores 1–3) | Invent scope beyond the epic |
+| Flag items that still need **human review** after revision | Create, update, or comment on Jira issues |
+| Include **Review flags** in the delivered output ([TEMPLATE.md](TEMPLATE.md)) | Skip review because drafts “look fine” |
+| Skip this step only when user asked for **breakdown only** ([DISCOVERY.md](DISCOVERY.md)) | Run jira-acceptance-criteria-check against Jira keys during breakdown |
+
+---
+
+## Workflow
+
+```
+Review progress (internal — not shown to user):
+- [ ] Build synthetic issue list from drafts
+- [ ] Classify each item
+- [ ] Score each item
+- [ ] Revise weak drafts from epic context
+- [ ] Build review flags table
+- [ ] Proceed to assemble and deliver
+```
+
+---
+
+## 1. Build synthetic issue list
+
+For each child item from decomposition, hold:
+
+| Field | Source |
+|-------|--------|
+| `draft_id` | Breakdown `#` (1, 2, 3, …) |
+| `summary` | Draft summary / Jira title |
+| `description` | Full pasted-ready body from step 4 (all `###` sections) |
+| `declared_type` | Type slug from breakdown table (from discovered rubrics) |
+
+Treat `declared_type` as the planning slug. For spikes filed as Jira **Story** with `Spike` in the summary, set `jira_issuetype` accordingly ([JIRA.md](JIRA.md) § Write). For custom types, use **Jira issuetype aliases** from that type’s metadata.
+
+---
+
+## 2. Classify
+
+For each synthetic issue:
+
+1. Discover types per [jira-acceptance-criteria-check/JIRA_TYPE/README.md](../jira-acceptance-criteria-check/JIRA_TYPE/README.md).
+2. Follow [CLASSIFY.md](../jira-acceptance-criteria-check/JIRA_TYPE/CLASSIFY.md):
+
+- Set `jira_issuetype` from `declared_type`
+- Set `classified_type` from **content** (summary + description)
+- Record `type_match`: **match** or **mismatch**
+
+---
+
+## 3. Score
+
+For each synthetic issue, follow [jira-acceptance-criteria-check/SCORING.md](../jira-acceptance-criteria-check/SCORING.md) and the **Scoring** section in the type file for `classified_type`.
+
+Record `score` (1–5) and `score_justification`.
+
+---
+
+## 4. Revise weak drafts
+
+For each item with **score 1–3**, try to improve the draft **before delivery**:
+
+1. Re-read epic Description, AC, Mockups/Design, Implementation notes, Test Plan.
+2. Follow [jira-acceptance-criteria-check/DRAFT.md](../jira-acceptance-criteria-check/DRAFT.md) — fill gaps only from epic (and repo paths from discovery when provided).
+3. **Do not extrapolate** — if epic context cannot honestly fix the gap, leave the draft as-is and flag for human review.
+
+After revision, optionally re-score. If revision clearly fixes the gap, treat as improved for the flags table.
+
+### Type mismatch
+
+When `type_match` is **mismatch**:
+
+- If content clearly fits `classified_type` better → update **Type** in the breakdown table and ticket heading.
+- If ambiguous → keep declared type and flag **Type mismatch — human review**.
+
+### Breakdown-specific flags (always check)
+
+Also flag when:
+
+| Condition | Flag |
+|-----------|------|
+| Item **depends on** a spike that has not run | **Blocked on spike** |
+| Traces epic **MIN** (More information needed) | **Epic gap — human review** |
+| Spike missing **timebox** or **outcomes** | **Spike incomplete** |
+| Story/task AC reads like a task list, not outcomes | **AC needs human review** |
+
+---
+
+## 5. Build review flags table
+
+Map each item to one **status** for [TEMPLATE.md](TEMPLATE.md) § Review flags:
+
+| Status | When |
+|--------|------|
+| **Ready** | Score **4–5** after revision; no breakdown-specific flags |
+| **Revised — ready for review** | Was 1–3; revised from epic context; now 4–5 or clearly improved |
+| **Needs human review** | Score 1–3 after revision attempt; type mismatch unresolved; AC quality flags; **Blocked on spike** |
+| **Needs refinement** | Score 1–3; not enough epic context to draft or revise honestly |
+
+**Flag column** — short reason (score, mismatch, blocked-on-spike, epic gap, etc.).
+
+Items in **Needs human review** or **Needs refinement** must **not** be silently dropped — they stay in the breakdown with flags visible.
+
+---
+
+## 6. Hand off to delivery
+
+Pass to step 6 ([TEMPLATE.md](TEMPLATE.md)):
+
+- Updated breakdown table (types fixed when clear)
+- Updated ticket bodies (revisions applied)
+- **Review flags** table
+- Counts: `N ready · M need human review · K need refinement`
+
+Do **not** post ticket bodies until this step completes. After delivery ([TEMPLATE.md](TEMPLATE.md)), the user must see the full breakdown in chat before any §7 Jira ask ([SKILL.md](SKILL.md) §7).

--- a/.agents/skills/jira-epic-breakdown/SKILL.md
+++ b/.agents/skills/jira-epic-breakdown/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: jira-epic-breakdown
+description: >-
+  Breaks a Jira epic into logical child work items with recommended type (from
+  jira-acceptance-criteria-check/JIRA_TYPE rubrics), summary, dependencies, and paste-ready
+  ticket bodies. Runs jira-acceptance-criteria-check-style review on drafts before delivery and flags items
+  needing human review. Always prints the full breakdown to chat before asking
+  whether to create child items in Jira (MCP only) or do nothing. Spikes file as Stories with Spike in the title; all
+  children set parent to the epic. Uses jira-acceptance-criteria-check type definitions
+  and templates. Fetches epic from Jira or uses pasted epic text. Use when the
+  user asks to break down, decompose, or split an epic into stories, tasks, spikes,
+  or child tickets.
+user-invocable: true
+---
+
+# Break down epic
+
+Decompose one **epic** into child Jira items with the correct **type** (from [JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md) rubrics), **order**, and **paste-ready bodies**. **Review every draft** before showing output ([REVIEW.md](REVIEW.md)). **Jira access:** MCP only ([JIRA.md](JIRA.md)) — no `acli`. **No Jira writes** until §7 when the user chooses to create items.
+
+**§ numbers are stable step IDs — do not renumber when editing.**
+
+**Default:** child items are **not** assumed to exist in Jira yet — do not search for existing children unless the user asks to dedupe ([JIRA.md](JIRA.md)).
+
+**Writing style:** [WRITING.md](WRITING.md) — same bar as **jira-epic-create** (concise, PM-readable, no repeat, no extrapolate).
+
+**Issue types:** [CLASSIFY.md](CLASSIFY.md) → discover types and assignment rules from **jira-acceptance-criteria-check** [JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md).
+
+---
+
+## Companion files
+
+| Step | File |
+|------|------|
+| Writing style | [WRITING.md](WRITING.md) |
+| Gather epic input | [DISCOVERY.md](DISCOVERY.md) |
+| Fetch epic from Jira | [JIRA.md](JIRA.md) |
+| Issue type | [CLASSIFY.md](CLASSIFY.md) · [JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md) |
+| Slice the epic | [DECOMPOSE.md](DECOMPOSE.md) |
+| Per-type ticket bodies | [TICKETS.md](TICKETS.md) |
+| Pre-delivery draft review | [REVIEW.md](REVIEW.md) |
+| Output shape | [TEMPLATE.md](TEMPLATE.md) |
+| Delivery rules | [REPORT.md](REPORT.md) |
+| Worked example | [EXAMPLE.md](EXAMPLE.md) |
+
+---
+
+## Workflow
+
+### 1. Discover epic source
+
+Follow [DISCOVERY.md](DISCOVERY.md).
+
+Hold: epic **key** and/or **pasted epic body**, optional repo paths, optional constraints (team split, must-use spikes, exclude bugs).
+
+**Ask** if no epic key and no pasted description was provided.
+
+---
+
+### 2. Load epic content
+
+| Source | Action |
+|--------|--------|
+| Jira key | [JIRA.md](JIRA.md) — fetch description, summary, AC, parent, linked issues |
+| Pasted epic | Parse sections using [jira-epic-create/TEMPLATE.md](../jira-epic-create/TEMPLATE.md) § Section registry ([JIRA.md](JIRA.md) § Parse epic description) |
+| Prior **jira-epic-create** session | Use epic body from same conversation |
+
+Extract epic AC as a checklist — every child item must **trace** to at least one epic AC (`AC` trace), **Implementation notes** boundary (`IN`), or **Test Plan** item (`TP`) per the registry.
+
+---
+
+### 3. Decompose
+
+Follow [DECOMPOSE.md](DECOMPOSE.md):
+
+1. Identify logical slices (user journey, integration layer, publish, docs/tests).
+2. **Split API/data-fetch work** — one task per endpoint or wizard `Resource`; add foundation task if needed ([DECOMPOSE.md](DECOMPOSE.md) § API and data-fetch splits).
+3. Assign **one type** per slice ([CLASSIFY.md](CLASSIFY.md)).
+4. Set **depends on** order (sequence or parallel).
+5. Draft **summary** (Jira title) per item — verb + outcome, under ~80 chars when possible.
+
+Target **right-sized** items: **completable in one sprint**; split oversized slices (especially combined API wiring).
+
+---
+
+### 4. Draft ticket bodies
+
+For each child item, follow [TICKETS.md](TICKETS.md):
+
+- Use the **Description template** from `jira-acceptance-criteria-check/JIRA_TYPE/{slug}.md` for each item’s `classified_type` ([JIRA_TYPE/README.md](../jira-acceptance-criteria-check/JIRA_TYPE/README.md)).
+- Apply [WRITING.md](WRITING.md) and [GENERAL.md](../jira-acceptance-criteria-check/GENERAL.md) (WHAT + WHY).
+- **Story/task AC:** 3–6 tight bullets each; user-visible or verifiable done conditions.
+- **Spike:** outcomes + scope + timebox — not story-style AC.
+- **Bug:** only when epic describes **broken existing behavior** — repro + expected + actual.
+
+Do **not** create bug items for net-new feature work.
+
+---
+
+### 5. Review drafts (before delivery)
+
+**Default — always run** unless the user asked for **breakdown only** ([DISCOVERY.md](DISCOVERY.md)).
+
+Follow [REVIEW.md](REVIEW.md):
+
+1. Classify and score each draft (jira-acceptance-criteria-check rubrics, synthetic input).
+2. Revise weak drafts from epic context when possible.
+3. Build the **Review flags** table — flag items needing human review.
+
+Do **not** print the breakdown to chat until this step completes.
+
+---
+
+### 6. Assemble and deliver (mandatory — always show the user)
+
+**Always post the full breakdown in chat** before any Jira question or write. The user must be able to read every suggested item — table, coverage, review flags, and ticket bodies — before deciding whether to file in Jira.
+
+Follow [TEMPLATE.md](TEMPLATE.md) and [REPORT.md](REPORT.md):
+
+1. **Breakdown table** — all items with type, summary, depends-on, epic AC trace.
+2. **Epic AC coverage**
+3. **Review flags** — ready vs needs human review ([REVIEW.md](REVIEW.md))
+4. **Ticket bodies** — paste-ready section per item (revisions applied; or summary-only if user asked for titles only)
+
+Run [TEMPLATE.md](TEMPLATE.md) § Quality check before sending.
+
+**Do not** skip this step, summarize it away, or jump to §7 with only a count or title list. **Do not** create Jira issues in the same turn as delivery.
+
+---
+
+### 7. Jira next step (mandatory — only after §6 is in chat)
+
+**Only after** the full §6 breakdown is posted in the message, ask what the user wants to do with the child items. Prefer **AskQuestion** when available — but **never** call AskQuestion (or any §7 prompt) **without** the complete §6 content in the same message above it.
+
+> **What would you like to do with these work items?**
+> 1. **Create them in Jira** under the epic (MCP)
+> 2. **Do nothing right now** — keep the breakdown in chat for manual filing later
+
+Wait for the user's choice before creating issues.
+
+| Choice | Action |
+|--------|--------|
+| **Create in Jira** | Follow [JIRA.md](JIRA.md) § Write. **Epic key** must be known — if not, **stop and ask** before any create. Create each item in suggested order; set **parent** to the epic on every issue. |
+| **Do nothing** | Acknowledge briefly. Do not create issues. |
+
+#### Epic key (create path)
+
+The epic being broken down must have a Jira **key** before creating children.
+
+| Known | Unknown → ask |
+|-------|----------------|
+| User gave epic key at discovery or in prompt | Breakdown used pasted epic only — no key in thread |
+| Epic key from same-thread **jira-epic-create** Jira write | User chose create but key never stated |
+
+Do **not** create children without a confirmed epic key.
+
+#### Spikes in Jira
+
+Planning type **spike** → Jira **`Story`** with **`Spike`** in the summary (e.g. `Spike: Compare subnet validation APIs`). Body still uses the spike template ([TICKETS.md](TICKETS.md), [SPIKE.md](../jira-acceptance-criteria-check/JIRA_TYPE/SPIKE.md)).
+
+---
+
+## Optional follow-ups (only when asked — after §7 resolves)
+
+- Run **jira-acceptance-criteria-check** on Jira keys after tickets are created
+- Re-run breakdown after epic edits
+- Dedupe against existing children — only when user asks ([JIRA.md](JIRA.md) § Existing children)
+
+---
+
+## Anti-patterns
+
+Workflow violations (skipping §6/§7, AskQuestion without breakdown, creating without epic key, spike as Jira Spike type, using `acli`) → see §6, §7, and [JIRA.md](JIRA.md) § Write.
+
+**Content and slicing:**
+
+- One giant story that mirrors the entire epic
+- **One task that wires all API/data fetches** when endpoints are independent or combined scope exceeds one sprint ([DECOMPOSE.md](DECOMPOSE.md) § API and data-fetch splits)
+- Task items that are single-file chores with no clear deliverable
+- Spikes disguising deliverable feature work
+- Bug items for missing features (net-new work → story)
+- Child AC that copy-pastes the full epic flow
+- Items with no trace to epic AC, Test Plan, or Implementation notes
+- Re-slicing work listed in epic **Out of scope**
+- Inventing scope not in the epic
+- Verbose ticket bodies ([WRITING.md](WRITING.md))

--- a/.agents/skills/jira-epic-breakdown/TEMPLATE.md
+++ b/.agents/skills/jira-epic-breakdown/TEMPLATE.md
@@ -1,0 +1,158 @@
+# Output template
+
+Deliver in this order **in chat** — the user reads this before any “create in Jira?” prompt. Do not wrap the full breakdown in one outer code fence. Do not replace this with a summary, file path only, or AskQuestion without the sections below.
+
+---
+
+## 1. Header
+
+```markdown
+# Epic breakdown — [KEY] [Epic summary]
+
+**Epic:** [KEY](https://redhat.atlassian.net/browse/KEY)
+**Items:** N (S stories · T tasks · …)
+**Suggested order:** 1 → 2 → 3 …
+```
+
+When epic was pasted (no key), omit link; use user’s working title.
+
+---
+
+## 2. Breakdown table
+
+```markdown
+| # | Type | Summary | Depends on | Traces epic |
+|---|------|---------|------------|----------------|
+| 1 | task | Publish wizard npm package | — | AC4 |
+| 2 | story | Add prerequisites screen before wizard | — | AC2 |
+| 3 | story | Integrate ROSA HCP wizard in ACM | 1 | AC4, AC5 |
+```
+
+**Columns:**
+
+| Column | Content |
+|--------|---------|
+| # | Implementation order |
+| Type | slug from [JIRA_TYPE/](../jira-acceptance-criteria-check/JIRA_TYPE/README.md) rubrics (e.g. story · task · bug · spike) |
+| Summary | Jira title candidate |
+| Depends on | `#` or `—` |
+| Traces epic | `AC1`, `AC2`, … · `IN` (Implementation notes) · `TP` (Test Plan) · `MIN` (More information needed) |
+
+---
+
+## 3. Coverage check
+
+Short bullet list:
+
+```markdown
+### Epic AC coverage
+
+* AC1 → #2, #3
+* AC2 → #2
+* …
+* All epic AC mapped: yes
+```
+
+If gap, fix decomposition before delivering.
+
+---
+
+## 4. Review flags
+
+Include when step 5 ([REVIEW.md](REVIEW.md)) ran. Omit when user asked for **breakdown only**.
+
+```markdown
+### Review flags
+
+**Summary:** 14 ready · 2 need human review · 1 need refinement
+
+| # | Type | Summary | Status | Flag |
+|---|------|---------|--------|------|
+| 1 | task | Publish wizard npm package | Ready | score 5 |
+| 3 | story | Integrate ROSA HCP wizard in ACM | Needs human review | AC vague on error states; score 3 |
+| 5 | spike | Compare subnet validation APIs | Needs human review | Spike incomplete — timebox missing |
+| 7 | story | Add prerequisites screen | Revised — ready for review | Filled AC from epic AC2 |
+```
+
+**Status values:** `Ready` · `Revised — ready for review` · `Needs human review` · `Needs refinement`
+
+**Flag column:** brief reason (score, type mismatch, blocked on spike, epic MIN trace, etc.).
+
+Every breakdown row appears in this table.
+
+---
+
+## 5. Ticket bodies
+
+One block per item, in suggested order:
+
+```markdown
+---
+
+## 1. [task] Publish wizard npm package
+
+### Description
+
+…
+
+### Acceptance Criteria
+
+* …
+```
+
+Use type-appropriate sections ([TICKETS.md](TICKETS.md)). Heading format: `## <#>. [<type>] <Summary>`.
+
+---
+
+## 6. Already filed (optional — user asked to dedupe only)
+
+When the user asked to check existing children ([JIRA.md](JIRA.md) § Existing children):
+
+```markdown
+### Already filed under epic
+
+* FCN-210 — … (story, In Progress) — overlaps #3; do not duplicate
+```
+
+**Do not** include this section by default — assume child items are not created yet.
+
+---
+
+## Section rules
+
+| Part | Required? |
+|------|-----------|
+| Header | Yes |
+| Breakdown table | Yes |
+| Epic AC coverage | Yes |
+| Review flags | Yes (default); omit only for **breakdown only** |
+| Ticket bodies | Yes (default); omit only if user asked for **table only** |
+| Already filed | Only when user asked to dedupe existing children |
+| §7 Jira ask | **Yes** — only **after** §1–§5 are in the chat message ([SKILL.md](SKILL.md) §6–§7). User must read the breakdown before choosing create vs do nothing. |
+
+---
+
+## Quality check
+
+- [ ] Every epic AC traced to ≥1 item; no orphan items; no items for **Out of scope** work
+- [ ] Types match [CLASSIFY.md](CLASSIFY.md); no bugs for net-new features
+- [ ] Dependencies acyclic and plausible
+- [ ] Summaries are distinct and **sprint-sized**
+- [ ] **API/data-fetch work split** per endpoint when epic implies many calls — not one mega-task ([DECOMPOSE.md](DECOMPOSE.md))
+- [ ] Parallel API items noted where independent
+- [ ] Ticket bodies concise ([WRITING.md](WRITING.md))
+- [ ] No extrapolated scope beyond epic
+- [ ] Story/task AC are outcomes, not task lists
+- [ ] Spikes have outcomes + timebox; no story-style AC
+- [ ] PM can read each Description without engineering translation
+- [ ] Draft review completed ([REVIEW.md](REVIEW.md)) unless **breakdown only**
+- [ ] Every item has a row in **Review flags** when review ran
+- [ ] **Full breakdown posted in chat** before any §7 create vs do nothing ask ([SKILL.md](SKILL.md) §6–§7)
+- [ ] Items flagged **Needs human review** / **Needs refinement** were not silently dropped
+- [ ] Spike summaries include **`Spike`** for Jira filing ([JIRA.md](JIRA.md) § Write)
+
+---
+
+## User asked "titles only"
+
+Deliver §1–§3 and table only; skip §4 ticket bodies.

--- a/.agents/skills/jira-epic-breakdown/TICKETS.md
+++ b/.agents/skills/jira-epic-breakdown/TICKETS.md
@@ -1,0 +1,124 @@
+# Ticket bodies — per type
+
+Draft paste-ready Jira bodies for each child item. Section headings must match **jira-acceptance-criteria-check** type templates (`###` headings).
+
+---
+
+## Common steps
+
+For each item from [DECOMPOSE.md](DECOMPOSE.md):
+
+1. Confirm **classified_type** ([CLASSIFY.md](CLASSIFY.md)).
+2. Open `jira-acceptance-criteria-check/JIRA_TYPE/{slug}.md` for that slug — **Description template** ([JIRA_TYPE/README.md](../jira-acceptance-criteria-check/JIRA_TYPE/README.md)).
+3. Apply [WRITING.md](WRITING.md) + [GENERAL.md](../jira-acceptance-criteria-check/GENERAL.md).
+4. Include only sections with real content — omit empty optional sections (Out of Scope, Implementation Notes, Mock ups).
+
+---
+
+## Story
+
+**Template:** [STORY.md](../jira-acceptance-criteria-check/JIRA_TYPE/STORY.md)
+
+**Required sections:**
+
+### Description or User Story
+
+- Epic link line ([WRITING.md](WRITING.md))
+- WHAT + WHY for **this slice** only
+
+### Acceptance Criteria
+
+- 3–6 testable, user-visible outcomes ([STORY.md](../jira-acceptance-criteria-check/JIRA_TYPE/STORY.md) § Acceptance criteria)
+- Cover happy path + errors for **this slice**
+
+**Optional:**
+
+### Mock ups / Design
+
+- Include when slice is large/complex UI; link Figma from epic **Mockups/Design** when relevant; otherwise omit or `N/A`
+
+**Omit unless needed:** Out of Scope, Implementation Notes
+
+---
+
+## Task
+
+**Template:** [TASK.md](../jira-acceptance-criteria-check/JIRA_TYPE/TASK.md)
+
+**Required sections:**
+
+### Description
+
+- Epic link line
+- WHAT + WHY — deliverable and reason
+
+### Acceptance Criteria
+
+- 3–6 verifiable done conditions ([TASK.md](../jira-acceptance-criteria-check/JIRA_TYPE/TASK.md) § Acceptance criteria)
+- Observable artifacts: package version, module exists, resources created, tests pass for module
+
+**Omit unless needed:** Out of Scope, Implementation Notes
+
+---
+
+## Bug
+
+**Template:** [BUG.md](../jira-acceptance-criteria-check/JIRA_TYPE/BUG.md)
+
+**Use rarely** in epic breakdown — only for broken **existing** behavior.
+
+**Required sections:**
+
+### Description
+
+### How to reproduce
+
+### Expected
+
+### Actual
+
+**No** Acceptance Criteria section for bugs ([BUG.md](../jira-acceptance-criteria-check/JIRA_TYPE/BUG.md)).
+
+---
+
+## Spike
+
+**Template:** [SPIKE.md](../jira-acceptance-criteria-check/JIRA_TYPE/SPIKE.md)
+
+**Required sections:**
+
+### Description
+
+- What will be learned and why now
+
+### Outcomes
+
+- Artifacts/decisions that unblock follow-up stories/tasks — **not** user-facing AC
+
+### Scope and boundaries
+
+- **In scope:** / **Out of scope:**
+
+### Timebox
+
+- Explicit limit (e.g. 2 days, 8 hours)
+
+**No** Acceptance Criteria section for spikes.
+
+**Jira filing:** planning type **spike** → create as **Story** with **`Spike`** in the summary ([JIRA.md](JIRA.md) § Write). Draft the spike body here; prefix the summary line when decomposing if needed ([DECOMPOSE.md](DECOMPOSE.md) § Summary line).
+
+---
+
+## Formatting
+
+- Use `*` bullets for lists; nest with 2 spaces when grouping related AC ([DRAFT.md](../jira-acceptance-criteria-check/DRAFT.md))
+- Match template **`###` heading** text exactly for Jira paste consistency
+- Do not wrap entire ticket in an outer code fence in chat delivery — use headings in normal markdown
+
+---
+
+## Do not
+
+- Copy epic AC wholesale into every child
+- Add story AC to spikes or bugs
+- Invent mockups, repro steps, or timeboxes not implied by epic

--- a/.agents/skills/jira-epic-breakdown/WRITING.md
+++ b/.agents/skills/jira-epic-breakdown/WRITING.md
@@ -1,0 +1,53 @@
+# Writing style — child tickets
+
+Same rules as **jira-epic-create** [WRITING.md](../jira-epic-create/WRITING.md):
+
+- **Concise** — tight lines, no filler
+- **Do not repeat** — epic flow lives in epic; child ticket covers **this slice only**
+- **Do not expand or extrapolate** — only epic content + necessary slice detail
+- **Plain language** — PM-readable Description; jargon in Implementation notes only when needed
+
+---
+
+## Child ticket vs epic
+
+| Epic owns | Child ticket owns |
+|-----------|-------------------|
+| Full journey, full AC set, Out of scope, Test Plan | One slice WHAT/WHY + slice AC |
+| Platform rationale | One-line link to epic in Description ("Part of FCN-XXX") |
+| Mockups/Design (Figma) | Figma link only when this slice needs it |
+| Implementation notes (repos, packages) | Only references **this slice** needs |
+
+Do **not** paste the epic Description into every child.
+
+---
+
+## Length targets (per child)
+
+| Section | Target |
+|---------|--------|
+| Description (WHAT + WHY) | **2–4 sentences** |
+| Acceptance criteria (story/task) | **3–6** bullets |
+| Spike outcomes | **2–4** bullets + timebox line |
+| Bug repro | **3–6** numbered steps |
+
+---
+
+## Epic link line
+
+Start each child Description with one line when epic key is known:
+
+```markdown
+Part of epic [FCN-123 Summary](https://redhat.atlassian.net/browse/FCN-123).
+```
+
+---
+
+## Before delivering
+
+1. Each ticket readable alone without the others
+2. No duplicate bullets across sibling tickets
+3. AC verifiable for **this slice only**
+4. PM can explain each item in one sentence
+
+See also [GENERAL.md](../jira-acceptance-criteria-check/GENERAL.md).

--- a/.agents/skills/jira-epic-create/DISCOVERY.md
+++ b/.agents/skills/jira-epic-create/DISCOVERY.md
@@ -1,0 +1,241 @@
+# Discovery — gather epic context
+
+Collect enough context to draft without guessing. Prefer **conversation history**, **open files**, and **named repos** before asking questions.
+
+**All facts must be resolved before drafting required registry sections.** If the user did not supply something a **Required: yes** section needs, the response is **discovery-only** — no epic draft ([SKILL.md](SKILL.md) §0).
+
+**Section facts:** read [TEMPLATE.md](TEMPLATE.md) § **Section registry** — for each row where **Required** is **yes** (or **yes for UI changes** when UI is in scope), open the **Guide** and collect every item in that file’s **Discovery** field.
+
+---
+
+## Discovery gate (mandatory — hierarchy)
+
+Run this **before** repo research, Jira fetch, or drafting when parent/related are unknown.
+
+### Resolved?
+
+Parent / related are **resolved** only when the user, in this thread:
+
+- Named issue key(s), **or**
+- Explicitly said **“none”**, **“no parent”**, **“standalone”**, or **“no related epics”** for that slot
+
+**Not resolved** = user gave rich product detail but never mentioned hierarchy. **Do not** treat silence as “standalone.”
+
+### If not resolved → discovery-only turn
+
+| Do | Do not |
+|----|--------|
+| Acknowledge what you understood (1–2 sentences) | Output any registry section heading or paste-ready epic |
+| Ask parent + related questions ([§ Ask — parent and related epics](#ask--parent-and-related-epics-mandatory)) | Run repo research or subagents |
+| Use **AskQuestion** when the tool is available | Fetch Jira (no keys yet) |
+| Ask other **unresolved** gaps in the same message if known | Use `(add …)`, `TBD`, or “confirm later” in required sections |
+
+**Wait for the user’s reply.** Draft only on a **later turn** after hierarchy is resolved.
+
+### If resolved → continue
+
+Proceed with checklist below, [JIRA.md](JIRA.md) fetch (when keys exist), [RESEARCH.md](RESEARCH.md), then [§ Completeness gate](#completeness-gate-mandatory--before-drafting).
+
+---
+
+## Completeness gate (mandatory — before drafting)
+
+Run **after** research and **before** writing any epic section.
+
+### Audit
+
+For each registry row where **Required** is **yes** (or **yes for UI changes** when the epic changes UI):
+
+1. Open the **Guide** file.
+2. List every fact that section will use (from its **Discovery** field and draft rules).
+3. Confirm each fact’s source is one of:
+
+| Source | OK? |
+|--------|-----|
+| User stated in this thread | Yes |
+| Fetched parent/related Jira | Yes |
+| Verified repo research (path, type, doc URL found in code) | Yes |
+| Would require guessing or a placeholder in a **required** section | **No — ask first** |
+
+### Common gaps — ask specifically
+
+| If epic would say… | Ask the user (example) |
+|--------------------|-------------------------|
+| Parity with another UI / doc (user mentioned mirroring or alignment) | Which screen, route, or doc is the parity target? Paste link or path. |
+| Submit creates CRDs / resources | Which resources are created on submit? List kinds or point to the template/team doc. |
+| Existing process picks up work | What process or component provisions after submit? |
+| Out of scope | What is explicitly **out** of this epic? |
+| **UI changes without Figma** | Paste Figma link for this flow — required for UI epics. |
+| Parent / related epic | Keys or “none” ([§ Ask — parent and related epics](#ask--parent-and-related-epics-mandatory)) |
+| Product behavior unclear | What should happen when …? |
+
+One **discovery-only** message may combine hierarchy + other gaps. Number each question.
+
+### If any gap remains (blocks required sections)
+
+| Do | Do not |
+|----|--------|
+| Stop; ask each open item by name | Deliver required registry sections with holes |
+| Wait for answers | Add a “Placeholders to confirm” section after the epic |
+| Re-run this gate after user replies | Guess URLs, CRD names, Figma links, or scope |
+
+### User deferral
+
+Only when the user **explicitly** defers in chat (“TBD”, “skip”, “don’t know yet”, “confirm with X team”):
+
+- Record in **[More information needed](SECTIONS/MORE_INFORMATION_NEEDED.md)** — phrase as an open question
+- **Mockups/Design** — if Figma deferred on UI epic, list in More information needed; do not use `(add Figma link)`
+- **Implementation notes** — one bullet with their exact deferral when partial technical context is known
+- **AC** — do not write vague criteria; omit or narrow until confirmed
+
+Deferral is **user-stated**, not agent-invented. Deferred items do **not** unblock missing facts for **required** sections unless the user explicitly said to draft anyway with open questions.
+
+---
+
+## Required inputs (cross-section)
+
+These span multiple registry sections — see each guide’s **Discovery** field for section-specific detail.
+
+| Input | Registry sections |
+|-------|-------------------|
+| **What** | Description |
+| **Why** | Description |
+| **End-to-end flow** | Description |
+| **Acceptance outcomes** | Acceptance criteria |
+| **Out of scope items** | Out of scope |
+| **Test approach** | Test Plan |
+| **Figma (UI epics)** | Mockups/Design |
+| **Parent epic** | Description, Implementation notes — **gate: ask if not provided** |
+| **Related epics** | Out of scope, AC boundaries — **gate: ask if not provided** |
+
+“Not provided” means the user did not name keys **and** did not explicitly say there is no parent or no related epics.
+
+---
+
+## Strongly recommended
+
+| Input | Registry sections |
+|-------|-------------------|
+| **Why this system** (vs CLI, external tool, other product) | Description |
+| **Consumer app** (e.g. ACM console) | Implementation notes |
+| **Library / package** (e.g. npm wizard) | Implementation notes |
+| **Auth / data boundary** (e.g. service account → API) | Description, AC, Implementation notes |
+| **Submit / side effects** (CRDs, API calls, jobs) | Description, AC, Implementation notes |
+| **Parity target** (**only when user mentioned**) | Mockups/Design, Description |
+| **Existing vs net-new** | AC |
+
+---
+
+## Infer before asking
+
+Check in order:
+
+1. **Current conversation** — user may have already described flow, why, and scope
+2. **Named workspace paths** — e.g. `console-acm`, `nxtcm-components`
+3. **Open / recently viewed files**
+4. **Git branch or ticket key** in prompt
+5. **Parent / related epic keys** in prompt or thread — if present, gate passes for that slot
+
+**Infer product detail freely; do not infer Jira hierarchy or Figma links.**
+
+---
+
+## Ask — parent and related epics (mandatory)
+
+If the user did **not** supply parent or related epic information, **stop and ask** — do not skip silently and do not draft first.
+
+### Prefer AskQuestion
+
+When **AskQuestion** is available, use it for structured answers:
+
+**Question 1 — Parent epic**
+
+- Prompt: *Is there a parent epic (initiative or epic) this work rolls up under?*
+- Options (example): `Yes — I’ll paste the key in chat` | `No — standalone epic` | `Not sure yet`
+
+**Question 2 — Related epics**
+
+- Prompt: *Are there related epics the team should align with (dependencies, parallel tracks, shared scope)?*
+- Options (example): `Yes — I’ll paste key(s) in chat` | `No related epics` | `Not sure yet`
+
+If the user picks “I’ll paste the key,” wait for keys in chat before drafting.
+
+### Fallback (no AskQuestion)
+
+One short message — **only** discovery, no epic body:
+
+> I have enough to draft the epic once hierarchy is clear:
+>
+> 1. **Parent epic** — issue key, or “none / standalone”?
+> 2. **Related epics** — issue key(s), or “none”?
+>
+> Optional: paste keys like `FCN-100` and I’ll pull context from Jira before drafting.
+
+Proceed to [JIRA.md](JIRA.md) fetch when keys are given. Record “no parent” / “no related” when user says none.
+
+Do **not** ask again if the user already answered in the same thread.
+
+---
+
+## Ask — other gaps (mandatory when unresolved)
+
+Use **AskQuestion** or a numbered list whenever the [Completeness gate](#completeness-gate-mandatory--before-drafting) audit finds a gap. Include in the **same discovery-only message** as parent/related when both are open:
+
+| Gap | Example question |
+|-----|------------------|
+| No clear **what** | What is the single sentence outcome of this epic? |
+| No **why** | What user pain or release driver motivates this? |
+| No **flow** | Walk through the steps from entry point to done state |
+| Ambiguous **scope** | What is explicitly out of scope for this epic? |
+| **UI epic, no Figma** | Paste the Figma link for this flow (required for UI changes). |
+| Unknown **submit behavior** | What happens when the user finishes — which resources or APIs? |
+| Unknown **downstream process** | What existing process picks up the work after submit? |
+| Vague **parity target** (user asked to mirror or align, link unclear) | Which screen, route, CLI flow, or doc should we align with? Paste link or path. |
+| Unconfirmed **artifacts** | Which CRDs, secrets, or other resources are created on submit? |
+| No **test expectations** | Any required test levels (e2e, component, manual) or CI gates? |
+
+Do **not** ask for information already provided in the same thread.
+
+Do **not** draft and list these as “placeholders to confirm” — ask **before** the epic body exists.
+
+## Discovery checklist
+
+Before drafting, confirm internally:
+
+- [ ] **Hierarchy gate passed** — parent and related each have keys **or** explicit “none”
+- [ ] **Completeness gate passed** — no unresolved gaps in any **Required: yes** registry section
+- [ ] Epic title or working name is clear (use user's wording)
+- [ ] WHAT and WHY can be stated in plain language
+- [ ] Flow has ordered steps (user + system)
+- [ ] **Out of scope** can be listed — user confirmed or inferable from parent/related
+- [ ] **Test Plan** can be drafted from user input or repo norms
+- [ ] **Figma** provided or epic confirmed non-UI
+- [ ] Know what exists vs must be built
+- [ ] Know integration boundaries (who owns routing, API, UI shell vs library)
+- [ ] **Parent epic** — key fetched or confirmed none
+- [ ] **Related epics** — keys fetched or confirmed none
+- [ ] **Parity** — only when user mentioned mirroring or alignment; link confirmed, not invented
+- [ ] **Submit / scope** — confirmed by user or verified research, not invented
+
+**Do not ask about parity, mirroring, or aligning with another product's UI unless the user mentioned it in this thread.** Do not default to any specific product (e.g. OCM) in discovery questions.
+
+If any checklist item fails → **discovery-only response** with specific questions. Do not draft.
+
+## Discovery-only response shape (example)
+
+```markdown
+I can draft the epic once a few items are clear:
+
+1. **Parent epic** — key, or standalone?
+2. **Related epics** — key(s), or none?
+3. **Figma** — link for this flow (required for UI changes).
+4. **Out of scope** — anything explicitly excluded beyond related epics?
+
+Include additional questions only when the user's prompt or research already implies them — e.g. submit resources when submit behavior is in scope but kinds are unknown; parity link when the user said to mirror an existing screen but did not paste the URL.
+
+[AskQuestion UI when available]
+```
+
+**Wrong:** full epic body with registry headings + “placeholders to confirm” at the bottom.
+
+**Wrong:** Mockups/Design row `| Figma | (add link) |` without having asked first.

--- a/.agents/skills/jira-epic-create/JIRA.md
+++ b/.agents/skills/jira-epic-create/JIRA.md
@@ -1,0 +1,170 @@
+# Jira — parent and related epics
+
+Fetch **parent** and **related** epics for context before drafting via **Atlassian MCP only** — no CLI fallback (same bar as **jira-acceptance-criteria-check** [JIRA.md](../jira-acceptance-criteria-check/JIRA.md)).
+
+**Site:** `redhat.atlassian.net`
+
+**No Jira writes** during discovery, research, or drafting. Writes happen only after §6 when the user chooses update or create new ([SKILL.md](SKILL.md) §6, § Write below).
+
+---
+
+## Prerequisite: discovery gate
+
+Do **not** fetch or draft until [DISCOVERY.md](DISCOVERY.md) § Discovery gate passes:
+
+- User named keys **or** explicitly said “none” / “standalone” for **each** of parent and related
+- If not → **discovery-only** response; no Jira calls
+
+Fetching Jira does not replace asking when the user never stated hierarchy.
+
+---
+
+## When to fetch
+
+After the discovery gate passes:
+
+| User provided | Action |
+|---------------|--------|
+| Parent epic key(s) | Fetch each parent |
+| Related epic key(s) | Fetch each related epic |
+| “No parent” / “standalone” | Skip parent fetch; note in internal context |
+| “No related epics” | Skip related fetch; note in internal context |
+
+Do **not** add `(add Jira key)` — ask in discovery ([DISCOVERY.md](DISCOVERY.md) § Completeness gate).
+
+---
+
+## Fields to fetch
+
+Per issue:
+
+| Field | Use |
+|-------|-----|
+| `key` | Implementation notes, chat context, Out of scope |
+| `summary` | Chat context line |
+| `description` | WHAT/WHY, scope, AC hints |
+| `issuetype` | Confirm epic vs initiative vs story |
+
+Optional when useful: `status`, parent link field (if MCP exposes it).
+
+Use `responseContentFormat: "markdown"` for descriptions when MCP supports it.
+
+---
+
+## Transport — MCP only
+
+1. Read MCP tool schemas under `user-atlassian-mcp-server` before calling.
+2. If only `mcp_auth` is listed → authenticate, re-check tools.
+3. `getAccessibleAtlassianResources` → `cloudId` for `redhat.atlassian.net`.
+4. `getJiraIssue` per key with `responseContentFormat: "markdown"` when available.
+
+**If MCP fails** for a **user-supplied key** (server missing, tools unavailable after auth, or fetch error):
+
+- Tell the user how to fix MCP (Cursor → **Settings → MCP** → enable Atlassian; `mcp_auth` for `user-atlassian-mcp-server`).
+- Continue drafting from conversation only — note unfetched keys in **More information needed**.
+- Do **not** use `acli`, Jira REST, or curl.
+- Do **not** stop the whole skill unless the user said drafting depends on Jira.
+
+There is **no** acli or other CLI fallback for this skill.
+
+---
+
+## How to use fetched content
+
+| Source | Apply to |
+|--------|----------|
+| **Parent epic** description | Align WHY and release context; narrow this epic’s scope to its slice of the parent |
+| **Parent epic** AC | Avoid duplicating parent-level outcomes; ensure this epic’s AC are a coherent subset or parallel track |
+| **Related epic** description | Note dependencies, shared components, sequencing |
+| **Related epic** scope | De-dupe AC; list in **Out of scope** when overlap risk — “covered by KEY” |
+
+Do **not** paste parent/related descriptions verbatim into the draft. Synthesize **briefly** ([WRITING.md](WRITING.md)).
+
+---
+
+## Chat context line (optional)
+
+Before the epic body, one line when hierarchy exists:
+
+```markdown
+**Context:** Parent [FCN-100](https://redhat.atlassian.net/browse/FCN-100); related [FCN-200](https://redhat.atlassian.net/browse/FCN-200), [FCN-201](https://redhat.atlassian.net/browse/FCN-201).
+```
+
+Omit when standalone with no related epics.
+
+Parent/related links may also appear in **Implementation notes** when coordination matters for implementers.
+
+---
+
+## Write — create or update epic (after §6)
+
+Run only when the user chose **update existing** or **create new** in [SKILL.md](SKILL.md) §6.
+
+**MCP only** — `user-atlassian-mcp-server`. Do **not** use `acli`, Jira REST, or curl.
+
+| Do | Do not |
+|----|--------|
+| `editJiraIssue` / `createJiraIssue` via MCP | `acli`, Jira REST, or curl for any Jira call |
+| Read MCP tool schemas before calling | Fall back to another transport when MCP fails |
+| `mcp_auth` on **401**, retry once | Silent switch to another transport |
+
+**Cloud ID:** `2b9e35e3-6bd3-4cec-b838-f4249ee02432` or `redhat.atlassian.net`
+
+1. Read MCP tool schemas under `user-atlassian-mcp-server`.
+2. If only `mcp_auth` is listed → authenticate, re-check tools.
+3. `getAccessibleAtlassianResources` → `cloudId` when needed.
+
+### Update existing epic
+
+**Prerequisite:** **Target epic key** is known ([SKILL.md](SKILL.md) §6 — if not, ask the user; do not use parent/related keys by default).
+
+1. Optionally `getJiraIssue` to confirm type is Epic (or note if not).
+2. Post the full draft body (all registry sections) as the issue **description** — markdown, same order as [TEMPLATE.md](TEMPLATE.md) § Section registry.
+3. Confirm success in chat with issue link: `https://redhat.atlassian.net/browse/<KEY>`.
+
+```text
+editJiraIssue
+  cloudId, issueIdOrKey: <TARGET_KEY>
+  fields: { "description": "<full epic markdown>" }
+  contentFormat: "markdown"
+```
+
+Do **not** change summary, parent, or other fields unless the user asked.
+
+### Create new epic
+
+Gather if missing:
+
+| Field | Source |
+|-------|--------|
+| **Project key** | User stated, or prefix from parent epic key (e.g. FCN-100 → `FCN`), or ask |
+| **Summary** | Working title from draft, or ask |
+| **Description** | Full paste-ready epic body from §5 |
+| **Parent** (optional) | Parent epic key from discovery, if user wants hierarchy set on create |
+
+```text
+createJiraIssue
+  cloudId, projectKey, issueTypeName: "Epic"
+  summary: "<title>"
+  description: "<full epic markdown>"
+  contentFormat: "markdown"
+  additional_fields: { "parent": { "key": "<PARENT_KEY>" } }  # only when user confirmed parent on create
+```
+
+Epic parent/link field names vary by site — use `getJiraIssueTypeMetaWithFields` when `additional_fields` fails.
+
+Confirm created key in chat with browse link.
+
+### MCP errors (writes)
+
+| Situation | Action |
+|-----------|--------|
+| **401** | `mcp_auth` for `user-atlassian-mcp-server`, retry once |
+| Still failing after auth | **Stop** — report error; paste-ready draft stays in chat |
+| **-32601** | Wrong tool name — re-read MCP schema |
+| Create/update rejected | Show MCP error; ask user to fix fields or paste manually |
+
+### After write
+
+- **Do not** auto-invoke jira-epic-breakdown or other skills — wait for the user.
+- On failure, show the error; leave the paste-ready draft in chat.

--- a/.agents/skills/jira-epic-create/README.md
+++ b/.agents/skills/jira-epic-create/README.md
@@ -1,0 +1,207 @@
+# jira-epic-create
+
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that drafts **paste-ready Jira epic descriptions** for project owners and management — from conversation, parent/related epics, and optional codebase research. Stops for discovery first; no placeholders in required sections. After delivery, asks whether to create or update in Jira (MCP only) or do nothing.
+
+Use when you need a complete epic body — not a rough outline you still have to fill in.
+
+---
+
+## Requirements
+
+### Atlassian Jira MCP
+
+| Capability | MCP required? | Fallback |
+|------------|---------------|----------|
+| Draft epic in chat from your notes | **No** | — |
+| Optional repo research | **No** | — |
+| Fetch **parent** / **related** epics for context | **Yes** (when keys provided) | Draft from conversation; note unfetched keys in **More information needed** |
+| **Create** or **update** epic in Jira (after you choose §6) | **Yes** | None — all Jira access is **MCP only** |
+
+**Primary workflow:** discovery → draft in chat → ask whether to update Jira, create new, or do nothing.
+
+You can run the full drafting flow **without MCP** if you supply context in chat and choose **do nothing** at the Jira step. MCP is **required** when you provide parent/related **keys** (fetch) or choose **create/update** at §6 — there is no `acli` fallback.
+
+**Setup (when using Jira fetch or writes):**
+
+1. Cursor → **Settings → MCP** — enable the **Atlassian** server (`user-atlassian-mcp-server`).
+2. Complete auth when prompted (`mcp_auth` for `user-atlassian-mcp-server`).
+3. Confirm tools such as `getJiraIssue`, `editJiraIssue`, and `createJiraIssue` are available.
+
+Without MCP, the agent can still draft from conversation; unfetched parent/related keys are noted in **More information needed** if fetch was attempted and failed.
+
+---
+
+## What it does
+
+The agent follows [SKILL.md](SKILL.md) in order (§0–§6). The README step list below groups quality-check and deliver for readability — both map to SKILL §5.
+
+1. **Discovery gate** — ask for missing facts **before** drafting (parent/related epics, Figma for UI, scope, submit behavior, etc.). No placeholders in required sections.
+2. **Context** — extract what/why/flow from conversation; optional Jira fetch for parent and related epics ([JIRA.md](JIRA.md)).
+3. **Research** (optional) — explore named repos/packages when paths are given ([RESEARCH.md](RESEARCH.md)).
+4. **Completeness gate** — re-check that every **Required: yes** registry section can be written without guessing.
+5. **Draft** — one section at a time using [SECTIONS/](SECTIONS/) guides; assemble in [TEMPLATE.md](TEMPLATE.md) § Section registry order.
+6. **Quality check** — concise, plain language, no repeat, no extrapolate ([WRITING.md](WRITING.md)).
+7. **Deliver** — full epic body in chat (paste-ready markdown).
+8. **Jira next step** — ask: update existing epic, create new, or do nothing. Writes use **MCP only** when you choose create/update.
+
+**Discovery-only turns** happen when hierarchy or other required facts are missing — the agent asks questions and does **not** output an epic body until you reply.
+
+---
+
+## How to use it
+
+### Install the skill
+
+Copy this folder into a skills location Cursor reads:
+
+| Location | Scope |
+|----------|-------|
+| `~/.cursor/skills/jira-epic-create/` | Personal — all projects |
+| `.cursor/skills/jira-epic-create/` | Project — shared with the repo |
+
+Enable **Atlassian MCP** when you want Jira fetch or create/update (see [Requirements](#requirements)).
+
+### Trigger in Cursor
+
+Ask the agent to run the skill — for example:
+
+- “Create an epic for integrating the ROSA HCP wizard into ACM”
+- “Draft a Jira epic — parent FCN-100, related FCN-200”
+- “Write an epic description for [feature]; I’ll paste into Jira myself”
+- “Update epic FCN-500 with this draft” (after delivery, choose update at §6)
+
+The skill is **user-invocable** (`SKILL.md` frontmatter). The description helps the agent auto-select it for epic-drafting tasks.
+
+### What to have ready
+
+| Input | When |
+|-------|------|
+| **What** and **why** | Always — outcome and motivation |
+| **End-to-end flow** | Always — entry point through done state |
+| **Parent epic** key or “standalone” | Always — agent asks if not provided |
+| **Related epics** keys or “none” | Always — agent asks if not provided |
+| **Figma link** | UI epics — mandatory for UI changes |
+| **Out of scope** | When boundaries matter — agent asks if unclear |
+| **Repo paths** | Optional — sharper Implementation notes |
+| **Target epic key** | When choosing **update existing** at §6 |
+
+### After delivery
+
+The agent asks what to do with the draft:
+
+| Choice | Behavior |
+|--------|----------|
+| **Update existing** | MCP `editJiraIssue` — asks for target key if unknown |
+| **Create new** | MCP `createJiraIssue` — asks for project key and summary if needed |
+| **Do nothing** | Draft stays in chat for manual paste |
+
+Optional follow-ups (only if **you** ask in a later turn):
+
+- [jira-epic-breakdown](../jira-epic-breakdown/SKILL.md) — decompose into child stories/tasks
+- [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) — score the draft
+
+---
+
+## Directory layout
+
+```
+jira-epic-create/
+├── SKILL.md              # Orchestrator — workflow and gates
+├── README.md             # This file
+├── TEMPLATE.md           # Section registry + paste skeleton + quality check
+├── WRITING.md            # Global prose rules (concise, no repeat, plain language)
+├── DISCOVERY.md          # Discovery and completeness gates
+├── JIRA.md               # MCP-only fetch (parent/related) and writes
+├── RESEARCH.md           # Optional codebase research
+├── EXAMPLE.md            # Worked two-turn example (ROSA HCP wizard)
+└── SECTIONS/             # ← customize: one guide file per epic section
+    ├── README.md         # Add/remove/rename sections
+    ├── SECTION_SKELETON.md
+    ├── DESCRIPTION.md
+    ├── ACCEPTANCE_CRITERIA.md
+    ├── MOCKUPS_DESIGN.md
+    ├── OUT_OF_SCOPE.md
+    ├── TEST_PLAN.md
+    ├── IMPLEMENTATION_NOTES.md
+    └── MORE_INFORMATION_NEEDED.md
+```
+
+---
+
+## How to modify it
+
+### Do not edit (orchestration)
+
+These files discover sections from the registry and delegate — they do **not** define section content or headings:
+
+- `SKILL.md`
+- `DISCOVERY.md`, `WRITING.md`, `RESEARCH.md`, `JIRA.md`, `EXAMPLE.md`
+- `SECTIONS/README.md` (orchestration within the section folder)
+
+### Customize (your epic template)
+
+| What to change | Where | Why |
+|----------------|-------|-----|
+| **Section order and headings** | [TEMPLATE.md](TEMPLATE.md) § **Section registry** | Authoritative list of epic sections |
+| **What belongs in a section** | [SECTIONS/{NAME}.md](SECTIONS/) | Rules, discovery facts, length, breakdown trace |
+| **Add a section** | New `SECTIONS/*.md` + registry row | See [SECTIONS/README.md](SECTIONS/README.md) — no `SKILL.md` edit |
+| **Remove a section** | Delete registry row + guide file | Same |
+| **Rename a heading** | Update **Heading** in guide metadata + registry | **jira-epic-breakdown** follows the registry automatically |
+| **Required vs optional** | Registry **Required** column + guide **Required** metadata | Controls completeness gate blocking |
+
+**Example — add a Risks section:**
+
+1. Copy [SECTIONS/SECTION_SKELETON.md](SECTIONS/SECTION_SKELETON.md) → `SECTIONS/RISKS.md`
+2. Set **Heading** to `## Risks`, **Required** to `no`, **Breakdown trace** to `—`
+3. Add a row to [TEMPLATE.md](TEMPLATE.md) § Section registry
+4. Add `## Risks` to the template skeleton in [TEMPLATE.md](TEMPLATE.md)
+
+### Bundled defaults
+
+This install ships seven sections tuned for product epics with UI, scope boundaries, and test planning. Treat them as **starting templates** — edit guides and the registry to match your team’s epic format.
+
+Section customization details → [SECTIONS/README.md](SECTIONS/README.md).
+
+---
+
+## Default section registry (summary)
+
+| Order | Heading | Required |
+|-------|---------|----------|
+| 1 | Description | yes |
+| 2 | Acceptance criteria | yes |
+| 3 | Mockups/Design | yes for UI changes |
+| 4 | Out of scope | yes |
+| 5 | Test Plan | yes |
+| 6 | Implementation notes | no |
+| 7 | More information needed | no |
+
+Full registry and paste skeleton → [TEMPLATE.md](TEMPLATE.md).
+
+---
+
+## Related skills
+
+| Skill | Relationship |
+|-------|----------------|
+| [jira-epic-breakdown](../jira-epic-breakdown/SKILL.md) | Parses epic bodies using this skill’s section registry; optional follow-up after delivery |
+| [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) | Optional follow-up to score draft quality |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, skill index |
+
+---
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|----------------|
+| Agent drafted with `(add link)` placeholders | Discovery gate skipped — required facts were missing; reply to discovery questions first |
+| Agent asks for parent/related before every draft | Expected — hierarchy is mandatory unless you said “standalone” / “none” |
+| Parent epic fetch fails | Atlassian MCP auth; or paste parent description manually and continue |
+| Fetch or create/update fails | MCP required for all Jira access — no `acli` fallback; retry `mcp_auth` |
+| Agent used wrong epic key on update | Target key must be explicit — parent/related keys are context only ([SKILL.md](SKILL.md) §6) |
+| **jira-epic-breakdown** missed a section | Heading must match registry exactly; see [SECTIONS/](SECTIONS/) metadata |
+| UI epic blocked on Figma | Required for UI changes — paste link or confirm non-UI scope |
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-epic-create/RESEARCH.md
+++ b/.agents/skills/jira-epic-create/RESEARCH.md
@@ -1,0 +1,76 @@
+# Research — codebase and package context
+
+Optional but recommended when the user names repos, packages, or paths. Route findings to the registry section whose guide lists them under **Research feeds** ([TEMPLATE.md](TEMPLATE.md) § Section registry).
+
+**Do not invent** API names, package names, or file paths — verify in repo or ask the user ([DISCOVERY.md](DISCOVERY.md) § Completeness gate).
+
+**Prerequisite:** [DISCOVERY.md](DISCOVERY.md) § Discovery gate must pass before research. Do not spawn repo exploration or subagents on a discovery-only turn.
+
+After research, run [DISCOVERY.md](DISCOVERY.md) § Completeness gate. Unverified findings (URLs, CRD names, routes not found in code) → ask the user or list in **More information needed** if user deferred; do not carry forward as placeholders in required sections.
+
+---
+
+## When to research
+
+| Signal | Action |
+|--------|--------|
+| User names consumer repo (e.g. `console-acm`) | Search routes, existing flows, integration patterns |
+| User names library repo / npm package | Find package name, props/types, README, submit shape |
+| User mentions CRDs, APIs, or backend process | Grep for kinds, resources, existing handlers |
+| User mentions parity with another UI | Search sibling product if path known; if not found, add to completeness audit and ask user |
+| User mentions "already exists" | Confirm in code (routes, pages, service account flows) |
+| User mentions tests | Find test scripts (e2e, component) for **Test Plan** |
+
+Skip when user provides a complete narrative and asks for prose only with no repo context.
+
+---
+
+## Research targets (priority order)
+
+1. **Integration contract** — props, callbacks, types, npm package name → **Implementation notes**
+2. **Submit / output shape** — CRDs, payloads, templates → **Implementation notes**, **Acceptance criteria**
+3. **Existing routes and entry points** — navigation, create-cluster flows → **Description**, **Acceptance criteria**
+4. **Auth / credential pattern** — service accounts, secrets, token usage → **Description**, **AC**, **Implementation notes**
+5. **Official docs** — Red Hat docs, README links in repo → **Implementation notes** or **Mockups/Design** (parity)
+6. **Parity reference** — existing screen, CLI, or doc paths (**only when user mentioned alignment**) → **Mockups/Design**
+7. **Test tooling** — Playwright, Jest, CT config → **Test Plan**
+
+---
+
+## Techniques
+
+| Goal | Approach |
+|------|----------|
+| Package identity | `package.json` `name` field in library repo |
+| Public API | `index.ts`, main component props in `types.ts` |
+| HTTP boundary | Confirm library **does not** call APIs; host app injects `Resource<T>` + `fetch` |
+| CRD / resource names | Grep `kind:`, template files (`.hbs`, `.yaml`) |
+| Routes | Grep `NavigationPath`, `Route`, `create*` in consumer frontend |
+| Existing pages | Glob `**/*Create*`, `**/*Wizard*` under relevant routes |
+| Test scripts | `package.json` scripts, CI workflows |
+
+Keep research **scoped** — read types, README, and representative files; do not exhaust the repo.
+
+---
+
+## Record for drafting
+
+For each finding, open the target section’s guide and confirm **Research feeds** includes that finding type. Default routing:
+
+| Finding | Section guide |
+|---------|---------------|
+| npm package name + repo path | [SECTIONS/IMPLEMENTATION_NOTES.md](SECTIONS/IMPLEMENTATION_NOTES.md) |
+| Key types / props file | [SECTIONS/IMPLEMENTATION_NOTES.md](SECTIONS/IMPLEMENTATION_NOTES.md) |
+| CRD kinds and apiVersion | [SECTIONS/IMPLEMENTATION_NOTES.md](SECTIONS/IMPLEMENTATION_NOTES.md), [SECTIONS/ACCEPTANCE_CRITERIA.md](SECTIONS/ACCEPTANCE_CRITERIA.md) |
+| Existing vs net-new pages | [SECTIONS/ACCEPTANCE_CRITERIA.md](SECTIONS/ACCEPTANCE_CRITERIA.md) |
+| Doc URLs from code constants | [SECTIONS/IMPLEMENTATION_NOTES.md](SECTIONS/IMPLEMENTATION_NOTES.md) or [SECTIONS/MOCKUPS_DESIGN.md](SECTIONS/MOCKUPS_DESIGN.md) |
+| Test scripts / frameworks | [SECTIONS/TEST_PLAN.md](SECTIONS/TEST_PLAN.md) |
+| Gaps / unconfirmed items | [DISCOVERY.md](DISCOVERY.md) § Completeness gate — ask before drafting |
+
+---
+
+## When research is incomplete
+
+Do **not** add `(add link …)` or similar to required sections. Add each gap to the completeness audit and ask the user in a **discovery-only** turn ([DISCOVERY.md](DISCOVERY.md) § Completeness gate).
+
+Never present unverified research as fact in the delivered epic.

--- a/.agents/skills/jira-epic-create/SECTIONS/ACCEPTANCE_CRITERIA.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/ACCEPTANCE_CRITERIA.md
@@ -1,0 +1,104 @@
+# Acceptance criteria section
+
+Apply when drafting the **Acceptance criteria** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Acceptance criteria` |
+| **Required** | yes |
+| **Discovery** | each in-scope piece/item — verifiable outcomes required to close the epic |
+| **Breakdown trace** | `AC` (primary trace target — AC1, AC2, …) |
+| **Owns** | Each in-scope piece/item — verifiable done conditions |
+| **Does not own** | Full narrative, step-by-step flow, link lists |
+| **Length target** | **5–10** items for a large epic; **3–6** for a narrow epic |
+| **Research feeds** | CRD kinds and apiVersion; existing vs net-new surfaces |
+
+Detail description of each **in-scope individual piece / item** — high-level, **verifiable outcomes** required to **close the epic**, not a sprint task breakdown.
+
+**Audience & style:** [WRITING.md](../WRITING.md) — plain language a PM can verify. Concise. **Do not restate** the Description flow step-for-step.
+
+---
+
+## Format
+
+- Markdown checkbox list: `- [ ] …`
+- One in-scope piece or item per checkbox — enough detail to identify the work, not a story title alone
+- **5–10 items** for a large epic; **3–6** for a narrow epic
+- Nest only when necessary — prefer flat list
+
+---
+
+## What belongs at epic level
+
+| Include | Example |
+|---------|---------|
+| New navigation / entry point | Route and discoverability from cluster creation flows |
+| User-facing screens | Prerequisites, confirmation, error states |
+| Integration of shared library | Wizard runs in ACM; required data is loaded and shown |
+| Data / auth wiring | Service account is used to load regions, accounts, and other wizard options |
+| Submit side effects | Submitted cluster is queued for creation on the hub |
+| Non-functional gates | RBAC, error handling, tests at appropriate level |
+| Documentation | Operator/admin or team docs updated |
+
+| Exclude (child stories) | Example |
+|-------------------------|---------|
+| Individual wizard step UI tweaks | "Fix machine pool validation message" |
+| Single API endpoint implementation detail | "Add retry with exponential backoff" |
+| Per-file refactors | "Extract hook to utils" |
+
+When in doubt, phrase as **observable user or system outcome** with enough specificity to identify the in-scope piece.
+
+---
+
+## AC writing rules
+
+1. **Verifiable** — reviewer can confirm yes/no
+2. **Outcome-focused** — "User can …", "Team can …", "Flow handles …"
+3. **Plain language** — same terms as Description; technical names only in **Implementation notes** / **Mockups/Design**
+4. **Existing vs new** — call out reuse vs net-new when it affects done-ness
+5. **Error and auth** — one AC for failures and one for authorization when applicable
+6. **Testing & docs** — one AC each only when the user implied them; detailed test approach goes in **Test Plan**
+7. **Parent alignment** — this epic’s slice only; no duplicate parent outcomes ([JIRA.md](../JIRA.md))
+8. **Related epics** — boundary in **Out of scope** or **Implementation notes**, not a long AC, unless user stated a hard dependency
+
+---
+
+## Categories checklist
+
+Ensure coverage across these when relevant to the epic (not every epic needs every row):
+
+| Category | Prompt |
+|----------|--------|
+| Discoverability | Can users find and start the flow? |
+| Prerequisites | Are preconditions explained before main work? |
+| Credential / account | Can user select or create required identity? |
+| Core experience | Does the main feature/integration work end-to-end? |
+| Data integration | Is external data fetched and shown correctly? |
+| Submit / persistence | Are artifacts created and processed downstream? |
+| Completion UX | Does user get clear post-submit state? |
+| Errors | Are fetch/submit/auth failures handled? |
+| Security / RBAC | Are unauthorized users blocked? |
+| Quality | Are tests and docs updated? |
+
+---
+
+## Do not
+
+- Duplicate the Description flow — AC are **done conditions** for each in-scope piece, not a second walkthrough
+- Use vague criteria ("works well", "is performant")
+- Invent scope, CRDs, APIs, or RBAC not from user or research
+- Extrapolate extra AC for "best practices" the user did not mention
+
+---
+
+## Section template
+
+```markdown
+## Acceptance criteria
+
+- [ ] …
+- [ ] …
+- [ ] …
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/DESCRIPTION.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/DESCRIPTION.md
@@ -1,0 +1,144 @@
+# Description section
+
+Apply when drafting the **Description** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Description` |
+| **Required** | yes |
+| **Discovery** | what (outcome), why (motivation), end-to-end flow (ordered user/system steps); parent slice when parent exists |
+| **Breakdown trace** | `—` (context only — journey slicing) |
+| **Owns** | What, why, user journey, business/platform rationale |
+| **Does not own** | Checkbox outcomes, repo paths, design links, test steps |
+| **Length target** | ~3–5 short paragraphs + flow list (**5–9** numbered steps) |
+| **Research feeds** | Existing vs net-new pages (for AC alignment); entry points and routes |
+
+Summarize **what**, **why**, and **how users move through the work** — not implementation tasks.
+
+**Audience & style:** [WRITING.md](../WRITING.md) — plain language for project owners, PMs, and management. Concise. Do not repeat content that belongs in other registry sections.
+
+---
+
+## Structure
+
+Use this order inside Description:
+
+1. **Opening paragraph** — one or two sentences: integrate/build X so users can Y without Z
+2. **Problem / today state** — what happens now and why it is painful
+3. **Proposed solution** — what the epic delivers at a high level
+4. **Platform rationale** (when relevant) — why this product/system vs alternatives the user named (e.g. console vs CLI)
+5. **Relationship to parent epic** (when parent exists) — one short paragraph: this epic’s slice of the parent initiative; do not repeat the full parent description
+6. **End-to-end flow** — numbered list of user + system steps
+
+Optional short subheading before the flow: `### End-to-end flow`
+
+---
+
+## WHAT (opening + solution)
+
+State clearly:
+
+- The **outcome** (feature, integration, capability)
+- **Where** it lives (which app, route, or surface)
+- **What replaces or improves** current behavior (CLI, docs-only, manual steps)
+
+**Weak:** "Integrate the wizard."
+
+**Strong:** "Integrate the ROSA HCP cluster creation wizard into the ACM console so users can create AWS ROSA Hosted Control Plane clusters entirely within the UI."
+
+---
+
+## WHY (problem + platform rationale)
+
+Include:
+
+- **User pain** — leaving the UI, missing guidance, error-prone manual steps
+- **Product benefit** — faster creation, validation, preselected options, fewer support issues
+- **Why this system** — when user explained it (e.g. auto-connect to hub, governance, lifecycle)
+
+Use a dedicated paragraph or bullets for "why ACM" / "why not alternative" when the user provided that reasoning.
+
+---
+
+## Parent and related epics ([JIRA.md](../JIRA.md))
+
+When a **parent epic** was fetched:
+
+- Align opening and WHY with the parent’s intent — this epic should read as a coherent **slice**, not a duplicate
+- Prefer the parent’s release or customer framing when this epic did not restate it
+- Optional one paragraph under proposed solution: how this epic contributes to the parent outcome
+
+When **related epics** exist:
+
+- Do not claim scope owned by a related epic
+- Mention coordination in flow or a brief note only when dependency affects this epic’s narrative (e.g. “wizard package publish tracked in FCN-200”)
+
+Do **not** paste parent or related descriptions verbatim.
+
+---
+
+## End-to-end flow
+
+Numbered steps in **user terms** (see [WRITING.md](../WRITING.md) § Plain language):
+
+- Entry point (where the user starts — note if new)
+- Preconditions (setup, account, permissions)
+- Main experience (wizard, form, configuration)
+- What data the user sees and where it comes from (plain terms — e.g. "account credentials", not callback names)
+- What happens when they submit
+- How they know it succeeded
+
+Each step: **who** + **what** + **new vs existing** when known. **5–9 steps** typical; combine steps before adding more.
+
+Example pattern:
+
+```markdown
+1. User opens Create cluster in ACM (new entry for ROSA HCP).
+2. User reviews prerequisites and confirms setup is complete.
+3. User selects or creates a service account.
+4. User completes the cluster creation wizard.
+5. The console loads account and region options using that service account.
+6. User submits; cluster creation is queued on the hub.
+7. User sees a confirmation that the cluster was submitted.
+```
+
+---
+
+## Tone and length
+
+- Complete sentences; **plain language** ([WRITING.md](../WRITING.md))
+- No file paths, component names, or API details — those go in **Implementation notes**
+- **3–5 short paragraphs** plus flow list; cut before you expand
+
+---
+
+## Do not
+
+- Paste acceptance criteria into Description
+- List child stories or sprint tasks
+- Speculate or extrapolate beyond user input or research
+- Repeat parent epic text or related epic scope
+
+---
+
+## Section template
+
+```markdown
+## Description
+
+[Overall high-level description — what, why, where]
+
+[Problem / today state]
+
+[Proposed solution]
+
+[Platform rationale — when applicable]
+
+### End-to-end flow
+
+1. …
+2. …
+3. …
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/IMPLEMENTATION_NOTES.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,59 @@
+# Implementation notes section
+
+Apply when drafting the **Implementation notes** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Implementation notes` |
+| **Required** | no — omit entire section when nothing beyond Description and AC |
+| **Discovery** | optional — partial technical context; user deferrals recorded as open bullets when known |
+| **Breakdown trace** | `IN` (API/repo boundaries, release coordination) |
+| **Owns** | Hiccups, boundaries, repos/packages for implementers |
+| **Does not own** | User story, AC restatement, full design spec |
+| **Length target** | **0–8** bullets; omit section if empty |
+| **Research feeds** | npm package name, types/props paths, CRD kinds, integration patterns, doc URLs |
+
+Some good things to know about the **hiccups** someone may experience while implementing the epic — boundaries, coordination, and technical context.
+
+**Style:** [WRITING.md](../WRITING.md) — brief bullets for implementers.
+
+---
+
+## Include when known
+
+| Topic | Example content |
+|-------|-----------------|
+| Separation of concerns | Library owns UI; host owns routing, API clients, CRD creation |
+| Auth / data boundary | Service account credentials scope all platform API calls |
+| Integration pattern | Injected `Resource<T>` with `fetch` callbacks; no HTTP in library |
+| Submit translation | Host implements `onSubmit` → hub CRDs |
+| Existing backend | Provisioning after CRD creation — see **Out of scope** |
+| Parity | Prerequisites in shell UI; wizard starts after gate |
+| Release coordination | Pin npm package version between library publish and consumer |
+| Epic dependencies | Related epic KEY owns X; this epic owns Y |
+| **Repos / packages** | `@scope/package` in `repo` → `path/`; props in `types.ts` |
+| **Parent / related Jira** | [FCN-100](https://redhat.atlassian.net/browse/FCN-100) — parent; coordinate with FCN-200 for npm publish |
+
+Use bullet list. Technical names (npm, CRD kinds, paths) belong here — not in Description or AC.
+
+---
+
+## Do not
+
+- Repeat Description or AC in technical terms
+- Expand into full design spec or file-by-file plan
+- Duplicate **Out of scope** exclusions
+- Use as a second References table — weave links inline in bullets when helpful
+
+---
+
+## Section template
+
+```markdown
+## Implementation notes
+
+- …
+- …
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/MOCKUPS_DESIGN.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/MOCKUPS_DESIGN.md
@@ -1,0 +1,87 @@
+# Mockups/Design section
+
+Apply when drafting the **Mockups/Design** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Mockups/Design` |
+| **Required** | yes for UI changes — Figma link mandatory when the epic changes UI; N/A or omit for backend-only |
+| **Discovery** | Figma link for UI epics; parity reference URL only when user mentioned alignment |
+| **Breakdown trace** | `—` (Figma/parity links passed to UI child stories) |
+| **Owns** | Figma and design/parity links |
+| **Does not own** | Prose design spec, user journey |
+| **Length target** | Links + short labels — **1–5** entries |
+| **Research feeds** | Doc URLs from code constants (parity) |
+
+Design references for UI work. Official template note: **FIGMA DESIGNS MANDATORY!!!(for UI changes at discretion)**.
+
+**Style:** [WRITING.md](../WRITING.md) — links and brief labels only; no design spec prose.
+
+---
+
+## When required
+
+| Epic type | Action |
+|-----------|--------|
+| **UI changes** (new screens, flows, layout, visual behavior) | **Figma link required** — ask in discovery if missing ([DISCOVERY.md](../DISCOVERY.md) § Completeness gate) |
+| Backend-only, config, docs, or non-visual integration | State **N/A — no UI changes** or omit section with one line: "No UI changes in this epic." |
+
+Use team discretion for borderline cases (e.g. error text only) — when in doubt, ask whether Figma exists.
+
+---
+
+## Format
+
+**Preferred — bullet list with links:**
+
+```markdown
+- **Figma — [flow or screen name]:** [link](https://www.figma.com/…)
+- **Parity reference — [screen or doc name]:** [link](https://…) — only when user confirmed mirroring an existing UI or doc
+```
+
+**When multiple artifacts:**
+
+```markdown
+| Artifact | Link |
+|----------|------|
+| Figma — Create cluster flow | [link](https://www.figma.com/…) |
+| Parity — prerequisites screen | [link](https://…) |
+```
+
+---
+
+## What to include
+
+| Priority | Reference type |
+|----------|----------------|
+| 1 | **Figma** — primary design for this epic's UI |
+| 2 | Parity references (existing screen, CLI, or doc) — **only when user mentioned alignment** and URL is confirmed |
+| 3 | Parent or related epic design links when fetched from Jira and relevant |
+
+---
+
+## Link rules
+
+- Use **full URLs** — only when user provided or research verified
+- **Missing Figma for a UI epic** → ask in discovery; do **not** deliver `(add Figma link)` in the epic
+- Do not invent design links
+
+---
+
+## Do not
+
+- Describe pixel-level or component-level design in prose — point to Figma
+- Duplicate Description flow as a design walkthrough
+- List every mockup frame — link to the epic-relevant file or page
+
+---
+
+## Section template
+
+```markdown
+## Mockups/Design
+
+[FIGMA DESIGNS MANDATORY!!!(for UI changes at discretion)]
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/MORE_INFORMATION_NEEDED.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/MORE_INFORMATION_NEEDED.md
@@ -1,0 +1,73 @@
+# More information needed section
+
+Apply when drafting the **More information needed** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## More information needed` |
+| **Required** | no — omit entire section when no open questions remain |
+| **Discovery** | not used to block drafting — only for user-explicit deferrals or residual ambiguity after gates pass |
+| **Breakdown trace** | `MIN` (spike candidates in jira-epic-breakdown) |
+| **Owns** | Open questions after deferral or residual ambiguity |
+| **Does not own** | Facts that should have blocked drafting |
+| **Length target** | **0–5** items; omit section if none |
+
+Open questions and answers that may arise during implementation — **optional** section.
+
+**Style:** [WRITING.md](../WRITING.md) — numbered or bulleted questions; include known partial answers when the user supplied them.
+
+---
+
+## When to include
+
+| Situation | Action |
+|-----------|--------|
+| User **explicitly deferred** ("TBD", "confirm with X team", "don't know yet") | List each deferred item as an open question |
+| Genuine ambiguity remains **after** discovery and drafting | List specific questions — not vague "confirm scope" |
+| **No open questions** | **Omit entire section** — do not add filler |
+
+---
+
+## Relationship to discovery gate
+
+This section is **not** a workaround for skipping discovery:
+
+- **Critical facts** needed to write any **Required: yes** registry section → still **discovery-only** turn first ([DISCOVERY.md](../DISCOVERY.md) § Completeness gate)
+- **More information needed** is for items that can ship in the epic draft but need follow-up from PM, design, or another team
+
+---
+
+## Format
+
+```markdown
+- **Full CRD set on submit?** — User noted `ROSAControlPlane`; provisioning team to confirm companion secrets/kinds.
+- **Parity reference URL?** — User asked to align with an existing prerequisites screen; design team to confirm link.
+```
+
+Or Q&A pairs when the user partially answered:
+
+```markdown
+1. **Which service account roles are required?** — Partial: ROSA installer role documented; cluster-admin on hub TBD with identity team.
+```
+
+---
+
+## Do not
+
+- Use `(add link)` or `(add Jira key)` — phrase as a question
+- Dump a "placeholders to confirm" footer outside this section
+- List questions that should have blocked drafting (missing Figma for UI epic, unknown parent epic, no idea what the feature does)
+- Invent open questions for polish
+
+---
+
+## Section template
+
+```markdown
+## More information needed
+
+- …
+- …
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/OUT_OF_SCOPE.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/OUT_OF_SCOPE.md
@@ -1,0 +1,70 @@
+# Out of scope section
+
+Apply when drafting the **Out of scope** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Out of scope` |
+| **Required** | yes |
+| **Discovery** | explicit exclusions — user-stated, parent/related de-dupe, or inferable boundaries |
+| **Breakdown trace** | `—` (hard exclusions — jira-epic-breakdown must not slice listed work) |
+| **Owns** | Explicit exclusions |
+| **Does not own** | In-scope AC restatement |
+| **Length target** | **1–8** bullets |
+| **Research feeds** | Existing backend/process boundaries verified in code |
+
+What should be **excluded** for this feature — explicit boundaries so implementers and PMs do not assume work belongs here.
+
+**Style:** [WRITING.md](../WRITING.md) — plain language bullets. Ask in discovery when scope boundaries are unclear ([DISCOVERY.md](../DISCOVERY.md) § Completeness gate).
+
+---
+
+## Format
+
+- Bullet list: `- …`
+- One exclusion per bullet
+- **3–8 items** typical for a large epic; **1–3** for a narrow epic
+
+---
+
+## What to include
+
+| Include | Example |
+|---------|---------|
+| Work owned by **related epics** | Wizard npm publish (FCN-200); service account UX (FCN-201) |
+| **Parent epic** scope handled elsewhere | Full ROSA HCP backend provisioning — existing ACM process |
+| **Future phases** user named but deferred | Multi-cloud support; edit-in-place after create |
+| **Alternative surfaces** | CLI-only path; same flow in another product the user named |
+| **Non-goals** user stated | Performance tuning; redesign of unrelated cluster list |
+
+Phrase as **what is excluded**, not what is included.
+
+---
+
+## Sources
+
+- User-stated exclusions
+- Parent/related epic scope from [JIRA.md](../JIRA.md) fetch — de-dupe against this epic's AC
+- Verified research (e.g. "provisioning after CRD is existing backend")
+
+---
+
+## Do not
+
+- Repeat acceptance criteria as negated items ("not failing tests")
+- Use vague exclusions ("nice-to-haves", "low priority items")
+- Invent out-of-scope items the user never implied
+- Hide scope boundaries only in Description — they belong here
+
+---
+
+## Section template
+
+```markdown
+## Out of scope
+
+- …
+- …
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/OUT_OF_SCOPE.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/OUT_OF_SCOPE.md
@@ -54,7 +54,7 @@ Phrase as **what is excluded**, not what is included.
 ## Do not
 
 - Repeat acceptance criteria as negated items ("not failing tests")
-- Use vague exclusions ("nice-to-haves", "low priority items")
+- Use vague exclusions ("nice-to-haves", "low-priority items")
 - Invent out-of-scope items the user never implied
 - Hide scope boundaries only in Description — they belong here
 

--- a/.agents/skills/jira-epic-create/SECTIONS/README.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/README.md
@@ -1,0 +1,69 @@
+# SECTIONS — epic section guides
+
+One markdown file per epic section. The skill discovers sections from [TEMPLATE.md](../TEMPLATE.md) § **Section registry** — it does **not** assume a fixed set of headings beyond what the registry lists.
+
+**Bundled defaults:** `DESCRIPTION.md`, `ACCEPTANCE_CRITERIA.md`, `MOCKUPS_DESIGN.md`, `OUT_OF_SCOPE.md`, `TEST_PLAN.md`, `IMPLEMENTATION_NOTES.md`, `MORE_INFORMATION_NEEDED.md`. Teams may add, rename, or remove sections to match their epic template.
+
+---
+
+## What each section file defines (authoritative source)
+
+Each section file’s **Section metadata** and body rules define:
+
+- **Heading** — exact Jira `##` line used in the assembled epic
+- **Required** — whether missing facts block drafting ([DISCOVERY.md](../DISCOVERY.md) § Completeness gate)
+- **Discovery** — facts this section needs before drafting
+- **Breakdown trace** — code used by **jira-epic-breakdown** (`AC`, `IN`, `TP`, `MIN`, or `—`)
+- **Owns / Does not own** — duplication boundaries ([WRITING.md](../WRITING.md))
+- **Length target** — typical size
+- **Research feeds** (optional) — repo findings that belong in this section
+
+Orchestration files (`SKILL.md`, `DISCOVERY.md`, `WRITING.md`, etc.) **delegate** to the registry and section files — they do not hard-code section names.
+
+---
+
+## Discovery
+
+Before draft, assemble, or quality-check:
+
+1. Read [TEMPLATE.md](../TEMPLATE.md) § **Section registry** in **Order** column sequence.
+2. For each registry row, open the **Guide** file.
+3. Read **Section metadata** at the top of each guide.
+4. Draft using that file’s rules; omit optional sections when metadata says to omit empty sections.
+
+**Exclude** `README.md` from section discovery — it is orchestration docs, not a section.
+
+---
+
+## Adding a section
+
+1. Copy [SECTION_SKELETON.md](SECTION_SKELETON.md) to a new file (e.g. `RISKS.md`).
+2. Fill in **Section metadata** and section body rules.
+3. Add a row to [TEMPLATE.md](../TEMPLATE.md) § **Section registry** (set **Order**, **Heading**, **Guide**, **Required**).
+4. Add the heading block to [TEMPLATE.md](../TEMPLATE.md) § **Template** skeleton (optional but recommended for paste preview).
+5. No changes to [SKILL.md](../SKILL.md) are required — the skill picks up the new section on the next run.
+
+**jira-epic-breakdown:** If **Breakdown trace** is not `—`, decomposition will parse and trace that section automatically via the same registry.
+
+---
+
+## Removing a section
+
+1. Delete the registry row from [TEMPLATE.md](../TEMPLATE.md) § **Section registry**.
+2. Remove the heading from [TEMPLATE.md](../TEMPLATE.md) § **Template** skeleton if present.
+3. Delete the guide file from `SECTIONS/`.
+4. No changes to [SKILL.md](../SKILL.md) are required.
+
+---
+
+## Renaming a heading
+
+1. Update **Heading** in the section file’s metadata.
+2. Update **Heading** in the registry row.
+3. Update the skeleton in [TEMPLATE.md](../TEMPLATE.md) § **Template**.
+
+**jira-epic-breakdown** follows the registry — no separate parser edit needed when headings change.
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-epic-create/SECTIONS/SECTION_SKELETON.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/SECTION_SKELETON.md
@@ -1,0 +1,48 @@
+# Section name — evaluation and draft rules
+
+Apply when drafting this registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Section name` |
+| **Required** | yes \| no |
+| **Discovery** | <Facts needed before drafting — e.g. user-stated exclusions, Figma link> |
+| **Breakdown trace** | `—` \| `AC` \| `IN` \| `TP` \| `MIN` |
+| **Owns** | <What belongs in this section> |
+| **Does not own** | <What belongs in other sections> |
+| **Length target** | <e.g. 3–8 bullets> |
+| **Research feeds** | <optional — repo findings that land here> |
+
+**Style:** [WRITING.md](../WRITING.md) unless this file says otherwise.
+
+---
+
+## Format
+
+<How to structure content — bullets, checkboxes, links, etc.>
+
+---
+
+## What to include
+
+| Include | Example |
+|---------|---------|
+| … | … |
+
+---
+
+## Do not
+
+- …
+
+---
+
+## Section template
+
+```markdown
+## Section name
+
+…
+```

--- a/.agents/skills/jira-epic-create/SECTIONS/TEST_PLAN.md
+++ b/.agents/skills/jira-epic-create/SECTIONS/TEST_PLAN.md
@@ -1,0 +1,78 @@
+# Test Plan section
+
+Apply when drafting the **Test Plan** registry section ([TEMPLATE.md](../TEMPLATE.md) § Section registry).
+
+## Section metadata
+
+| Field | Value |
+|-------|-------|
+| **Heading** | `## Test Plan` |
+| **Required** | yes |
+| **Discovery** | what to verify and how — from user input or repo test norms |
+| **Breakdown trace** | `TP` (test/docs tasks in jira-epic-breakdown) |
+| **Owns** | What to test and how |
+| **Does not own** | AC outcomes duplicated verbatim |
+| **Length target** | **4–10** bullets |
+| **Research feeds** | Test scripts, frameworks, CI workflows |
+
+What will need to be **tested** and **how** — epic-level verification strategy, not a story-level test case dump.
+
+**Style:** [WRITING.md](../WRITING.md) — plain language bullets.
+
+---
+
+## Format
+
+- Bullet list grouped by area when helpful
+- Each bullet: **what** to verify + **how** (manual, unit, component, e2e, integration)
+- **4–10 bullets** typical
+
+Example pattern:
+
+```markdown
+- **Happy path — create flow:** Manual or e2e — user completes prerequisites, wizard, and submit; cluster creation is queued.
+- **Service account auth:** Integration — wizard data loads using selected credentials; failures show clear errors.
+- **RBAC:** Manual — unauthorized users cannot access the create route.
+- **Submit / CRDs:** Integration or unit — host `onSubmit` produces expected hub resources.
+- **Error states:** Component or manual — API timeout, invalid credentials, submit failure each surface actionable messages.
+```
+
+---
+
+## Coverage checklist
+
+Ensure relevant rows when applicable (not every epic needs every row):
+
+| Area | Prompt |
+|------|--------|
+| Happy path | End-to-end user flow from entry to confirmation |
+| Prerequisites / gates | Preconditions block or allow progress correctly |
+| Data integration | External data loads and displays |
+| Submit / side effects | Artifacts created; downstream process starts |
+| Error handling | Fetch, auth, validation, submit failures |
+| RBAC / auth | Unauthorized access blocked |
+| Regression | Existing flows unaffected |
+| Accessibility | Key flows keyboard-navigable and labeled (when UI epic) |
+| Docs | Operator or team docs accurate (when user implied) |
+
+Match test **level** to team norms from conversation or repo (e.g. Playwright e2e in `console-acm`, component tests in library packages).
+
+---
+
+## Do not
+
+- Duplicate acceptance criteria verbatim — Test Plan says **how** to verify, AC says **what** must be true
+- List every unit test file or describe block
+- Invent test tooling the user never mentioned unless research found standard scripts in repo
+- Add performance or load testing unless user requested
+
+---
+
+## Section template
+
+```markdown
+## Test Plan
+
+- …
+- …
+```

--- a/.agents/skills/jira-epic-create/SKILL.md
+++ b/.agents/skills/jira-epic-create/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: jira-epic-create
+description: >-
+  Drafts concise Jira epic descriptions for project owners and management —
+  from user context, parent/related Jira epics, and optional codebase research.
+  Sections defined in TEMPLATE.md § Section registry (default: Description,
+  Acceptance criteria, Mockups/Design, Out of scope, Test Plan, Implementation
+  notes, More information needed). Plain language; no repeat, expand, or
+  extrapolate. **Stops for discovery first:** asks for all missing facts
+  (parent/related epics, Figma for UI, parity links, submit artifacts, scope,
+  etc.) before research or drafting — never delivers placeholders in required
+  sections. After delivery, asks whether to update an existing epic, create a new
+  one, or do nothing; Jira access MCP only. Use when the user asks to write,
+  draft, or create a Jira epic, epic description, or high-level feature epic.
+user-invocable: true
+---
+
+# Create epic
+
+Draft a **paste-ready Jira epic body** for **project owners, PMs, and management** — concise, plain language, no repeat or extrapolation ([WRITING.md](WRITING.md)). **Jira access:** MCP only ([JIRA.md](JIRA.md)) — no `acli`. **No Jira writes** until §6 when the user chooses update or create new.
+
+**§ numbers are stable step IDs — do not renumber when editing.**
+
+---
+
+## Companion files
+
+| Step | File |
+|------|------|
+| Writing style (global) | [WRITING.md](WRITING.md) |
+| Section registry + output shape | [TEMPLATE.md](TEMPLATE.md) |
+| Section guides (one file per section) | [SECTIONS/](SECTIONS/) — see [SECTIONS/README.md](SECTIONS/README.md) |
+| Gather input | [DISCOVERY.md](DISCOVERY.md) |
+| Parent / related epics | [JIRA.md](JIRA.md) |
+| Explore repos (optional) | [RESEARCH.md](RESEARCH.md) |
+| Worked example | [EXAMPLE.md](EXAMPLE.md) |
+
+---
+
+## Workflow
+
+### 0. Discovery gate (hard stop)
+
+**Before research, repo exploration, or drafting:** follow [DISCOVERY.md](DISCOVERY.md) § Discovery gate and § Completeness gate.
+
+| All required facts resolved? | Allowed next step |
+|-----------------------------|-------------------|
+| **No** — any gap would become a placeholder, guess, or “confirm later” note in a **required** registry section | **Discovery-only response** — ask for each missing item; do **not** draft |
+| **Yes** — user, Jira, or verified research supplied every fact used in required sections | Continue to §1 |
+
+**Discovery-only response** means:
+
+1. Briefly acknowledge what you understood (1–2 sentences).
+2. Ask every **unresolved** item in one message — numbered, specific ([DISCOVERY.md](DISCOVERY.md) § Ask).
+3. Prefer **AskQuestion** when available.
+4. **Do not** output any registry section heading or paste-ready epic body.
+5. **Do not** run repo research until hierarchy is resolved; after research, run completeness audit before drafting.
+
+**Mandatory asks** (when not already provided): parent epic, related epics ([DISCOVERY.md](DISCOVERY.md) § Ask — parent and related epics).
+
+**Also ask before drafting** when research or the user’s prompt leaves gaps that would otherwise become `(add link)`, “confirm with team”, TBD rows in required sections, or vague AC ([DISCOVERY.md](DISCOVERY.md) § Completeness gate). **UI epics:** Figma link mandatory — ask if missing.
+
+Rich context does **not** waive missing facts.
+
+---
+
+### 1. Discover context
+
+Follow [DISCOVERY.md](DISCOVERY.md) — only after §0 gate passes.
+
+Extract from conversation or ask when still blocked — use each registry section’s **Discovery** field in [SECTIONS/](SECTIONS/) plus [DISCOVERY.md](DISCOVERY.md) § Required inputs.
+
+For other gaps, ask only when missing info would force guessing on product behavior, scope, or acceptance criteria. Prefer inferring from conversation history and open files.
+
+---
+
+### 2. Fetch parent and related epics
+
+Follow [JIRA.md](JIRA.md) when the user gave issue keys.
+
+Use fetched descriptions to align scope, WHY, and dependencies. Skip fetch when user confirmed none for both.
+
+---
+
+### 3. Research (when repos are named or inferable)
+
+Follow [RESEARCH.md](RESEARCH.md) when the user names repos, packages, or paths — or when implementation notes would benefit from code evidence.
+
+Skip research when the user only wants prose from their notes and no repo paths were given.
+
+Record findings internally per each section guide’s **Research feeds** field.
+
+---
+
+### 3b. Completeness gate (before drafting)
+
+Re-runs [DISCOVERY.md](DISCOVERY.md) § Completeness gate after research.
+
+If any gap remains that blocks **required** registry sections → **discovery-only response** listing each open item. Do **not** draft until the user answers or explicitly defers (see [DISCOVERY.md](DISCOVERY.md) § User deferral).
+
+---
+
+### 4. Draft each section
+
+1. Read [TEMPLATE.md](TEMPLATE.md) § **Section registry** in order.
+2. For each row, open the **Guide** file and read **Section metadata**.
+3. Apply [WRITING.md](WRITING.md) plus that guide’s rules.
+4. Use the guide’s **Heading** value **verbatim**.
+5. **Omit** optional sections when the guide says to omit empty content.
+
+---
+
+### 5. Assemble and quality-check
+
+1. Merge sections into [TEMPLATE.md](TEMPLATE.md) § Section registry order.
+2. Run [WRITING.md](WRITING.md) § Before delivering — writing pass.
+3. Run the checklist in [TEMPLATE.md](TEMPLATE.md) § Quality check.
+4. Deliver only when the epic is **paste-ready** — no `(add …)` placeholders in required sections ([DISCOVERY.md](DISCOVERY.md) § Completeness gate).
+5. Do **not** wrap the full epic in a single outer code fence — use normal markdown so the user can paste into Jira. Section snippets may use fences when helpful.
+
+---
+
+### 6. Jira next step (mandatory after delivery)
+
+After the paste-ready epic body is delivered (§5), **always** ask what the user wants to do with it. Prefer **AskQuestion** when available.
+
+> **What would you like to do with this epic?**
+> 1. **Update an existing epic** in Jira with this description
+> 2. **Create a new epic** in Jira
+> 3. **Do nothing right now** — keep the draft in chat for manual paste later
+
+Wait for the user's choice before Jira writes or other follow-up skills.
+
+| Choice | Action |
+|--------|--------|
+| **Update existing** | Follow [JIRA.md](JIRA.md) § Write — **MCP only** (`editJiraIssue`). If **target epic key** is unknown, **stop and ask** for the key — do not guess from parent/related keys. |
+| **Create new** | Follow [JIRA.md](JIRA.md) § Write — **MCP only** (`createJiraIssue`). Ask for **project key** and **summary** when not already clear from the draft. |
+| **Do nothing** | Acknowledge briefly. Do not write to Jira. Optional follow-ups (jira-epic-breakdown, etc.) only if the user asks in a later turn. |
+
+#### Target epic key (update path)
+
+The **target** is the Jira issue that receives this draft — not the parent or related epics used for context during drafting.
+
+| Known | Unknown → ask |
+|-------|----------------|
+| User named the epic key for this work (e.g. “update FCN-500”, “draft for FCN-500”) | User chose update but never gave which epic |
+| User pasted the key when picking update | |
+
+Do **not** assume the parent epic is the update target unless the user said so.
+
+---
+
+## Output destination
+
+| User request | Destination |
+|--------------|-------------|
+| Epic description / paste into Jira | **Chat** — full epic body **after** discovery gate passes |
+| First turn, hierarchy unknown | **Chat** — discovery-only ([DISCOVERY.md](DISCOVERY.md) § Discovery-only response shape) |
+| Multiple epics in one session | **Chat** per epic, separated by `---`; or one markdown file if user asks |
+
+Default: deliver one complete epic in chat unless the user asked for a file.
+
+---
+
+## Optional follow-ups (only when asked — after §6 resolves)
+
+- Break epic into child items — invoke **jira-epic-breakdown**
+- Score the draft with **jira-acceptance-criteria-check** (story/epic rubric)
+- Jira create/update — handled in §6 when the user chooses that path ([JIRA.md](JIRA.md) § Write)
+
+---
+
+## Anti-patterns
+
+Workflow violations (drafting before discovery, skipping §6, updating without target key, using `acli`) → see §0, §6, and [JIRA.md](JIRA.md).
+
+**Content and scope:**
+
+- **Placeholders in required sections** — `(add link)`, `(add Jira key)`, “confirm with team” in any **Required: yes** registry section
+- **Burying questions at the end** — asking for parent/related, Figma, or other gaps after delivering the epic body
+- **Silent inference** — assuming “standalone”, CRD sets, parity targets, product-specific UI alignment, or links the user never stated
+- **Verbose, repetitive, or extrapolated** prose ([WRITING.md](WRITING.md))
+- Jargon in Description or AC that blocks PM/management readers
+- Inventing product behavior, APIs, or deadlines not supported by user input or repo evidence
+- Writing implementation task lists instead of epic-level acceptance criteria
+- Deep technical design in Implementation notes (keep high level per [SECTIONS/IMPLEMENTATION_NOTES.md](SECTIONS/IMPLEMENTATION_NOTES.md))
+- **UI epic without Figma** — delivering Mockups/Design without a link when UI changes are in scope
+- Skipping a **Required: yes** registry section
+- Using **More information needed** to avoid discovery for facts that block required sections
+- Skipping **why not alternatives** when the user explained platform-specific rationale
+- Claiming repo research was done without reading named paths
+- Duplicating parent epic AC or scope instead of scoping this epic as a distinct slice

--- a/.agents/skills/jira-epic-create/TEMPLATE.md
+++ b/.agents/skills/jira-epic-create/TEMPLATE.md
@@ -1,0 +1,146 @@
+# Epic output template
+
+Assemble sections in **Section registry** order. Use each guide file’s **Heading** value **verbatim** so Jira paste and **jira-epic-breakdown** parsing stay consistent.
+
+---
+
+## Section registry
+
+**Authoritative list of epic sections.** To add or remove a section, edit this table and the matching file in [SECTIONS/](SECTIONS/) — see [SECTIONS/README.md](SECTIONS/README.md). No changes to [SKILL.md](SKILL.md) are required.
+
+| Order | Heading | Guide | Required |
+|-------|---------|-------|----------|
+| 1 | Description | [SECTIONS/DESCRIPTION.md](SECTIONS/DESCRIPTION.md) | yes |
+| 2 | Acceptance criteria | [SECTIONS/ACCEPTANCE_CRITERIA.md](SECTIONS/ACCEPTANCE_CRITERIA.md) | yes |
+| 3 | Mockups/Design | [SECTIONS/MOCKUPS_DESIGN.md](SECTIONS/MOCKUPS_DESIGN.md) | yes for UI changes |
+| 4 | Out of scope | [SECTIONS/OUT_OF_SCOPE.md](SECTIONS/OUT_OF_SCOPE.md) | yes |
+| 5 | Test Plan | [SECTIONS/TEST_PLAN.md](SECTIONS/TEST_PLAN.md) | yes |
+| 6 | Implementation notes | [SECTIONS/IMPLEMENTATION_NOTES.md](SECTIONS/IMPLEMENTATION_NOTES.md) | no |
+| 7 | More information needed | [SECTIONS/MORE_INFORMATION_NEEDED.md](SECTIONS/MORE_INFORMATION_NEEDED.md) | no |
+
+**Required** meanings:
+
+| Value | Completeness gate |
+|-------|-------------------|
+| **yes** | All facts for this section must be resolved before drafting — no placeholders |
+| **yes for UI changes** | Required when the epic changes UI; otherwise N/A or omit |
+| **no** | Omit the section when empty; deferrals go here only per [SECTIONS/MORE_INFORMATION_NEEDED.md](SECTIONS/MORE_INFORMATION_NEEDED.md) |
+
+Each guide’s **Section metadata** defines **Discovery**, **Breakdown trace**, **Owns**, and **Length target**.
+
+---
+
+## Template
+
+Paste-ready skeleton — headings must match the registry:
+
+```markdown
+## Description
+
+[Overall high-level description — what, why, where]
+
+[Problem / today state]
+
+[Proposed solution]
+
+[Platform rationale — when applicable]
+
+### End-to-end flow
+
+1. …
+2. …
+3. …
+
+---
+
+## Acceptance criteria
+
+- [ ] …
+- [ ] …
+- [ ] …
+
+---
+
+## Mockups/Design
+
+[FIGMA DESIGNS MANDATORY!!!(for UI changes at discretion)]
+
+---
+
+## Out of scope
+
+- …
+- …
+
+---
+
+## Test Plan
+
+- …
+- …
+
+---
+
+## Implementation notes
+
+- …
+- …
+
+---
+
+## More information needed
+
+- …
+- …
+```
+
+Use horizontal rule `---` between major sections when pasting into Jira improves readability (optional).
+
+---
+
+## Quality check
+
+### Gate (before any epic delivery)
+
+- [ ] **Discovery gate passed** — parent and related each resolved (keys or explicit “none”) **in this thread**
+- [ ] **Completeness gate passed** — every fact in each **Required: yes** registry section traced to user, Jira, or verified research ([DISCOVERY.md](DISCOVERY.md) § Completeness gate)
+- [ ] If any gate failed, response was **discovery-only** — no registry section headings in that turn
+- [ ] **No placeholders** in required sections — no `(add …)`, no invented URLs or CRD lists
+
+### Content (after gate passes)
+
+Before delivering, verify [WRITING.md](WRITING.md) § Before delivering — writing pass, then:
+
+- [ ] **Concise** — no filler; length within each section’s **Length target**
+- [ ] **No repeat** — each fact in one section only (see each guide’s **Owns** / **Does not own**)
+- [ ] **No extrapolate** — only user input, Jira hierarchy, verified research
+- [ ] **PM-readable** — Description and AC understandable without engineering context
+- [ ] Description answers **what**, **why**, and **why this system** (if applicable)
+- [ ] Parent/related resolved in discovery; fetched content synthesized (not pasted)
+- [ ] Scope does not duplicate parent or related epics without explicit boundaries
+- [ ] **Out of scope** lists exclusions explicitly — not buried in Description
+- [ ] **UI epics** include Figma link in Mockups/Design or were flagged in discovery
+- [ ] Flow is numbered and covers entry → submit → terminal state
+- [ ] AC describes each in-scope piece/item — outcomes, not a second flow
+- [ ] **Test Plan** covers user flows, integration, errors, and auth when applicable
+- [ ] **Implementation notes** stay high level when present
+- [ ] **More information needed** lists only genuine open questions — not a substitute for skipping discovery
+- [ ] No invented behavior, APIs, or dates
+- [ ] Prose is **paste-ready** — user can copy into Jira without filling gaps in required sections
+
+---
+
+## Chat delivery
+
+**Discovery-only turn** (gate not passed):
+
+- No registry section headings in the response
+- Acknowledge + questions only ([DISCOVERY.md](DISCOVERY.md) § Discovery-only response shape)
+
+**Draft turn** (all gates passed):
+
+- Deliver the full template body in chat (not wrapped in an outer code fence)
+- Optional brief intro: "Epic description for [working title]:"
+- Optional **context line** when parent/related epics exist ([JIRA.md](JIRA.md))
+- **No** trailing “placeholders to confirm” footer — unresolved items belong in **More information needed** only when the user explicitly deferred or a question remains after drafting
+- **Then** mandatory §6 Jira next-step ask ([SKILL.md](SKILL.md) §6) — update existing, create new, or do nothing

--- a/.agents/skills/jira-epic-create/TEMPLATE.md
+++ b/.agents/skills/jira-epic-create/TEMPLATE.md
@@ -63,7 +63,7 @@ Paste-ready skeleton — headings must match the registry:
 
 ## Mockups/Design
 
-[FIGMA DESIGNS MANDATORY!!!(for UI changes at discretion)]
+[Figma link or design reference when this epic includes UI changes; omit or N/A when there is no UI work]
 
 ---
 

--- a/.agents/skills/jira-epic-create/WRITING.md
+++ b/.agents/skills/jira-epic-create/WRITING.md
@@ -1,0 +1,54 @@
+# Writing style — all sections
+
+Apply to **every registry section** ([TEMPLATE.md](TEMPLATE.md) § Section registry) unless that section’s guide says otherwise.
+
+**Primary audience:** project owners, project managers, and management — plus engineers who need a clear epic summary. Write so a non-technical reader understands **what**, **why**, and **done means what** without reading code or architecture docs.
+
+**Per-section rules:** each guide in [SECTIONS/](SECTIONS/) defines **Owns**, **Does not own**, and **Length target** in **Section metadata** — use those to avoid duplication across sections.
+
+---
+
+## Core rules
+
+| Rule | Meaning |
+|------|---------|
+| **Concise** | Short sentences. No filler. Cut anything that does not add clarity. |
+| **Do not repeat** | Each fact lives in **one** section. If the flow is in Description, AC states outcomes — not the same steps again. |
+| **Do not expand** | Use only what the user said, parent/related epics, and verified research. No invented scope, risks, or nice-to-haves. |
+| **Do not extrapolate** | No guessing future phases, edge cases, or implementation the user did not mention. Unknowns → ask in discovery ([DISCOVERY.md](DISCOVERY.md) § Completeness gate) or **More information needed** when user explicitly defers. |
+| **Plain language** | Prefer user and product terms over engineering jargon in Description and AC. |
+
+---
+
+## Plain language (Description & AC)
+
+**Use:**
+
+- "Users can create a cluster in the console" not "host implements onSubmit handler"
+- "Required setup is explained before the wizard starts" not "prerequisites gate component"
+- "Cluster creation is submitted and processing begins" not "CRDs are applied to the hub"
+
+**OK to name products and surfaces** the user used (e.g. ACM, ROSA HCP, service account, wizard). **Do not introduce** product or parity targets (e.g. another team's UI) the user did not mention.
+
+**Keep in Implementation notes / Mockups/Design:** npm package names, file paths, CRD kinds, API hosts, Figma URLs, type names — not in Description or AC unless the user explicitly used that term for a business reason.
+
+---
+
+## Before delivering — writing pass
+
+1. Remove sentences that repeat another section (check each guide’s **Owns** / **Does not own**)
+2. Replace jargon in Description and AC with plain language
+3. Delete anything not traceable to user input, Jira parent/related, or verified research
+4. Trim adjectives and hedge words ("comprehensive", "robust", "seamlessly")
+5. Confirm a PM could read Description + AC and explain the epic without engineering help
+6. Confirm each section’s content fits its **Length target**
+
+---
+
+## Do not
+
+- Pad length to look thorough
+- Copy parent epic prose into this epic
+- Restate the flow as acceptance criteria line-by-line
+- Add AC for quality areas the user never implied (e.g. performance) unless they asked
+- Use Implementation notes as a second Description

--- a/.agents/skills/jira-get-estimates/JIRA.md
+++ b/.agents/skills/jira-get-estimates/JIRA.md
@@ -1,0 +1,52 @@
+# Jira fetch and update
+
+Supplement to [SKILL.md](SKILL.md). Target-issue search only — no changelog fetch.
+
+For historical closed-item fetch (changelog, pipeline), use [jira-get-historical-items/SKILL.md](../jira-get-historical-items/SKILL.md).
+
+Shared MCP rules: [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md).
+
+---
+
+## MCP server
+
+`user-atlassian-mcp-server`
+
+Read tool schema JSON in the MCP descriptors folder **before** calling.
+
+| | Value |
+|--|--------|
+| Cloud ID | `redhat.atlassian.net` or value from [CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) |
+| Story points field (FCN) | `customfield_10028` (or `meta.storyPointsField` from the report) |
+
+---
+
+## Fetch target issues
+
+Call `searchJiraIssuesUsingJql` with:
+
+- `cloudId`: `redhat.atlassian.net`
+- `jql`: exact JQL from step 2
+- `maxResults`: 50 (raise if user expects more; paginate with `nextPageToken` when needed)
+- `responseContentFormat`: `markdown`
+- `fields`: `summary`, `description`, `issuetype`, `status`, `customfield_10028` (or `meta.storyPointsField` from the report), `comment`
+
+**0 results:** post the JQL, say no issues matched, **stop**.
+
+For each returned issue, read `key`, `summary`, issue type, full `description`, and **comments** (for duplicate cycle-time detection in step 6). Fetch story points from Jira if present, but **do not use them** when estimating — historical data drives the estimate.
+
+---
+
+## Errors
+
+| Code / situation | Action |
+|------------------|--------|
+| **401** | `mcp_auth` on `user-atlassian-mcp-server`, retry once |
+| **-32601** | Wrong tool name — re-read schema; use `searchJiraIssuesUsingJql` exactly |
+| 0 issues matched | Show JQL + stop |
+
+---
+
+## Jira writes
+
+Story-point and comment updates happen only in **step 6** after the user chooses **Update Jira**. See [UPDATE_JIRA.md](UPDATE_JIRA.md).

--- a/.agents/skills/jira-get-estimates/OUTPUT.md
+++ b/.agents/skills/jira-get-estimates/OUTPUT.md
@@ -1,0 +1,82 @@
+# Estimate output format
+
+Supplement to [SKILL.md](SKILL.md). Post results **in chat** unless the user asks for a markdown file.
+
+---
+
+## Order
+
+Post **in this order**:
+
+### 1. JQL
+
+Fenced block with the exact JQL from step 2.
+
+### 2. Summary line
+
+One short line: issues matched and estimated.
+
+### 3. Per-issue blocks
+
+For **each fetched issue**, use this format (blank line between issues):
+
+```text
+KEY - summary
+
+Issue type: <Story | Bug | Task | Spike | ...>
+Estimated points: <number | n/a | cannot determine>
+Estimated cycletime: <N business days (p75) | n/a | cannot determine>
+```
+
+**By issue type:**
+
+| Type | Estimated points | Estimated cycletime |
+|------|------------------|---------------------|
+| **Story, Task** | Allowed point (1, 2, 3, 5, 8) or `cannot determine` | p75 for that point (or type/all fallback) |
+| **Bug** | `n/a` — never assign story points | p75 from **all bugs** in the historical report, or `cannot determine` when no bug history |
+| **Spike** | `n/a` | `n/a` — no time estimate |
+
+Do not add extra sections unless the user asks.
+
+After posting results, continue to step 6 in [SKILL.md](SKILL.md) — ask whether to update Jira or do nothing ([UPDATE_JIRA.md](UPDATE_JIRA.md)).
+
+---
+
+## Examples
+
+**Story or task:**
+
+```text
+FCN-600 - Add validation to subnet step
+
+Issue type: Story
+Estimated points: 3
+Estimated cycletime: 6 business days (p75)
+```
+
+**Bug:**
+
+```text
+FCN-601 - Submit button disabled after YAML edit
+
+Issue type: Bug
+Estimated points: n/a
+Estimated cycletime: 4.2 business days (p75, all bugs)
+```
+
+**Spike:**
+
+```text
+FCN-602 - [SPIKE] Compare subnet validation APIs
+
+Issue type: Spike
+Estimated points: n/a
+Estimated cycletime: n/a
+```
+
+When a story/task cannot be sized:
+
+```text
+Estimated points: cannot determine
+Estimated cycletime: cannot determine
+```

--- a/.agents/skills/jira-get-estimates/README.md
+++ b/.agents/skills/jira-get-estimates/README.md
@@ -1,0 +1,163 @@
+# jira-get-estimates
+
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that recommends **story points** and **p75 cycle time** for Jira issues from `.jira-historical-report.json` — stories and tasks get both; bugs get time only; spikes get neither. After reporting, asks whether to update Jira or do nothing.
+
+Use when you want data-backed sizing for a backlog slice — unpointed stories, epic children, or a sprint candidate list.
+
+---
+
+## Prerequisites
+
+This skill **does not fetch historical data on its own**. It reads an existing `.jira-historical-report.json` produced by [jira-get-historical-items](../jira-get-historical-items/SKILL.md).
+
+| Requirement | Details |
+|-------------|---------|
+| **Historical report** | `.jira-historical-report.json` — lookup order: active workspace, then `~/.cursor/skills/` (see [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md)); or a path you provide |
+| **Target scope** | JQL, issue keys, or natural language (“unpointed FCN stories under FCN-41”) |
+| **Atlassian MCP** | Required to **fetch** target issues and **optionally update** Jira — see [JIRA.md](JIRA.md) |
+| **No report yet?** | The agent stops and offers to generate one via jira-get-historical-items (with your consent) |
+
+**Tip:** A narrow, recent historical window (one project, last 3–6 months, resolution Done) makes both point buckets and p75 cycle times more trustworthy. See [jira-get-historical-items/README.md](../jira-get-historical-items/README.md).
+
+---
+
+## What it does
+
+**Report → JQL → fetch targets → size each issue → print in chat → optionally update Jira.**
+
+1. **Resolve report** — load `.jira-historical-report.json` ([SKILL.md](SKILL.md) step 1).
+2. **Build JQL** — translate your scope into exact JQL; post it before fetching ([SKILL.md](SKILL.md) step 2).
+3. **Fetch targets** — MCP search for summary, description, type, comments ([JIRA.md](JIRA.md)).
+4. **Estimate** — build effort profiles from historical `items`; match each issue to the closest point bucket; look up p75 cycle time ([SIZING.md](SIZING.md)).
+5. **Report** — per-issue story points + cycle time in chat ([OUTPUT.md](OUTPUT.md)).
+6. **Optional Jira update** — set story points and post cycle-time comments when you agree ([UPDATE_JIRA.md](UPDATE_JIRA.md)).
+
+### How historical data drives both numbers
+
+**Story points (stories and tasks)**
+
+- Reads all `items` in the report — pointed and unpointed — to characterize typical effort at each allowed point value.
+- Compares each target issue’s scope, complexity, and touch surface to those profiles.
+- Picks the closest value on the team scale: **1, 2, 3, 5, 8** only.
+- **Ignores** story points already on the Jira issue — the estimate is fresh from history + issue content.
+
+**Estimated work time (cycle time)**
+
+- Uses `cycleTime.percentiles` from the same report — **p75 business days** (Mon–Fri).
+- **Stories/tasks:** p75 for the chosen point bucket (falls back through issue type → all items when needed).
+- **Bugs:** p75 across **all historical bugs** — no story points; time only.
+- **Spikes:** no story points and no time estimate.
+
+Together, you get a **point recommendation** and a **“how long similar work took”** number grounded in the same historical baseline.
+
+---
+
+## Output (chat)
+
+After each run, chat includes the exact JQL and a block per issue ([OUTPUT.md](OUTPUT.md)):
+
+```text
+FCN-600 - Add validation to subnet step
+
+Issue type: Story
+Estimated points: 3
+Estimated cycletime: 6 business days (p75)
+```
+
+| Issue type | Estimated points | Estimated cycletime |
+|------------|------------------|---------------------|
+| Story, Task | 1, 2, 3, 5, 8 or `cannot determine` | p75 for matched bucket or `cannot determine` |
+| Bug | `n/a` | p75 from bug history or `cannot determine` |
+| Spike | `n/a` | `n/a` |
+
+The agent then asks whether to **update Jira** (story points + cycle-time comments via MCP) or **do nothing**.
+
+---
+
+## How to use it
+
+### Install the skill
+
+| Location | Scope |
+|----------|-------|
+| `~/.cursor/skills/jira-get-estimates/` | Personal — all projects |
+| `.cursor/skills/jira-get-estimates/` | Project — shared with the repo |
+
+### Trigger in Cursor
+
+Ask the agent — for example:
+
+- “Estimate story points and cycle time for unpointed FCN stories under parent FCN-41”
+- “Size these keys from historical data: FCN-600, FCN-601, FCN-602”
+- “Run jira-get-estimates on `project = FCN AND \"Story Points[Number]\" IS EMPTY AND type in (Story, Task)`”
+- “Give me point and p75 time estimates for the open backlog in FCN phase 2 epics”
+
+**Not this skill:** building the historical baseline → use [jira-get-historical-items](../jira-get-historical-items/SKILL.md) first; summarizing closed work stats → [jira-get-stats](../jira-get-stats/SKILL.md).
+
+The skill is **user-invocable** (`SKILL.md` frontmatter).
+
+### What to have ready
+
+| Input | When |
+|-------|------|
+| **Historical report** path or prior jira-get-historical-items run | Always — agent stops if missing |
+| **What to estimate** — keys, JQL, or natural language | Always — agent asks if unclear |
+| **Atlassian MCP** authenticated | Fetch + optional Jira writes |
+
+### After delivery
+
+1. Review per-issue **Estimated points** and **Estimated cycletime** in chat.
+2. Choose **Update Jira** to apply story points and post standardized cycle-time comments, or **do nothing** to keep estimates in chat only.
+3. To refresh the baseline, re-run jira-get-historical-items with a recent window, then estimate again.
+
+---
+
+## Directory layout
+
+```
+jira-get-estimates/
+├── README.md       # This file
+├── SKILL.md        # Orchestrator — workflow, gates, report resolution
+├── SIZING.md       # Effort profiles, point scale, p75 lookup rules
+├── JIRA.md         # MCP fetch for target issues
+├── OUTPUT.md       # Chat output format
+└── UPDATE_JIRA.md  # Optional story points + cycle-time comments (MCP)
+
+# Shared with jira-get-stats:
+jira-get-historical-items/RESOLVE_REPORT.md   # Step 1 — find report file
+jira-acceptance-criteria-check/CONVENTIONS.md                      # Paths, MCP, glossary
+```
+
+---
+
+## Related skills
+
+| Skill | Relationship |
+|-------|------------|
+| [jira-get-historical-items](../jira-get-historical-items/SKILL.md) | **Upstream** — produces `.jira-historical-report.json` and p75 percentiles this skill consumes |
+| [jira-get-stats](../jira-get-stats/SKILL.md) | **Sibling** — readable stats summary from the same report |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, skill index |
+| [jira-epic-breakdown](../jira-epic-breakdown/SKILL.md) | Optional follow-on — break down epics; run estimates on child items |
+| [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) | Separate — ticket quality review; does not size from history |
+
+---
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|----------------|
+| No `.jira-historical-report.json` found | Generate via [jira-get-historical-items](../jira-get-historical-items/SKILL.md) or paste a report path |
+| Agent asks what to estimate | Provide keys, JQL, or a filter before fetch |
+| `cannot determine` on a story/task | Empty or vague description — add scope in Jira and re-run |
+| Bug cycle time `cannot determine` | Historical report has no closed bugs with cycle time — widen bug history in the report JQL |
+| Spike shows `n/a` for both fields | Expected — spikes get no points or time estimate |
+| Estimates feel off | Tighten historical report scope (project, 3–6 months, Done) and re-run upstream skill |
+| MCP auth failed | Settings → MCP → Atlassian; `mcp_auth`; see [JIRA.md](JIRA.md) |
+| Jira not updated | Agent waits for explicit **Update Jira** choice — see [UPDATE_JIRA.md](UPDATE_JIRA.md) |
+| Duplicate cycle-time comments skipped | Prior comment starting with “Estimated cycle time” — edit in Jira or delete before re-posting |
+
+Site default: **redhat.atlassian.net**. Story points field default (FCN): `customfield_10028` (or `meta.storyPointsField` from the report).
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-get-estimates/SIZING.md
+++ b/.agents/skills/jira-get-estimates/SIZING.md
@@ -1,0 +1,144 @@
+# Story point sizing
+
+Supplement to [SKILL.md](SKILL.md). Read after resolving the historical report and fetching target issues.
+
+**Allowed story points:** `1`, `2`, `3`, `5`, `8` only — never 4, 6, 7, or other values.
+
+Report schema and `items` / `cycleTime` fields: [jira-get-historical-items/REPORT.md](../jira-get-historical-items/REPORT.md).
+
+---
+
+## Build effort profiles (once per run)
+
+Before estimating individual issues, read all `items` in the report and characterize **typical effort** for each story-point value on the allowed scale.
+
+**Pointed items** (positive `storyPoints` on the allowed scale) are the primary source for each bucket. For each point value that appears in history, note:
+
+- Typical scope and complexity from summaries and descriptions
+- Touch surface (single file vs backend + frontend vs cross-cutting)
+- Issue types commonly seen at that size
+- Actual `cycleTime` on sample items when available
+
+**Unpointed items** still inform effort calibration — use them to understand what small/medium work looks like for bugs and stories in this team, even though they do not define a point bucket on their own.
+
+### Incomplete historical data
+
+Historical reports are often sparse — some point values may have **no** (or very few) examples. That is expected. Do **not** skip those values on the scale.
+
+1. Build profiles for every point value that **does** appear in history.
+2. For **missing** buckets, infer effort boundaries from neighboring values that do have data, plus the team point scale below.
+3. Treat the scale as **ordered effort levels**: 1 < 2 < 3 < 5 < 8.
+
+### Team point scale
+
+Use to anchor missing buckets and bound effort:
+
+| Points | Typical effort |
+|-------:|----------------|
+| **1** | Tiny docs, typing, CI-doc, trivial fix |
+| **2** | Focused helper, single field, narrow refactor, port existing behavior |
+| **3** | Single step/substep, one API proxy + hook, wrapper extension, moderate research spike |
+| **5** | Multi-endpoint or multi-step feature, full page/flow, large spike, props contract refactor, comprehensive UX |
+| **8** | Epic-scale slice, major cross-cutting refactor, multi-flow feature with heavy unknowns |
+
+**Example — sparse data for 2:** History has strong examples at **1** and **3** but nothing at **2**. A new item whose effort is clearly **more than a 1** but **less than a 3** should be estimated as **2**, even with no historical 2-point tickets.
+
+Apply the same logic between other neighbors (e.g. effort above 3 but below 5 → weigh **3** vs **5**; above 5 but below 8 → weigh **5** vs **8**).
+
+---
+
+## Estimate each fetched issue
+
+Branch on **issue type** first. **Never assign story points to bugs or spikes.**
+
+### Spikes — no estimate
+
+If the issue is a **spike** (Jira type Spike or content is timeboxed research only):
+
+- Do **not** assign story points.
+- Do **not** assign estimated cycle time.
+- Output **Estimated points:** `n/a` and **Estimated cycletime:** `n/a` (see [OUTPUT.md](OUTPUT.md)).
+
+Skip effort profiling and point matching for spikes.
+
+### Bugs — cycle time only
+
+If the issue is a **bug**:
+
+- Do **not** assign story points — output **Estimated points:** `n/a`.
+- Do **not** match effort to the story-point scale.
+- Assign **estimated cycle time** from historical **bugs only** (see [Assign estimated cycle time](#assign-estimated-cycle-time) below).
+- When the report has no closed bugs with measurable cycle time, **Estimated cycletime:** `cannot determine`.
+
+### Stories and tasks — story points + cycle time
+
+#### Ignore existing story points
+
+If the issue **already has story points** in Jira, **ignore that value**. Still estimate from effort profiling. Do not skip the issue and do not treat the Jira value as the answer.
+
+#### Assess effort on the target issue
+
+Read **summary + full description** (including acceptance criteria when present). Judge:
+
+- Scope breadth (one endpoint vs many, one UI area vs full page)
+- Complexity (data transforms, auth flow, parallel queries, dependencies)
+- Ambiguity (spike/research vs well-defined implementation)
+
+Use summary + issue type only when description is missing but summary is specific enough to judge effort.
+
+#### Match to closest point on the scale
+
+Compare the target issue's assessed effort to the profiles above and the ordered scale **1 < 2 < 3 < 5 < 8**.
+
+1. Decide where the issue's effort sits relative to calibrated anchors (from history and the team scale).
+2. Pick the **single allowed value** that best fits that effort level.
+3. When effort falls **between two neighbors** and the middle value lacks historical examples, still assign the middle value when effort belongs there (e.g. above 1, below 3 → **2**).
+4. When effort is closer to one neighbor than another, pick that neighbor (e.g. clearly a large 3, not quite a 5 → **3**).
+
+- Imperfect history is expected — choose the best-fit value and proceed.
+- Report **cannot determine** only when description is empty/missing **and** summary is too vague to judge scope (e.g. title-only with no context).
+
+Then assign cycle time from the chosen point value (below).
+
+---
+
+## Assign estimated cycle time
+
+### Bugs
+
+Look up `cycleTime.percentiles` for **all historical bugs** (see [REPORT.md](../jira-get-historical-items/REPORT.md)):
+
+1. Prefer `group: "issueType"` where `issueType` is `bug` (case-insensitive)
+2. If no bug group exists, **Estimated cycletime:** `cannot determine`
+
+Use `p75Days` from the match. Format as `{p75Days} business days (p75, all bugs)`.
+
+Do **not** fall back to story-point groups or `group: "all"` for bugs — the estimate must reflect bug history only.
+
+### Stories and tasks
+
+Look up `cycleTime.percentiles` for the **chosen story points**:
+
+1. Prefer `group: "issueTypeAndStoryPoints"` matching issue type + points
+2. Else `group: "storyPoints"` for that point value
+3. Else `group: "issueType"` for the issue type
+4. Else `group: "all"`
+
+Use `p75Days` from the best match. Format as `{p75Days} business days (p75)`.
+
+When points are **cannot determine**, estimated cycle time is **cannot determine**.
+
+When `cycleTime` is `null` in the report, estimated cycle time is **cannot determine** for stories and tasks (and for bugs when no bug percentile exists).
+
+---
+
+## Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| Historical report missing some point values | Use ordered scale + neighbors; assign gap values (e.g. **2**) when effort falls between known buckets |
+| Empty description, vague summary | Report **cannot determine** for that story/task only |
+| Bug in scope | Points **n/a**; cycle time from `issueType: bug` percentile only |
+| Spike in scope | Points and cycle time both **n/a** |
+| No bug history in report | Bug cycle time **cannot determine** |
+| Sparse history | Still estimate stories/tasks — imperfect match is expected |

--- a/.agents/skills/jira-get-estimates/SKILL.md
+++ b/.agents/skills/jira-get-estimates/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: jira-get-estimates
+description: >-
+  Recommend Jira story point estimates using historical closed-item data from
+  .jira-historical-report.json. Resolves the report from user path, active
+  workspace, or ~/.cursor/skills fallback; fetches target issues via JQL, builds effort profiles from
+  historical story-point groups, and maps each issue to the closest point bucket.
+  Stories and tasks only for points; bugs get p75 cycle time from bug history (no
+  points); spikes get no points or time estimate. After reporting, asks whether to
+  update Jira (story points + cycle-time comments) or do nothing. Use when the user
+  asks for Jira estimates, story point sizing, or estimate recommendations from
+  historical cycle time data.
+user-invocable: true
+---
+
+# Get Jira estimates
+
+Recommend story point estimates by calibrating effort levels from historical items in `.jira-historical-report.json`, then matching each target issue to the closest story-point bucket.
+
+**Reference files** (read when you reach that step):
+
+| File | Contents |
+|------|----------|
+| [SIZING.md](SIZING.md) | Effort profiles, team scale, per-issue estimation, cycle time lookup |
+| [JIRA.md](JIRA.md) | Fetch target issues via MCP |
+| [OUTPUT.md](OUTPUT.md) | Chat output format |
+| [UPDATE_JIRA.md](UPDATE_JIRA.md) | Optional Jira write after report (story points + cycle-time comments) |
+| [jira-get-historical-items/RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) | Step 1 — resolve `.jira-historical-report.json` |
+| [jira-get-historical-items/REPORT.md](../jira-get-historical-items/REPORT.md) | Report JSON schema (`items`, `cycleTime.percentiles`) |
+| [jira-get-historical-items/SKILL.md](../jira-get-historical-items/SKILL.md) | Generate `.jira-historical-report.json` (user consent only) |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, glossary |
+
+---
+
+## Hard rules
+
+| Do | Do not |
+|----|--------|
+| Resolve `.jira-historical-report.json` first → [RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) | Guess a report path or continue with empty historical data |
+| **Stop** when no report file is found | Silently invoke `jira-get-historical-items` without user consent |
+| Post estimate results **in chat** by default → [OUTPUT.md](OUTPUT.md) | Write a markdown file unless the user asks for one |
+| Write optional markdown to `{report-dir}/.jira-estimates-report.md` when asked — **absolute path** | Save estimates to skill dir, cwd, or a path the user did not request |
+| **Post absolute paths** under `## Saved files` when a markdown file was written | Omit where the file was saved |
+| **Hand off** to `jira-get-historical-items` with its §0 discovery gate | Assume report scope or CLI/MCP from the estimating conversation |
+| Build exact JQL before fetching | Run a vague or invented query |
+| Post the exact JQL used before results | Hide the query from the user |
+| **Build effort profiles** per story-point group from historical data | Require an exact ticket-to-ticket description match |
+| Assess target issue **effort** (scope, complexity, touch surface) | Size from summary alone when a description exists |
+| Match effort to the **closest valid point** (1, 2, 3, 5, or 8) for **stories and tasks only** | Use values outside the allowed scale or skip gaps when effort falls between neighbors |
+| Use **all** historical `items` to calibrate effort (pointed and unpointed) | Ignore unpointed rows entirely |
+| **Ignore** existing Jira story points when estimating stories/tasks | Use the current Jira point value as the estimate |
+| **Spikes:** no story points and no time estimate | Assign points or cycle time to spikes |
+| **Bugs:** no story points; report **p75 cycle time** from historical bugs only | Assign story points to bugs or size bugs against the point scale |
+| Report **cannot determine** only when scope is truly unknown (stories/tasks) or no bug history exists (bugs) | Refuse to estimate because history is sparse or the match is imperfect |
+| Read MCP tool schemas before Jira calls | Call Jira tools without checking schema |
+| **Ask** after the report whether to update Jira or do nothing | Update Jira without clear user agreement |
+| **MCP only** for Jira writes in step 6 | Use `acli` or REST for story points or comments |
+
+---
+
+## Constants
+
+| | Value |
+|--|--------|
+| **`{workspace}`**, **`{report-dir}`**, report lookup | [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) |
+| Report filename | `.jira-historical-report.json` |
+| Default output | **Chat only** — no file written |
+| Optional markdown artifact | `{report-dir}/.jira-estimates-report.md` — only when the user asks for a markdown file |
+| Jira site | `redhat.atlassian.net` |
+| **Allowed story points** | `1`, `2`, `3`, `5`, `8` only |
+
+---
+
+## Workflow
+
+```
+Progress:
+- [ ] Step 1 — Resolve historical report file → [RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md)
+- [ ] Step 2 — Resolve scope and build JQL
+- [ ] Step 3 — Fetch target issues → [JIRA.md](JIRA.md)
+- [ ] Step 4 — Estimate each issue → [SIZING.md](SIZING.md)
+- [ ] Step 5 — Report results → [OUTPUT.md](OUTPUT.md)
+- [ ] Step 6 — Offer to update Jira → [UPDATE_JIRA.md](UPDATE_JIRA.md)
+```
+
+---
+
+## Step 1 — Resolve historical report file
+
+Follow [jira-get-historical-items/RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) (steps 1a–1d).
+
+---
+
+## Step 2 — Resolve scope and build JQL
+
+The user must supply **what to estimate** — either natural language or JQL. If they invoked the skill with no scope, **stop and ask** what issues to review (paste keys, describe a filter, or provide JQL).
+
+### 2a. User provided JQL
+
+Use the JQL **as-is** unless it is obviously invalid. Normalize only when needed (e.g. `createdDate` → `created`).
+
+### 2b. User provided natural language
+
+Translate intent into **exact JQL**. Common patterns:
+
+| User intent | JQL pattern |
+|-------------|-------------|
+| Specific keys | `key in (FCN-123, FCN-456)` |
+| Unpointed items in a project | `project = FCN AND "Story Points[Number]" IS EMPTY AND type in (Story, Task)` |
+| Items under parent epics | add `AND parent in (FCN-41, FCN-100, ...)` |
+| Open backlog | add `AND status not in (Closed, Done)` |
+| Closed items for review | add `AND status in (Closed, Done)` |
+
+Combine filters the user mentions. When project or type is missing, infer from issue keys or ask — do not invent a project.
+
+### 2c. Confirm JQL
+
+Before fetching, post the exact JQL in a fenced block:
+
+```text
+<exact JQL>
+```
+
+---
+
+## Step 3 — Fetch target issues
+
+Follow [JIRA.md](JIRA.md).
+
+---
+
+## Step 4 — Estimate each issue
+
+Sizing logic: [SIZING.md](SIZING.md). Orchestration constraints: Hard rules above.
+
+---
+
+## Step 5 — Report results
+
+Follow [OUTPUT.md](OUTPUT.md). Default: post in chat only.
+
+When the user asked for a **markdown file**, write the same content to `{report-dir}/.jira-estimates-report.md` using an **absolute path**, then post `## Saved files` with a clickable link to that file (and the historical report path used). Do not re-paste the file body under `## Saved files`.
+
+---
+
+## Step 6 — Offer to update Jira (optional)
+
+After step 5 is complete, ask what the user wants to do with the estimates.
+
+> **What would you like to do with these estimates?**
+> 1. **Update Jira** — set story points and post cycle-time comments for all applicable items (MCP)
+> 2. **Do nothing** — keep the estimates in chat only
+
+Wait for the user's choice before any Jira writes.
+
+| Choice | Action |
+|--------|--------|
+| **Update Jira** | Follow [UPDATE_JIRA.md](UPDATE_JIRA.md) for every fetched issue |
+| **Do nothing** | Acknowledge briefly. Do not call Jira write tools. |
+
+Treat clear agreement (**yes**, **y**, **update**, **post**, option **1**) as **Update Jira**. **No** or option **2** → **do nothing**. **Implicit default: do nothing** (including silence).
+
+If the user restricts keys in their reply (“only FCN-100”), honor that subset.
+
+---
+
+## Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| No report file | [RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) step 1c — stop; workspace then `~/.cursor/skills/` |
+| Report in workspace but agent checked skills dir only | RESOLVE_REPORT step 1b — workspace first |
+| User asked for markdown file | Step 5 — write `{report-dir}/.jira-estimates-report.md`; post `## Saved files` |
+| Generate report handoff | Follow jira-get-historical-items §0 — ask scope + CLI/MCP; don't infer FCN or date range |
+| User gave no scope (estimates) | Ask for keys, JQL, or a natural-language filter before fetching |
+| Historical report missing some point values | [SIZING.md](SIZING.md) — ordered scale + neighbors |
+| MCP 401 | [JIRA.md](JIRA.md) — `mcp_auth`, retry once |
+| Empty description, vague summary | **cannot determine** for that story/task only — [SIZING.md](SIZING.md) |
+| Bug or spike in scope | No story points — bugs use bug p75 only; spikes get `n/a` for both |
+| No bugs in historical report | Bug cycle time **cannot determine** — do not fall back to all-items p75 |
+| **Skipping step 6** | Delivering estimates without asking update vs do nothing |
+| **Updating without consent** | Calling `editJiraIssue` or `addCommentToJiraIssue` before the user chooses **Update Jira** |
+| **acli for writes** | Step 6 uses MCP only — [UPDATE_JIRA.md](UPDATE_JIRA.md) |

--- a/.agents/skills/jira-get-estimates/UPDATE_JIRA.md
+++ b/.agents/skills/jira-get-estimates/UPDATE_JIRA.md
@@ -1,0 +1,124 @@
+# Update Jira with estimates (optional)
+
+After [OUTPUT.md](OUTPUT.md) delivers the estimate report and [SKILL.md](SKILL.md) step 6 asks the user, apply estimates to Jira via **MCP only**.
+
+---
+
+## When to run
+
+Run **only when** the user clearly chooses **Update Jira** in step 6.
+
+| Do | Do not |
+|----|--------|
+| Wait for step 5 report to finish first | Call write tools before the user agrees |
+| Update every fetched issue that has applicable values | Re-fetch issues just to double-check estimates |
+| Honor a user-named key subset | Update keys the user excluded |
+
+---
+
+## Per-issue rules
+
+Use the estimates from **this run's** step 5 output — not existing Jira values.
+
+| Field | Apply when | Skip when |
+|-------|------------|-----------|
+| **Story points** (`editJiraIssue`) | Issue type is **Story** or **Task** **and** `Estimated points` is a definite number (`1`, `2`, `3`, `5`, `8`) | `n/a`, `cannot determine`, **Bug**, **Spike** |
+| **Cycle-time comment** (`addCommentToJiraIssue`) | `Estimated cycletime` is a definite value (e.g. `6 business days (p75)`) | `n/a`, `cannot determine` |
+
+An issue may get **story points only**, **comment only**, **both**, or **neither** — depending on which values exist for that issue.
+
+**Never** set story points on **bugs** or **spikes**, even if Jira already has points.
+
+---
+
+## MCP transport
+
+**MCP only** — do **not** use `acli` or direct REST for this step.
+
+1. Read MCP tool schemas under `user-atlassian-mcp-server` before calling.
+2. If only **`mcp_auth`** is listed → call `mcp_auth` for `user-atlassian-mcp-server` with `{}`, then re-check tools.
+3. Use `cloudId`: `redhat.atlassian.net` (or `2b9e35e3-6bd3-4cec-b838-f4249ee02432`).
+4. Story points field: `meta.storyPointsField` from the historical report when present; otherwise `customfield_10028`.
+
+### Set story points
+
+For each issue that qualifies, call **`editJiraIssue`**:
+
+- `issueIdOrKey`: the Jira key
+- `fields`: `{ "<storyPointsField>": <number> }` — use the numeric estimate from this run
+
+### Post cycle-time comment
+
+For each issue that qualifies, call **`addCommentToJiraIssue`**:
+
+- `issueIdOrKey`: the Jira key
+- `commentBody`: built per [Comment body](#comment-body) below
+- `contentFormat`: `"markdown"`
+
+Run story-point updates and comments in any sensible order per issue (e.g. points first, then comment).
+
+**On MCP failure** (auth, server missing, API error): report the **full error** for that key; do **not** fall back to acli. Tell the user to fix MCP in **Settings → MCP** (Atlassian server enabled; complete `mcp_auth` if prompted) and re-run the update step if they want.
+
+After **each** successful write, confirm in chat: key + what was updated (`story points set to N`, `cycle-time comment posted`, or both). On failure, show the error and continue or stop per user preference.
+
+---
+
+## Skip duplicate cycle-time comments
+
+Before posting a cycle-time comment, check whether this run's fetch already found an existing Jira comment that **starts with**:
+
+```text
+Estimated cycle time
+```
+
+**Source:** comment data from the step 3 fetch in this run — **do not** re-fetch just to double-check.
+
+If a prior estimated cycle-time comment exists for a key → **skip** the comment for that key (still set story points when applicable). Tell the user Jira already has an estimated cycle-time comment; they can edit or delete it in Jira if they want a new one.
+
+---
+
+## Comment body
+
+Build one `commentBody` per key from this run's `Estimated cycletime` line.
+
+**Format:**
+
+```text
+Estimated cycle time
+
+<exact cycletime text from step 5 output, without the "Estimated cycletime:" label>
+
+Created with AI
+```
+
+**Example** (story/task):
+
+```text
+Estimated cycle time
+
+6 business days (p75)
+
+Created with AI
+```
+
+**Example** (bug):
+
+```text
+Estimated cycle time
+
+4.2 business days (p75, all bugs)
+
+Created with AI
+```
+
+Use the same cycle-time wording the user saw in the step 5 report — do not rephrase or round.
+
+---
+
+## Summary after all writes
+
+Post a short closing summary:
+
+- Keys updated (story points, comments, or both)
+- Keys skipped (no applicable values, duplicate comment, or user subset)
+- Any failures

--- a/.agents/skills/jira-get-historical-items/CLI.md
+++ b/.agents/skills/jira-get-historical-items/CLI.md
@@ -80,7 +80,7 @@ export JIRA_API_TOKEN='your-api-token'
 Use **absolute** `--output`. Replace `{workspace}` with the Cursor workspace root (or wherever artifacts should live).
 
 ```bash
-node scripts/fetch-historical-items.mjs \
+node .agents/skills/jira-get-historical-items/scripts/fetch-historical-items.mjs \
   --jql 'parent = FCN-41 AND created >= -20d' \
   --output /absolute/path/to/workspace/.jira-historical-issues.json \
   --env-file ~/.config/jira-fetch.env
@@ -144,7 +144,7 @@ Tell the agent fetch is done (e.g. "continue") so it can post JQL + report + **S
 To re-run the report from an existing fetch file:
 
 ```bash
-node scripts/run-historical-report.mjs \
+node .agents/skills/jira-get-historical-items/scripts/run-historical-report.mjs \
   --input /absolute/path/to/workspace/.jira-historical-issues.json \
   --workspace /absolute/path/to/workspace \
   --jql 'parent = FCN-41 AND created >= -20d'

--- a/.agents/skills/jira-get-historical-items/CLI.md
+++ b/.agents/skills/jira-get-historical-items/CLI.md
@@ -1,0 +1,166 @@
+# Jira fetch (CLI)
+
+Supplement to [SKILL.md](SKILL.md). Fast path: `fetch-historical-items.mjs` (Jira REST).
+
+**Do not use this file when the user chose MCP** — see [JIRA.md](JIRA.md) instead.
+
+---
+
+## When to use
+
+- User chose **CLI** at step 2 (or said command / terminal / faster)
+- User wants the fastest fetch (parallel REST, no MCP round-trips)
+- User explicitly **switches** to CLI after MCP failed (new run)
+- User will say "continue" or "JSON is ready" after the script finishes **only when using `--skip-report`**
+
+If the user did **not** pick a route, the agent must **ask first** — see [SKILL.md](SKILL.md) §0 and step 2. Do not jump to this path by default.
+
+Do **not** use CLI because MCP was slow, Write was awkward, or env vars happen to exist — those are not reasons to break route lock.
+
+The agent **stops after giving the command** unless asked to run it or the output file already exists. By default the fetch script also writes `.jira-historical-report.json` in the same workspace — the agent can read that file after the user confirms fetch is done.
+
+---
+
+## Prerequisites
+
+1. **Node.js 18 or newer** — required to run the fetch and report scripts (`node --version`). Uses ES modules (`.mjs`) and native `fetch`; Node 16 and below will not work.
+2. [Atlassian API token](https://id.atlassian.com/manage-profile/security/api-tokens) for your account
+3. Credentials in `~/.config/jira-fetch.env` (recommended) or exported env vars (see below)
+
+The agent should mention the Node requirement when giving the CLI command for the first time in a thread.
+
+### First-time setup — create an env file
+
+Keep credentials in a local file outside any git repo. The agent should walk the user through this once when they pick **CLI** and do not already have credentials set up.
+
+1. Create the file (example path):
+
+```bash
+mkdir -p ~/.config
+touch ~/.config/jira-fetch.env
+chmod 600 ~/.config/jira-fetch.env
+```
+
+2. Add your Jira site, email, and API token:
+
+```bash
+# ~/.config/jira-fetch.env
+JIRA_SITE=redhat.atlassian.net
+JIRA_EMAIL=you@redhat.com
+JIRA_API_TOKEN=your-api-token
+```
+
+3. Pass it on every fetch command:
+
+```bash
+--env-file ~/.config/jira-fetch.env
+```
+
+**Do not commit this file.** Add `jira-fetch.env` to your global or project gitignore if needed.
+
+**Environment variables** (alternative to `--env-file`; any of these pairs work):
+
+| Variable | Alternate |
+|----------|-----------|
+| `JIRA_EMAIL` | `ATLASSIAN_EMAIL` |
+| `JIRA_API_TOKEN` | `ATLASSIAN_API_TOKEN`, `JIRA_TOKEN` |
+| `JIRA_SITE` (optional) | `ATLASSIAN_SITE` — default `redhat.atlassian.net` |
+
+Export before running, or inline on the command:
+
+```bash
+export JIRA_EMAIL='you@redhat.com'
+export JIRA_API_TOKEN='your-api-token'
+```
+
+---
+
+## Command
+
+Use **absolute** `--output`. Replace `{workspace}` with the Cursor workspace root (or wherever artifacts should live).
+
+```bash
+node scripts/fetch-historical-items.mjs \
+  --jql 'parent = FCN-41 AND created >= -20d' \
+  --output /absolute/path/to/workspace/.jira-historical-issues.json \
+  --env-file ~/.config/jira-fetch.env
+```
+
+With env vars instead of `--env-file`, omit that flag after `export JIRA_EMAIL` / `JIRA_API_TOKEN`.
+
+### Options
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `--jql` | *(required)* | JQL query |
+| `--output`, `-o` | *(required)* | Output JSON path |
+| `--env-file` | — | `.env` file with `JIRA_EMAIL`, `JIRA_API_TOKEN`, optional `JIRA_SITE` |
+| `--site` | `redhat.atlassian.net` | Jira hostname |
+| `--story-points-field` | `customfield_10028` | FCN story points field |
+| `--concurrency` | `10` | Parallel issue fetches |
+| `--max-results` | `100` | Cap on issues returned — wider date windows may need a narrower JQL instead of raising this |
+| `--workspace`, `-w` | output file directory | Where `.jira-historical-report.json` is written |
+| `--skip-report` | off | Fetch only; skip report pipeline |
+
+### 0 results
+
+Writes `[]` to the output file and an empty report JSON. The agent should post JQL + "No issues matched" and skip re-running the pipeline.
+
+---
+
+## Output format
+
+Same as MCP `getJiraIssue` with `expand=changelog`:
+
+```json
+[
+  {
+    "key": "FCN-533",
+    "fields": {
+      "summary": "…",
+      "description": "…",
+      "status": { "name": "Closed" },
+      "resolution": { "name": "Done" },
+      "issuetype": { "name": "Story" },
+      "customfield_10028": 3
+    },
+    "changelog": {
+      "histories": [ … ]
+    }
+  }
+]
+```
+
+Array of issues. Each must have non-empty `changelog.histories` (the script paginates changelog when Jira truncates).
+
+---
+
+## After fetch
+
+By default the script also runs the report pipeline and writes `{workspace}/.jira-historical-report.json` next to the fetch file (same artifact as the MCP path after step 4).
+
+Tell the agent fetch is done (e.g. "continue") so it can post JQL + report + **Saved files** links in chat. Use `--skip-report` only if you want fetch JSON without the report.
+
+To re-run the report from an existing fetch file:
+
+```bash
+node scripts/run-historical-report.mjs \
+  --input /absolute/path/to/workspace/.jira-historical-issues.json \
+  --workspace /absolute/path/to/workspace \
+  --jql 'parent = FCN-41 AND created >= -20d'
+```
+
+---
+
+## Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| Missing Jira API credentials | Create `~/.config/jira-fetch.env` or export `JIRA_EMAIL` / `JIRA_API_TOKEN`; see **First-time setup** above |
+| `fetch is not defined` / syntax errors on `.mjs` | Upgrade to **Node.js 18+** — check with `node --version` |
+| HTTP 401 | Bad email/token; regenerate API token |
+| HTTP 400 on JQL | Fix JQL syntax; use `created >= -20d` not `createdDate` |
+| `field 'customfield_10028' is not allowed` on search | Should not happen — script requests fields on issue fetch, not search-only |
+| Permission denied writing output | Use a workspace path you can write to; prefer absolute paths |
+
+**Do not use** the Atlassian CLI (`acli`) for this skill — `acli jira workitem view` returns `"changelog": null`. Use `fetch-historical-items.mjs` (this path) or MCP instead.

--- a/.agents/skills/jira-get-historical-items/JIRA.md
+++ b/.agents/skills/jira-get-historical-items/JIRA.md
@@ -1,0 +1,117 @@
+# Jira fetch (MCP)
+
+Supplement to [SKILL.md](SKILL.md). Agent-driven fetch via `user-atlassian-mcp-server` **only**.
+
+Shared MCP rules: [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md).
+
+For the CLI path, see [CLI.md](CLI.md). **Do not use CLI.md on this path.**
+
+**Cloud ID:** see [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md)
+
+---
+
+## When to use
+
+- User chose **MCP** at step 2 (or said agent fetch / fetch in chat)
+- User does not want to run a terminal command
+- After MCP fetch, the agent **continues automatically** to the pipeline (no pause)
+
+If the user did **not** pick a route, the agent must **ask first** — see [SKILL.md](SKILL.md) §0 and step 2. Do not jump to this path by default.
+
+---
+
+## MCP-only (route lock)
+
+When the user chose **MCP**, Jira issue data comes **only** from `user-atlassian-mcp-server`. Until the user explicitly starts over with **CLI**, do not:
+
+| Forbidden on MCP path | Why |
+|-----------------------|-----|
+| `fetch-historical-items.mjs` | CLI REST fetch — different route |
+| Atlassian CLI (`acli`) | No changelog; wrong tool — use `fetch-historical-items.mjs` or MCP |
+| Jira REST / curl / env-file credential probes | Not MCP |
+| Silent fallback to CLI when MCP or Write fails | Ask user to switch routes instead |
+
+**Allowed after MCP save:** `run-historical-report.mjs` (and `summarize-cycle-times.mjs` if needed) — local JSON processing only, no Jira API.
+
+---
+
+## MCP tools (exact names)
+
+Read the tool schema JSON in the MCP descriptors folder **before** calling. Typos cause JSON-RPC **-32601** (method not found).
+
+| Step | Tool | Required args |
+|------|------|----------------|
+| Auth check | `getAccessibleAtlassianResources` | — |
+| Search | `searchJiraIssuesUsingJql` | `cloudId`, `jql`, `maxResults`, `fields` |
+| Changelog | `getJiraIssue` | `cloudId`, `issueIdOrKey`, `expand=changelog`, `fields` |
+
+**Changelog fetch:** one `getJiraIssue` per key. Issue **all** calls in **one parallel batch** (same tool-use turn).
+
+On **401**: `mcp_auth` for `user-atlassian-mcp-server`, retry once. **Stop** if MCP still fails — say MCP auth failed; ask if the user wants to **start over with CLI** ([CLI.md](CLI.md)). Do not run CLI fetch without that explicit switch.
+
+---
+
+## MCP error codes
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| **-32601** | Method not found | Verify exact tool name in schema |
+| **401** | Not authenticated | `mcp_auth` on `user-atlassian-mcp-server`, retry |
+| Empty / invalid payload | Wrong args | Re-read schema; ensure `cloudId` and required fields are set |
+
+---
+
+## Fields to request
+
+`summary`, `description`, `status`, `resolution`, `issuetype`, `customfield_10028`
+
+---
+
+## Save format
+
+Array of `getJiraIssue` objects → `{workspace}/.jira-historical-issues.json`
+
+Each element must include:
+
+- `key`
+- `fields` (at least the fields above)
+- `changelog.histories` (non-empty)
+
+Use the **Write** tool. Save full MCP responses — do not reconstruct from memory or shorten descriptions.
+
+The pipeline rejects search-only payloads with a clear error per key.
+
+---
+
+## Parallel batch (required)
+
+- ≤100 keys: single parallel batch
+- More than 100 keys: parallel batches of ~15–20 keys per turn until all keys are fetched
+
+Search results alone have **no changelog** — you must call `getJiraIssue` per key.
+
+If the user's scope covers **more than ~6 months**, post the date-range heads-up from [SKILL.md](SKILL.md) §1 before fetching — do not block.
+
+---
+
+## JQL notes
+
+| Use | Avoid |
+|-----|-------|
+| `created >= -20d` | `createdDate > -20d` (non-standard) |
+| `parent = FCN-41` | unquoted keys are usually fine; match project key casing in links |
+
+---
+
+## Run pipeline after save
+
+See [SKILL.md](SKILL.md) step 4 — **`run-historical-report.mjs` only** (not `fetch-historical-items.mjs`).
+
+```bash
+node scripts/run-historical-report.mjs \
+  --input {workspace}/.jira-historical-issues.json \
+  --workspace {workspace} \
+  --jql '{exact JQL}'
+```
+
+This step does not call Jira; it only processes the MCP-saved JSON.

--- a/.agents/skills/jira-get-historical-items/README.md
+++ b/.agents/skills/jira-get-historical-items/README.md
@@ -1,8 +1,8 @@
 # jira-get-historical-items
 
-A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that builds a historical baseline from closed Jira work — fetch issues with changelog (CLI or MCP), compute cycle time and p75 percentiles, and write `.jira-historical-report.json` for sizing calibration.
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that builds a historical baseline from Jira work — fetch issues with changelog (CLI or MCP), compute cycle time and p75 percentiles, and write `.jira-historical-report.json` for sizing calibration.
 
-Use when you need data from real **finished** work — not to look up a single ticket.
+Use when you need data from real team work — closed items for cycle time, and pointed Done items (including bugs still in flight) for story-point calibration — not to look up a single ticket.
 
 **Supersedes:** [OLD/jira-cycle-time-report](../OLD/jira-cycle-time-report/SKILL.md).
 
@@ -17,19 +17,22 @@ Historical data is most useful when the window is **narrow and recent**. Asking 
 | **One project** (or a small set of parent epics) | Keeps fetch fast and relevant |
 | Items **closed in the last 3–6 months** | Recent work reflects how the team ships today |
 | **Story** and **Task** types you actually point | Epics and one-offs skew calibration |
-| **`resolution = Done`** | Report only includes Done — see below |
+| **`resolution = Done`** | Report includes Done-resolution items — see below |
+| **`status = Closed`** (optional) | Narrows fetch and ensures `completionDate` / `cycleTime` on every row |
 
-**Fetch vs report:** the skill runs **whatever JQL you provide**. It does **not** silently add `status = Closed`. **Open or in-progress items in the fetch won’t break anything** — they are **skipped during processing** (no row in the report). They still cost fetch time and count toward the **100-issue cap**, so narrowing JQL is a performance tip, not a hard requirement.
+**Fetch vs report:** the skill runs **whatever JQL you provide**. It does **not** silently add `status = Closed`. **Processing keeps items with `resolution = Done`** — regardless of status. Only items with a **non-Done** resolution (open, in progress, Won’t Fix, Duplicate, etc.) are **skipped** (no row in the report).
 
-**Example JQL** for sizing calibration (adjust project and window):
+**Done but not Closed:** pointed stories, tasks, and bugs with Done resolution can appear in the report even when status is still open or in progress. They contribute **`storyPoints`** for [jira-get-estimates](../jira-get-estimates/SKILL.md) calibration; **`completionDate`** and **`cycleTime`** are filled only when status is **Closed**. That is intentional — pointed work without cycle time still helps humans and bots size new items.
+
+Looser JQL is fine when you want that pointing signal — e.g. `project = FCN AND updated >= -90d` fetches open tickets too; only **resolution Done** items land in `.jira-historical-report.json`. They still cost fetch time and count toward the **100-issue cap**, so narrowing JQL is a performance tip, not a hard requirement.
+
+**Example JQL** for cycle-time calibration (adjust project and window):
 
 ```text
 project = FCN AND status = Closed AND resolution = Done AND type in (Story, Task) AND updated >= -90d
 ```
 
-Looser JQL is fine if you accept skips — e.g. `project = FCN AND updated >= -90d` will fetch open tickets too; only **resolution Done** items appear in `.jira-historical-report.json`.
-
-Items **closed without** Done resolution (won’t fix, duplicate, cancelled) are also skipped at processing — add `resolution = Done` in JQL to avoid fetching them.
+Items **closed without** Done resolution (won’t fix, duplicate, cancelled) are skipped at processing — add `resolution = Done` in JQL to avoid fetching them.
 
 If you ask for **more than ~6 months**, the agent posts a heads-up (older data is often less useful for sizing) but still proceeds unless you narrow the scope.
 
@@ -70,7 +73,7 @@ Once you pick a path, the agent **locks** to it for that run — no silent switc
 1. **Discovery** — confirm what to include (project, types, status, date window) and **CLI vs MCP** ([SKILL.md](SKILL.md) §0).
 2. **Build JQL** — from your filters or paste JQL as-is.
 3. **Fetch** — save raw issues + changelog to `.jira-historical-issues.json`.
-4. **Process** — keep resolution **Done**; compute dates and cycle time.
+4. **Process** — keep resolution **Done**; compute dates and cycle time (cycle time only when status is **Closed**).
 5. **Report** — write `.jira-historical-report.json`; post JQL, counts, summary, and **clickable file links** in chat ([REPORT.md](REPORT.md)).
 
 ---
@@ -90,8 +93,8 @@ Each processed item in the report includes:
 |-------|---------|
 | `key`, `summary`, `description`, `issueType`, `storyPoints` | Issue metadata |
 | `startDate` | First date the item moved **out of To Do** into another status (from changelog) |
-| `completionDate` | Date the item moved to **Closed** |
-| `cycleTime` | Business days (Mon–Fri) from start to close |
+| `completionDate` | Date the item moved to **Closed** — empty when status is not Closed |
+| `cycleTime` | Business days (Mon–Fri) from start to close — present only when status is **Closed** |
 
 The report also includes **75th-percentile cycle time** grouped by issue type and story points — useful when suggesting how long similar work might take.
 
@@ -185,14 +188,14 @@ jira-get-historical-items/
 |---------|----------------|
 | Agent asks scope / CLI vs MCP before fetching | Expected — [SKILL.md](SKILL.md) §0 discovery gate |
 | Fetch is slow or times out | Narrow to 3–6 months; prefer **CLI**; check issue count vs 100 cap |
-| Many items **skipped** after fetch | Expected if JQL included open or non-Done items — report keeps **resolution Done** only; tighten JQL to fetch fewer skips |
-| No `startDate` / `cycleTime` on some rows | Changelog missing a **To Do → …** transition or **Closed** transition |
+| Many items **skipped** after fetch | Expected if JQL included non-Done resolutions — report keeps **resolution Done** only; tighten JQL to fetch fewer skips |
+| Empty `completionDate` / missing `cycleTime` on some rows | Item has Done resolution but status is not **Closed** (expected for pointing-only rows), or changelog missing a **To Do → …** or **Closed** transition |
 | CLI: missing credentials | [CLI.md](CLI.md) — create `~/.config/jira-fetch.env` |
 | CLI: `fetch is not defined` | Upgrade to **Node.js 18+** |
 | MCP auth failed | Settings → MCP → Atlassian; run `mcp_auth`; or switch to CLI |
 | Want estimates from the report | Run [jira-get-estimates](../jira-get-estimates/SKILL.md) with the saved report path |
 
-Site default: **redhat.atlassian.net**. Story points field default (FCN): `customfield_10028`.
+Site and story-points defaults: [CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md#jira-site-defaults).
 
 ---
 

--- a/.agents/skills/jira-get-historical-items/README.md
+++ b/.agents/skills/jira-get-historical-items/README.md
@@ -1,0 +1,199 @@
+# jira-get-historical-items
+
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that builds a historical baseline from closed Jira work — fetch issues with changelog (CLI or MCP), compute cycle time and p75 percentiles, and write `.jira-historical-report.json` for sizing calibration.
+
+Use when you need data from real **finished** work — not to look up a single ticket.
+
+**Supersedes:** [OLD/jira-cycle-time-report](../OLD/jira-cycle-time-report/SKILL.md).
+
+---
+
+## Scope — be careful what you ask for
+
+Historical data is most useful when the window is **narrow and recent**. Asking for too much slows the fetch, hits caps, and mixes old process with how the team works today.
+
+| Prefer in JQL (for sizing / cycle time) | Why |
+|---------------------------------------|-----|
+| **One project** (or a small set of parent epics) | Keeps fetch fast and relevant |
+| Items **closed in the last 3–6 months** | Recent work reflects how the team ships today |
+| **Story** and **Task** types you actually point | Epics and one-offs skew calibration |
+| **`resolution = Done`** | Report only includes Done — see below |
+
+**Fetch vs report:** the skill runs **whatever JQL you provide**. It does **not** silently add `status = Closed`. **Open or in-progress items in the fetch won’t break anything** — they are **skipped during processing** (no row in the report). They still cost fetch time and count toward the **100-issue cap**, so narrowing JQL is a performance tip, not a hard requirement.
+
+**Example JQL** for sizing calibration (adjust project and window):
+
+```text
+project = FCN AND status = Closed AND resolution = Done AND type in (Story, Task) AND updated >= -90d
+```
+
+Looser JQL is fine if you accept skips — e.g. `project = FCN AND updated >= -90d` will fetch open tickets too; only **resolution Done** items appear in `.jira-historical-report.json`.
+
+Items **closed without** Done resolution (won’t fix, duplicate, cancelled) are also skipped at processing — add `resolution = Done` in JQL to avoid fetching them.
+
+If you ask for **more than ~6 months**, the agent posts a heads-up (older data is often less useful for sizing) but still proceeds unless you narrow the scope.
+
+Default fetch cap: **100 issues**. Widen the date range without tightening JQL and you may get incomplete data.
+
+---
+
+## Requirements
+
+### Choose a fetch path
+
+The agent asks how to fetch unless you already said **CLI** or **MCP**.
+
+| Path | Speed | What you need |
+|------|-------|----------------|
+| **CLI (recommended)** | Faster — parallel Jira REST, no MCP round-trips | **Node.js 18+**, Jira **API token**, `~/.config/jira-fetch.env` or exported env vars — see [CLI.md](CLI.md) |
+| **MCP** | Slower for large sets — one MCP call per issue for changelog | **Atlassian MCP** enabled and authenticated — see [JIRA.md](JIRA.md) |
+
+**CLI setup (first time):**
+
+1. Create [Atlassian API token](https://id.atlassian.com/manage-profile/security/api-tokens).
+2. Save credentials in `~/.config/jira-fetch.env` (see [CLI.md](CLI.md) **First-time setup**).
+3. Confirm Node: `node --version` (must be **18+**).
+
+**MCP setup:**
+
+1. Cursor → **Settings → MCP** — enable **Atlassian** (`user-atlassian-mcp-server`).
+2. Complete auth when prompted (`mcp_auth`).
+
+Once you pick a path, the agent **locks** to it for that run — no silent switching if something fails.
+
+---
+
+## What it does
+
+**JQL → fetch with changelog → process → report in chat.**
+
+1. **Discovery** — confirm what to include (project, types, status, date window) and **CLI vs MCP** ([SKILL.md](SKILL.md) §0).
+2. **Build JQL** — from your filters or paste JQL as-is.
+3. **Fetch** — save raw issues + changelog to `.jira-historical-issues.json`.
+4. **Process** — keep resolution **Done**; compute dates and cycle time.
+5. **Report** — write `.jira-historical-report.json`; post JQL, counts, summary, and **clickable file links** in chat ([REPORT.md](REPORT.md)).
+
+---
+
+## Output
+
+Two JSON files in your **workspace** (absolute paths posted in chat after each successful run):
+
+| File | Contents |
+|------|----------|
+| `.jira-historical-issues.json` | Raw Jira fetch — fields + full changelog per issue |
+| `.jira-historical-report.json` | Processed report used for sizing calibration |
+
+Each processed item in the report includes:
+
+| Field | Meaning |
+|-------|---------|
+| `key`, `summary`, `description`, `issueType`, `storyPoints` | Issue metadata |
+| `startDate` | First date the item moved **out of To Do** into another status (from changelog) |
+| `completionDate` | Date the item moved to **Closed** |
+| `cycleTime` | Business days (Mon–Fri) from start to close |
+
+The report also includes **75th-percentile cycle time** grouped by issue type and story points — useful when suggesting how long similar work might take.
+
+### What you can do with it
+
+| Use | Skill |
+|-----|-------|
+| **Stats summary** — counts, cycle time, throughput, items table | [jira-get-stats](../jira-get-stats/SKILL.md) |
+| Recommend **story point** estimates from historical buckets | [jira-get-estimates](../jira-get-estimates/SKILL.md) |
+| Inspect raw changelog / re-run processing | Open `.jira-historical-issues.json` or use scripts in `scripts/` |
+
+---
+
+## How to use it
+
+### Install the skill
+
+| Location | Scope |
+|----------|-------|
+| `~/.cursor/skills/jira-get-historical-items/` | Personal — all projects |
+| `.cursor/skills/jira-get-historical-items/` | Project — shared with the repo |
+
+### Trigger in Cursor
+
+Ask the agent — for example:
+
+- “Get historical Jira items for project FCN — closed stories and tasks, last 90 days”
+- “Build a cycle-time report for parent FCN-41, resolution Done, updated last 6 months”
+- “Generate `.jira-historical-report.json` for sizing — use the CLI command”
+- Paste exact JQL: `project = FCN AND status = Closed AND resolution = Done AND updated >= -180d`
+
+The skill is **user-invocable** (`SKILL.md` frontmatter).
+
+### What to have ready
+
+| Input | When |
+|-------|------|
+| **Project** and/or **parent epic(s)** | Almost always — agent asks if unclear |
+| **Date window** (3–6 months typical) | Always — agent asks if not stated |
+| **Issue types** (e.g. Story, Task) | Recommended |
+| **`resolution = Done`** in JQL or filters | Strongly recommended |
+| **CLI vs MCP** | Agent asks unless you specify |
+| **API token + Node 18+** | CLI path only |
+
+### After delivery
+
+Chat includes JQL, fetch counts, the historical report JSON, a cycle-time summary, and **Saved files** links to open both artifacts.
+
+**CLI path:** you run the fetch command in your terminal, then say “continue” when files exist.
+
+**MCP path:** the agent fetches and continues automatically.
+
+---
+
+## Directory layout
+
+```
+jira-get-historical-items/
+├── README.md             # This file
+├── SKILL.md              # Orchestrator — workflow, gates, route lock
+├── CLI.md                # Terminal fetch (recommended) — env file, Node, commands
+├── JIRA.md               # MCP fetch path
+├── REPORT.md             # Chat output shape and report schema
+├── RESOLVE_REPORT.md     # Shared step 1 for jira-get-stats and jira-get-estimates
+├── SCRIPTS.md            # What each script does
+└── scripts/
+    ├── fetch-historical-items.mjs   # JQL + changelog fetch (CLI)
+    ├── run-historical-report.mjs    # Validate → process → summarize
+    ├── process-historical-items.mjs
+    ├── summarize-cycle-times.mjs
+    ├── summarize-report-stats.mjs   # Stats summary from report JSON
+    └── lib/                         # Auth, fetch, analyze, report builders
+```
+
+---
+
+## Related skills
+
+| Skill | Relationship |
+|-------|----------------|
+| [jira-get-stats](../jira-get-stats/SKILL.md) | Consumes `.jira-historical-report.json` for readable stats summary |
+| [jira-get-estimates](../jira-get-estimates/SKILL.md) | Consumes `.jira-historical-report.json` to suggest story points and cycle-time comments |
+| [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) | Separate — scores ticket quality; does not use this report |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, skill index |
+
+---
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|----------------|
+| Agent asks scope / CLI vs MCP before fetching | Expected — [SKILL.md](SKILL.md) §0 discovery gate |
+| Fetch is slow or times out | Narrow to 3–6 months; prefer **CLI**; check issue count vs 100 cap |
+| Many items **skipped** after fetch | Expected if JQL included open or non-Done items — report keeps **resolution Done** only; tighten JQL to fetch fewer skips |
+| No `startDate` / `cycleTime` on some rows | Changelog missing a **To Do → …** transition or **Closed** transition |
+| CLI: missing credentials | [CLI.md](CLI.md) — create `~/.config/jira-fetch.env` |
+| CLI: `fetch is not defined` | Upgrade to **Node.js 18+** |
+| MCP auth failed | Settings → MCP → Atlassian; run `mcp_auth`; or switch to CLI |
+| Want estimates from the report | Run [jira-get-estimates](../jira-get-estimates/SKILL.md) with the saved report path |
+
+Site default: **redhat.atlassian.net**. Story points field default (FCN): `customfield_10028`.
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-get-historical-items/REPORT.md
+++ b/.agents/skills/jira-get-historical-items/REPORT.md
@@ -1,0 +1,175 @@
+# Report output
+
+Always post results in **chat**.
+
+---
+
+## Chat report shape
+
+Post these sections **in order**:
+
+### 1. JQL
+
+```text
+<JQL used for the search>
+```
+
+One fenced block with the exact JQL string.
+
+### 2. Fetch counts
+
+One short paragraph:
+
+- Issues matched by JQL: **N**
+- Included after processing (resolution Done): **M**
+- Skipped (non-Done resolution): **N − M**
+- Note any fetch/changelog caveats (truncated changelog, auth retry, CLI vs MCP) if applicable
+
+### 3. Historical report
+
+Heading: **`## Historical report`**
+
+Paste the **full** `.jira-historical-report.json` as a JSON code block (or stdout from `run-historical-report.mjs --stdout` before the `---CYCLE_TIME_SUMMARY---` delimiter).
+
+Do **not** omit or summarize this JSON unless the user asked for summary only.
+
+### 4. Cycle time summary
+
+Heading: **`## Cycle time summary`**
+
+Paste human-readable text from:
+
+```bash
+node scripts/summarize-cycle-times.mjs \
+  --input {workspace}/.jira-historical-report.json
+```
+
+Or use the text after `---CYCLE_TIME_SUMMARY---` when using `--stdout`.
+
+When `cycleTime` is `null` in the report, show:
+
+```text
+No items with measurable cycle time — summary not produced.
+```
+
+### 5. Saved files
+
+Heading: **`## Saved files`**
+
+**Always** post after a successful run (including 0-issue fetches that still wrote empty artifact files). Use **absolute paths** from this run as markdown links so the user can open them in the editor:
+
+```markdown
+## Saved files
+
+- [.jira-historical-issues.json](/absolute/path/to/workspace/.jira-historical-issues.json)
+- [.jira-historical-report.json](/absolute/path/to/workspace/.jira-historical-report.json)
+```
+
+- Link **label** = filename; link **target** = full absolute path (not `{workspace}` placeholders).
+- **Paths and links only** — do not paste file contents again under this heading (the report JSON already appears in §3).
+- Skip this section when fetch or the report pipeline failed.
+
+---
+
+## Report schema (version 1)
+
+```json
+{
+  "version": 1,
+  "runAt": "2026-06-24T15:30:00.000Z",
+  "jql": "parent = FCN-41 AND created >= -20d",
+  "meta": {
+    "site": "redhat.atlassian.net",
+    "storyPointsField": "customfield_10028",
+    "counts": {
+      "fetched": 12,
+      "included": 10,
+      "skipped": 2
+    }
+  },
+  "items": [
+    {
+      "key": "FCN-533",
+      "summary": "…",
+      "description": "…",
+      "issueType": "Story",
+      "storyPoints": 3,
+      "startDate": "2026-06-17",
+      "completionDate": "2026-06-24",
+      "cycleTime": 6
+    }
+  ],
+  "cycleTime": {
+    "closedDateRange": {
+      "earliest": "2026-06-10",
+      "latest": "2026-06-24"
+    },
+    "percentiles": [
+      { "group": "all", "label": "All items", "count": 5, "p75Days": 3.4 },
+      { "group": "issueType", "issueType": "story", "label": "All stories", "count": 1, "p75Days": 6 },
+      { "group": "storyPoints", "storyPoints": 3, "label": "All 3 point items", "count": 1, "p75Days": 6 },
+      { "group": "issueTypeAndStoryPoints", "issueType": "story", "storyPoints": 3, "label": "3 point items", "count": 1, "p75Days": 6 }
+    ]
+  }
+}
+```
+
+`cycleTime` is `null` when no processed item has a numeric `cycleTime`.
+
+---
+
+## Example (structure only)
+
+## JQL
+
+```text
+parent = FCN-41 AND created >= -20d
+```
+
+Fetched **12** issues; **10** included (resolution Done); **2** skipped.
+
+## Historical report
+
+```json
+{
+  "version": 1,
+  "runAt": "2026-06-24T15:30:00.000Z",
+  "jql": "parent = FCN-41 AND created >= -20d",
+  "meta": { "counts": { "fetched": 12, "included": 10, "skipped": 2 } },
+  "items": [ … ],
+  "cycleTime": { … }
+}
+```
+
+## Cycle time summary
+
+```text
+Closed date range: 2026-06-18 - 2026-06-23
+Cycle time: 75th percentile (business days)
+
+All items (8): 4 days
+All stories (6): 3.5 days
+…
+```
+
+## Saved files
+
+- [.jira-historical-issues.json](/Users/you/project/.jira-historical-issues.json)
+- [.jira-historical-report.json](/Users/you/project/.jira-historical-report.json)
+
+---
+
+## Errors
+
+Respect **route lock** ([SKILL.md](SKILL.md)): on MCP path, never auto-run CLI fetch; on CLI path, never auto-run MCP fetch. Ask the user to **switch routes** explicitly if needed.
+
+| Situation | Chat response |
+|-----------|----------------|
+| Scope or fetch route unknown | **Stop** — [SKILL.md](SKILL.md) §0; ask what to include and CLI vs MCP; do not infer project or date range |
+| MCP auth failed | Say so; run `mcp_auth` once; if still failing, **stop** — ask if user wants to switch to CLI ([CLI.md](CLI.md)) |
+| MCP fetch/save failed (MCP path) | **Stop** — do not run `fetch-historical-items.mjs`; ask user to fix MCP or switch to CLI |
+| JQL returned 0 issues | Show JQL + "No issues matched." Still post **Saved files** links if empty artifacts were written |
+| All issues skipped (non-Done) | Show JQL, fetch count, report with `items: []` and `cycleTime: null` |
+| `run-historical-report.mjs` failure | Show JQL + full stderr (missing file, invalid fetch, missing changelog) — this is local processing, not a fetch fallback |
+| MCP -32601 | Wrong tool name — read MCP schema; retry MCP; ask before switching to CLI |
+| CLI fetch failed | Show stderr; check JIRA_EMAIL / JIRA_API_TOKEN — do not silently switch to MCP |

--- a/.agents/skills/jira-get-historical-items/RESOLVE_REPORT.md
+++ b/.agents/skills/jira-get-historical-items/RESOLVE_REPORT.md
@@ -1,0 +1,59 @@
+# Resolve `.jira-historical-report.json`
+
+Shared **step 1** for [jira-get-estimates](../jira-get-estimates/SKILL.md) and [jira-get-stats](../jira-get-stats/SKILL.md).
+
+**Hard stop:** Do not run later steps until a report file is resolved.
+
+Path symbols: [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md).
+
+---
+
+## 1a. User provided a file or path
+
+If the user pasted report JSON, attached a file, or gave an explicit path in chat, use that.
+
+- Expand `~` to the home directory.
+- Prefer **absolute paths** when verifying the file exists (e.g. `test -f` or Read).
+
+---
+
+## 1b. No path from the user
+
+Resolve `{workspace}` (see CONVENTIONS), then look for the report **in order**:
+
+1. `{workspace}/.jira-historical-report.json`
+2. `~/.cursor/skills/.jira-historical-report.json`
+
+Use the first path that exists. Do not assume either is present.
+
+---
+
+## 1c. File not found — stop
+
+If neither 1a nor 1b produced a readable report file, **stop the workflow**. Do not proceed to later steps.
+
+Post a short message like:
+
+> I couldn't find `.jira-historical-report.json`.
+>
+> How would you like to proceed?
+> 1. **Provide a file** — paste the report JSON or give me a path to `.jira-historical-report.json`.
+> 2. **Generate a report** — run the **jira-get-historical-items** skill to fetch historical Jira items and build the report, then come back here.
+
+Prefer **AskQuestion** when available. **Wait** for the user's choice before continuing.
+
+- If they choose **1**, resume from step 1a with their file or path.
+- If they choose **2**, read and follow [SKILL.md](SKILL.md) **from §0 Discovery gate**. Do **not** assume what the historical report should include (project, parents, date range) or CLI vs MCP from the calling thread unless the user stated those filters **for the historical report**. After that skill writes `.jira-historical-report.json`, return to the calling skill and re-run step 1.
+
+---
+
+## 1d. File found — confirm
+
+When a report file is resolved:
+
+1. Read the file and confirm it parses as JSON.
+2. Confirm expected top-level fields exist: `version`, `items` (array). See [REPORT.md](REPORT.md) for full schema.
+3. Note the resolved **absolute path** and **`{report-dir}`** (parent directory) for later steps.
+4. Briefly tell the user which file was used (path only — do not dump the full JSON).
+
+Load `meta.storyPointsField` when present; otherwise use `customfield_10028` ([CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md)).

--- a/.agents/skills/jira-get-historical-items/SCRIPTS.md
+++ b/.agents/skills/jira-get-historical-items/SCRIPTS.md
@@ -1,0 +1,21 @@
+# Scripts reference
+
+Local processing for [jira-get-historical-items](SKILL.md). **Do not reimplement this logic in chat.**
+
+All scripts live under `jira-get-historical-items/scripts/`. Use **absolute paths** for `--input`, `--output`, and `--workspace`.
+
+Requires **Node.js 18+** for CLI fetch.
+
+---
+
+| Script | Purpose |
+|--------|---------|
+| **fetch-historical-items.mjs** | JQL search + per-issue changelog via Jira REST → writes `.jira-historical-issues.json` and (by default) `.jira-historical-report.json` |
+| **run-historical-report.mjs** | Validates fetch → process → summarize → writes `.jira-historical-report.json` |
+| **process-historical-items.mjs** | Keeps items with resolution **Done**; computes `startDate`, `completionDate`, `cycleTime` (business days Mon–Fri) |
+| **summarize-cycle-times.mjs** | Human-readable 75th-percentile cycle time by type and story points |
+| **summarize-report-stats.mjs** | Stats summary from report JSON — used by [jira-get-stats](../jira-get-stats/SKILL.md) |
+
+**Alternative pipeline** (only if `run-historical-report.mjs` fails): run `process-historical-items.mjs` then `summarize-cycle-times.mjs`, both with absolute `--input` paths.
+
+See [CLI.md](CLI.md) for fetch credentials and [JIRA.md](JIRA.md) for MCP fetch.

--- a/.agents/skills/jira-get-historical-items/SKILL.md
+++ b/.agents/skills/jira-get-historical-items/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: jira-get-historical-items
+description: >-
+  Jira historical items and cycle time: discovery for scope and fetch route (CLI vs MCP),
+  build JQL, fetch issues with changelog, save .jira-historical-issues.json, run
+  run-historical-report.mjs, print JQL + results in chat. Use for historical Jira items,
+  75th-percentile cycle time, closed-item analysis on redhat.atlassian.net. Asks what to
+  include and CLI vs MCP unless the user already specified.
+user-invocable: true
+---
+
+# Get Jira historical items
+
+**JQL → fetch JSON → pipeline script → print in chat.**
+
+Two fetch paths produce the **same** artifact: `{workspace}/.jira-historical-issues.json`. After that, the workflow is identical.
+
+Shared paths and MCP rules: [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md).
+
+---
+
+## Hard rules
+
+| Do | Do not |
+|----|--------|
+| Save fetch JSON before running the pipeline | Run the pipeline without a fetch file |
+| Write both artifacts under one resolved **`{workspace}`** — same path for CLI `--output`/`--workspace`, MCP **Write**, pipeline, and step 5 links | Save to skill dir, script dir, or a different folder per step |
+| **Absolute paths** for `--input`, `--output`, `--workspace`, and MCP **Write** | Relative paths when cwd is unknown |
+| Scripts in `jira-get-historical-items/scripts/` only — see [SCRIPTS.md](SCRIPTS.md) | Ad-hoc node one-liners or new scripts elsewhere |
+| Post JQL + report in chat — shape in [REPORT.md](REPORT.md) | Ask the user to hand-parse JSON |
+| **Ask** user for fetch route when not specified | Guess MCP or CLI, or start fetch without asking |
+| **Ask** user for report scope when not specified | Infer project, parents, date range, or status from chat context |
+| **CLI** (`fetch-historical-items.mjs`) or **MCP** for fetch | Atlassian CLI (`acli`) — changelog is always null |
+| **Lock the fetch route** once the user picks CLI or MCP | Mix paths or fall back to the other fetch route mid-run |
+| **Post date-range heads-up** when scope exceeds ~6 months (step 1) | Block the fetch or narrow the window without user consent |
+| **Post absolute artifact paths** with clickable links after success (step 5) | Dump file contents twice or omit where the JSON files were saved |
+
+### Route lock
+
+Once the user picks a fetch path, **stay on it** for the rest of the run.
+
+| User chose | Fetch (step 2) | Report (step 4) |
+|------------|----------------|-----------------|
+| **MCP** | `user-atlassian-mcp-server` only — [JIRA.md](JIRA.md) | `run-historical-report.mjs` (local; no Jira network) |
+| **CLI** | `fetch-historical-items.mjs` only — [CLI.md](CLI.md) | Usually already written by fetch script; re-run pipeline only if needed |
+
+**MCP path — never for Jira data:** `fetch-historical-items.mjs`, Jira REST/curl, Atlassian CLI, env-file probes, or silent CLI fallback. If MCP fetch or save fails, **stop** and ask whether to **switch to CLI** (new run).
+
+**CLI path — never for Jira data:** MCP `searchJiraIssuesUsingJql` / `getJiraIssue`. If CLI fetch fails, **stop**; do not silently switch to MCP.
+
+`run-historical-report.mjs` reads local JSON only — required after MCP save; not a fetch path.
+
+---
+
+## Constants
+
+| | Value |
+|--|--------|
+| **`{workspace}`**, site, cloud ID, story points field | [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) |
+| Scripts dir | `scripts/` (under this skill — not the artifact workspace) |
+| Fetch artifact | `{workspace}/.jira-historical-issues.json` |
+| Report artifact | `{workspace}/.jira-historical-report.json` |
+| Recommended date window | **3–6 months** of closed work (`updated >= -90d` to `-180d`) for sizing / cycle-time calibration |
+| Date range warning | When scope exceeds **~6 months**, post a heads-up before fetch — **do not block** |
+| Min Node.js (CLI path) | **18** — see [CLI.md](CLI.md) |
+| Default fetch cap | **100** issues (`--max-results` on CLI; `maxResults` on MCP search) |
+
+---
+
+## Workflow
+
+```
+Progress:
+- [ ] Step 0 — Discovery gate (scope + CLI/MCP unless user specified)
+- [ ] Step 1 — Build JQL
+- [ ] Step 2 — Fetch → `.jira-historical-issues.json`
+- [ ] Step 3 — Confirm fetch JSON
+- [ ] Step 4 — Run pipeline → `.jira-historical-report.json`
+- [ ] Step 5 — Print in chat → [REPORT.md](REPORT.md)
+```
+
+### 0. Discovery gate (hard stop)
+
+Run **before** building JQL or fetching. If the user did not supply enough to proceed, **stop** — discovery-only response; do not fetch, do not run scripts, do not invent defaults.
+
+#### Resolved scope?
+
+Scope is **resolved** only when the user, in this thread, provided **at least one** of:
+
+- Exact **JQL** to use, **or**
+- Enough filters to build JQL without guessing: what to include (project and/or parent epics and/or keys), issue **types**, **status** (e.g. Closed/Done), and a **date window** (e.g. `updated >= -90d`)
+
+**Not resolved** = user said “create the report”, “generate historical data”, “yes” to building a file, or gave product context (e.g. epic breakdown) but never said what belongs **in the historical report**.
+
+Prior conversation (jira-epic-create, jira-epic-breakdown, estimate targets) does **not** resolve scope unless the user restated those filters for **this** report.
+
+#### Resolved fetch route?
+
+Route is **resolved** when the user said **CLI** (command, terminal, script) or **MCP** (agent fetch, fetch in chat).
+
+#### If scope or route is not resolved → ask
+
+Post one short message. Prefer **AskQuestion** when available. Example:
+
+> I can build `.jira-historical-report.json` once two things are clear:
+>
+> 1. **What should the report include?** For example: project, parent epic(s) or “whole project”, issue types (Story/Task), status (usually Closed/Done for cycle time), and how far back. Teams often use the **last 3–6 months** of closed work for sizing calibration — e.g. `updated >= -90d` or `updated >= -180d`. Paste JQL or describe the filter.
+> 2. **How should I fetch?**
+>    - **CLI** — I’ll help you set up a local `~/.config/jira-fetch.env` if needed, then give you a `fetch-historical-items.mjs` command to run (requires **Node.js 18+**; usually faster). Tell me when the files are ready.
+>    - **MCP** — I’ll fetch here in chat via Jira MCP and continue automatically.
+
+Wait for answers. If only one slot is missing, ask only that slot.
+
+**Do not** default to a project (e.g. FCN), parent list, or date range (e.g. 180 days) the user did not state.
+
+---
+
+### 1. Build JQL
+
+Only after step 0 scope is resolved.
+
+From user scope, or use their JQL as-is. Examples:
+
+```text
+parent = FCN-41 AND created >= -20d
+project = FCN AND status = Closed AND type in (Story, Task) AND updated >= -90d
+```
+
+Use `created >= -20d` or `updated >= -90d` (not `createdDate`). When the user picked a date range in step 0, reflect it in JQL. Suggest **3–6 months** only when asking in step 0 — do not apply that window unless the user confirmed it.
+
+#### Date range heads-up (do not block)
+
+When the user's JQL or stated scope covers **more than ~6 months**, post a short note **before step 2 (fetch)**. **Proceed** with their scope unless they ask to narrow it.
+
+**Trigger when any of these apply:**
+
+- Relative JQL beyond ~180 days — e.g. `-365d`, `-1y`, `-52w`, `-300d`
+- User phrasing — e.g. “last year”, “past 12 months”, “all of 2024”
+- A start date or filter window that clearly spans more than six months
+
+**Example note** (adapt to their scope):
+
+> **Heads-up:** For story-point sizing and cycle-time calibration, teams usually look at **closed work from the last 3–6 months** (`updated >= -90d` to `-180d`). Older tickets often reflect past process or team makeup and are less useful for estimating current work. Your window may also match **many** issues — the default fetch cap is **100** (`--max-results` / MCP `maxResults`); widening the date range without narrowing JQL can mean incomplete data, or a long fetch if the cap is raised.
+
+If they already acknowledged the tradeoff in this thread, skip repeating the full note.
+
+### 2. Fetch → `.jira-historical-issues.json`
+
+Only after step 0 route is resolved.
+
+**Skip fetch** (go to step 3) when:
+
+- User says the JSON is ready, fetch is done, or to continue from the file
+- `{workspace}/.jira-historical-issues.json` already exists and the user only wants a re-run of the report
+
+**If route is not resolved:** return to step 0 — ask only the fetch question; do not fetch.
+
+| User said | Path |
+|-----------|------|
+| CLI, command, terminal, script, faster, REST | **CLI** → [CLI.md](CLI.md) |
+| MCP, agent fetch, fetch in chat | **MCP** → [JIRA.md](JIRA.md) |
+| *(nothing)* | **Stop** — return to step 0 |
+
+#### Path A — CLI
+
+Full procedure: [CLI.md](CLI.md). Give the user a command with **absolute** `--output` and the exact JQL from step 1:
+
+```bash
+node scripts/fetch-historical-items.mjs \
+  --jql '{exact JQL}' \
+  --output {workspace}/.jira-historical-issues.json \
+  --env-file ~/.config/jira-fetch.env
+```
+
+**Stop after giving the command** unless the user asked the agent to run it or both output files already exist.
+
+#### Path B — MCP
+
+Follow [JIRA.md](JIRA.md). Save full issue+changelog payloads to `{workspace}/.jira-historical-issues.json`, then continue automatically to steps 3–5.
+
+**0 results:** post JQL in chat, say no issues matched, **stop**.
+
+### 3. Confirm fetch JSON
+
+Verify `{workspace}/.jira-historical-issues.json` exists. Each element must have `key`, `fields`, and `changelog.histories`.
+
+If the user resumed after CLI fetch and the file is missing, say so and stop.
+
+### 4. Run pipeline
+
+**CLI path:** skip when `.jira-historical-report.json` already exists from `fetch-historical-items.mjs` (default).
+
+**MCP path** (or re-run):
+
+```bash
+node scripts/run-historical-report.mjs \
+  --input {workspace}/.jira-historical-issues.json \
+  --workspace {workspace} \
+  --jql '{exact JQL}'
+```
+
+Optional: add `--stdout` for one-shot chat output. See [SCRIPTS.md](SCRIPTS.md) for alternatives if the pipeline fails.
+
+If a script exits **1**, read stderr.
+
+### 5. Print in chat
+
+Follow [REPORT.md](REPORT.md) for section order, JSON shape, and **Saved files** links.
+
+---
+
+## Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| CLI missing credentials | [CLI.md](CLI.md) first-time setup |
+| Node too old / not installed | CLI path needs **Node.js 18+** |
+| User asked for > 6 months of history | Post step 1 date-range heads-up; proceed unless they narrow scope |
+| MCP **-32601** | Wrong tool name — read MCP schema; use `searchJiraIssuesUsingJql` and `getJiraIssue` exactly |
+| MCP **401** | `mcp_auth` on `user-atlassian-mcp-server`, retry once |
+| Empty dates / no cycle time | Fetch used search only — need per-issue changelog |
+| Script exit 1, no output | Use **absolute** `--input` paths; read stderr |
+| `Input file not found` | Complete fetch first; path must match `--input` |
+| `missing changelog histories` | Save full issue+changelog payloads, not search-only rows |
+| Used Atlassian CLI (`acli`) for fetch | Changelog is null — use `fetch-historical-items.mjs` or MCP |
+| Slow MCP changelog fetch | Issue all `getJiraIssue` calls in one parallel batch — [JIRA.md](JIRA.md) |
+| User ran CLI, agent continued too early | Wait for user confirmation or verify the file exists |
+| Reconstructed/trimmed MCP JSON | Save full `getJiraIssue` responses — [JIRA.md](JIRA.md) |
+
+Scope, route, and artifact-path mistakes → see **Hard rules** and step 0.

--- a/.agents/skills/jira-get-historical-items/scripts/fetch-historical-items.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/fetch-historical-items.mjs
@@ -23,6 +23,11 @@ import { defaultWorkspaceDir, resolvePath } from './lib/paths.mjs';
 import { runHistoricalReport } from './lib/run-report.mjs';
 import { validateFetchIssues } from './lib/validate-fetch.mjs';
 
+function parsePositiveInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
 function parseArgs(argv) {
   const opts = {
     jql: '',
@@ -48,9 +53,13 @@ function parseArgs(argv) {
     else if (arg === '--token') ((opts.token = next), i++);
     else if (arg === '--env-file') ((opts.envFile = next), i++);
     else if (arg === '--story-points-field') ((opts.storyPointsField = next), i++);
-    else if (arg === '--concurrency') ((opts.concurrency = Number(next)), i++);
-    else if (arg === '--max-results') ((opts.maxResults = Number(next)), i++);
-    else if (arg === '--workspace' || arg === '-w') ((opts.workspace = next), i++);
+    else if (arg === '--concurrency') {
+      opts.concurrency = parsePositiveInt(next, opts.concurrency);
+      i++;
+    } else if (arg === '--max-results') {
+      opts.maxResults = parsePositiveInt(next, opts.maxResults);
+      i++;
+    } else if (arg === '--workspace' || arg === '-w') ((opts.workspace = next), i++);
     else if (arg === '--skip-report') opts.skipReport = true;
     else if (arg === '--help' || arg === '-h') {
       console.log(`Usage: node fetch-historical-items.mjs --jql 'JQL' --output /abs/path/.jira-historical-issues.json
@@ -121,6 +130,8 @@ async function main() {
       workspace,
       jql: opts.jql,
       storyPointsField: opts.storyPointsField,
+      site: auth.site,
+      maxResults: opts.maxResults,
       issues,
     });
   }

--- a/.agents/skills/jira-get-historical-items/scripts/fetch-historical-items.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/fetch-historical-items.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Fetch Jira issues with changelog via REST API.
+ * Writes the same JSON shape as MCP getJiraIssue (array of { key, fields, changelog }).
+ * By default also runs the report pipeline → .jira-historical-report.json
+ *
+ * Usage:
+ *   JIRA_EMAIL=user@example.com JIRA_API_TOKEN=... \
+ *   node fetch-historical-items.mjs \
+ *     --jql 'parent = FCN-41 AND created >= -20d' \
+ *     --output /abs/path/.jira-historical-issues.json
+ */
+
+import { writeFileSync } from 'fs';
+import { resolveJiraAuth } from './lib/jira-auth.mjs';
+import {
+  buildFieldList,
+  fetchIssueWithChangelog,
+  mapPool,
+  searchIssueKeys,
+} from './lib/jira-fetch.mjs';
+import { defaultWorkspaceDir, resolvePath } from './lib/paths.mjs';
+import { runHistoricalReport } from './lib/run-report.mjs';
+import { validateFetchIssues } from './lib/validate-fetch.mjs';
+
+function parseArgs(argv) {
+  const opts = {
+    jql: '',
+    output: '',
+    site: '',
+    email: '',
+    token: '',
+    envFile: '',
+    storyPointsField: 'customfield_10028',
+    concurrency: 10,
+    maxResults: 100,
+    workspace: '',
+    skipReport: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--jql') ((opts.jql = next), i++);
+    else if (arg === '--output' || arg === '-o') ((opts.output = next), i++);
+    else if (arg === '--site') ((opts.site = next), i++);
+    else if (arg === '--email') ((opts.email = next), i++);
+    else if (arg === '--token') ((opts.token = next), i++);
+    else if (arg === '--env-file') ((opts.envFile = next), i++);
+    else if (arg === '--story-points-field') ((opts.storyPointsField = next), i++);
+    else if (arg === '--concurrency') ((opts.concurrency = Number(next)), i++);
+    else if (arg === '--max-results') ((opts.maxResults = Number(next)), i++);
+    else if (arg === '--workspace' || arg === '-w') ((opts.workspace = next), i++);
+    else if (arg === '--skip-report') opts.skipReport = true;
+    else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node fetch-historical-items.mjs --jql 'JQL' --output /abs/path/.jira-historical-issues.json
+
+Auth:
+  --env-file PATH                     .env file (JIRA_EMAIL, JIRA_API_TOKEN, optional JIRA_SITE)
+  JIRA_EMAIL / JIRA_API_TOKEN         Environment variables
+  --email / --token / --site          Inline overrides (prefer --env-file for tokens)
+
+Options:
+  --jql                    JQL query (required)
+  --output, -o             Output JSON path (required; use absolute path)
+  --story-points-field     Story points field id (default: customfield_10028)
+  --concurrency            Parallel issue fetches (default: 10)
+  --max-results            Max issues to fetch (default: 100)
+  --workspace, -w          Workspace for report output (default: output file directory)
+  --skip-report            Fetch only; do not write .jira-historical-report.json`);
+      process.exit(0);
+    }
+  }
+
+  if (!opts.jql) throw new Error('Missing required --jql');
+  if (!opts.output) throw new Error('Missing required --output');
+
+  return opts;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv);
+  const auth = resolveJiraAuth({
+    site: opts.site,
+    email: opts.email,
+    token: opts.token,
+    envFile: opts.envFile,
+  });
+  const fields = buildFieldList(opts.storyPointsField);
+  const outputPath = resolvePath(opts.output);
+  const workspace = opts.workspace ? resolvePath(opts.workspace) : defaultWorkspaceDir(outputPath);
+
+  console.error(`Site: ${auth.site}`);
+  console.error(`JQL: ${opts.jql}`);
+
+  const keys = await searchIssueKeys(auth, opts.jql, fields, opts.maxResults);
+  console.error(`Matched ${keys.length} issue(s).`);
+
+  let issues = [];
+
+  if (keys.length === 0) {
+    writeFileSync(outputPath, '[]\n');
+    console.error(`Wrote empty array to ${outputPath}`);
+  } else {
+    issues = await mapPool(keys, opts.concurrency, async (key, index) => {
+      const issue = await fetchIssueWithChangelog(auth, key, fields);
+      console.error(`Fetched ${index + 1}/${keys.length}: ${key}`);
+      return issue;
+    });
+
+    validateFetchIssues(issues);
+
+    const json = JSON.stringify(issues, null, 2);
+    writeFileSync(outputPath, json);
+    console.error(`Wrote ${issues.length} issue(s) to ${outputPath}`);
+  }
+
+  if (!opts.skipReport) {
+    runHistoricalReport({
+      inputPath: outputPath,
+      workspace,
+      jql: opts.jql,
+      storyPointsField: opts.storyPointsField,
+      issues,
+    });
+  }
+}
+
+try {
+  await main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/analyze.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/analyze.mjs
@@ -1,0 +1,64 @@
+import { businessDaysBetween, formatDate, parseDate, plainDescription } from './metrics.mjs';
+
+const DONE_RESOLUTION = 'Done';
+
+/**
+ * @param {object} issue Jira issue with fields + changelog
+ * @returns {object|null} Output row, or null when resolution is not Done
+ */
+export function analyzeHistoricalItem(issue, storyPointsFieldId = 'customfield_10028') {
+  const resolutionName = issue.fields?.resolution?.name ?? '';
+  if (resolutionName !== DONE_RESOLUTION) return null;
+
+  const key = issue.key;
+  const summary = issue.fields?.summary ?? '';
+  const description = plainDescription(issue.fields?.description);
+  const statusName = issue.fields?.status?.name ?? '';
+  const isClosed = statusName === 'Closed';
+
+  const histories = [...(issue.changelog?.histories ?? [])].sort(
+    (a, b) => new Date(a.created) - new Date(b.created)
+  );
+
+  let startDate = null;
+  let completionDate = null;
+
+  for (const h of histories) {
+    for (const item of h.items ?? []) {
+      if (item.field !== 'status') continue;
+      if (item.fromString === 'To Do' && item.toString && item.toString !== 'To Do') {
+        const d = parseDate(h.created);
+        if (!startDate || d < startDate) startDate = d;
+      }
+      if (item.toString === 'Closed') {
+        const d = parseDate(h.created);
+        if (!completionDate || d > completionDate) completionDate = d;
+      }
+    }
+  }
+
+  const issueType = issue.fields?.issuetype?.name ?? '';
+  const rawPoints = issue.fields?.[storyPointsFieldId] ?? issue.fields?.storyPoints;
+  const storyPoints =
+    rawPoints === null || rawPoints === undefined || rawPoints === '' ? '' : Number(rawPoints);
+
+  const row = {
+    key,
+    summary,
+    description,
+    issueType,
+    storyPoints,
+    startDate: formatDate(startDate),
+    completionDate: isClosed ? formatDate(completionDate) : '',
+  };
+
+  if (isClosed) {
+    let cycleTime = '';
+    if (startDate && completionDate) {
+      cycleTime = businessDaysBetween(startDate, completionDate);
+    }
+    row.cycleTime = cycleTime;
+  }
+
+  return row;
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/analyze.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/analyze.mjs
@@ -2,6 +2,11 @@ import { businessDaysBetween, formatDate, parseDate, plainDescription } from './
 
 const DONE_RESOLUTION = 'Done';
 
+function historyTimestamp(iso) {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : 0;
+}
+
 /**
  * @param {object} issue Jira issue with fields + changelog
  * @returns {object|null} Output row, or null when resolution is not Done
@@ -17,12 +22,13 @@ export function analyzeHistoricalItem(issue, storyPointsFieldId = 'customfield_1
   const isClosed = statusName === 'Closed';
 
   const histories = [...(issue.changelog?.histories ?? [])].sort(
-    (a, b) => new Date(a.created) - new Date(b.created)
+    (a, b) => historyTimestamp(a.created) - historyTimestamp(b.created)
   );
 
   let startDate = null;
   let completionDate = null;
 
+  // Workflow-specific status names (Red Hat FCN default workflow).
   for (const h of histories) {
     for (const item of h.items ?? []) {
       if (item.field !== 'status') continue;
@@ -39,8 +45,11 @@ export function analyzeHistoricalItem(issue, storyPointsFieldId = 'customfield_1
 
   const issueType = issue.fields?.issuetype?.name ?? '';
   const rawPoints = issue.fields?.[storyPointsFieldId] ?? issue.fields?.storyPoints;
-  const storyPoints =
-    rawPoints === null || rawPoints === undefined || rawPoints === '' ? '' : Number(rawPoints);
+  let storyPoints = '';
+  if (rawPoints !== null && rawPoints !== undefined && rawPoints !== '') {
+    const parsed = Number(rawPoints);
+    if (Number.isFinite(parsed)) storyPoints = parsed;
+  }
 
   const row = {
     key,

--- a/.agents/skills/jira-get-historical-items/scripts/lib/jira-auth.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/jira-auth.mjs
@@ -87,7 +87,7 @@ export function resolveJiraAuth(options = {}) {
 
   if (!email || !token) {
     throw new Error(
-      'Missing Jira API credentials for fetch-historical-items.mjs.\n' +
+      'Missing Jira API credentials.\n' +
         'Provide credentials using one of:\n' +
         '  • --env-file ~/.config/jira-fetch.env\n' +
         '  • export JIRA_EMAIL and JIRA_API_TOKEN\n' +

--- a/.agents/skills/jira-get-historical-items/scripts/lib/jira-auth.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/jira-auth.mjs
@@ -1,0 +1,116 @@
+/**
+ * Jira REST auth: CLI flags → env vars → optional env file.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { homedir } from 'os';
+import { resolve } from 'path';
+
+const SITE_ENV_KEYS = ['JIRA_SITE', 'ATLASSIAN_SITE'];
+const EMAIL_ENV_KEYS = ['JIRA_EMAIL', 'ATLASSIAN_EMAIL'];
+const TOKEN_ENV_KEYS = ['JIRA_API_TOKEN', 'ATLASSIAN_API_TOKEN', 'JIRA_TOKEN'];
+
+function expandHome(pathValue) {
+  if (!pathValue) return pathValue;
+  return pathValue.startsWith('~/') ? resolve(homedir(), pathValue.slice(2)) : pathValue;
+}
+
+function firstEnv(keys) {
+  for (const key of keys) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+/**
+ * @param {string} pathValue
+ */
+function loadEnvFile(pathValue) {
+  const resolved = resolve(expandHome(pathValue));
+  if (!existsSync(resolved)) {
+    throw new Error(`Env file not found: ${resolved}`);
+  }
+
+  const vars = {};
+  for (const line of readFileSync(resolved, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    vars[key] = value;
+  }
+  return vars;
+}
+
+function pickFromMap(map, keys) {
+  for (const key of keys) {
+    const value = map[key]?.trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+/**
+ * @param {{
+ *   site?: string,
+ *   email?: string,
+ *   token?: string,
+ *   envFile?: string,
+ * }} options
+ * @returns {{ site: string, email: string, token: string, baseUrl: string }}
+ */
+export function resolveJiraAuth(options = {}) {
+  const fromEnvFile = options.envFile ? loadEnvFile(options.envFile) : {};
+
+  const site =
+    options.site?.trim() ||
+    firstEnv(SITE_ENV_KEYS) ||
+    pickFromMap(fromEnvFile, SITE_ENV_KEYS) ||
+    'redhat.atlassian.net';
+
+  const email =
+    options.email?.trim() || firstEnv(EMAIL_ENV_KEYS) || pickFromMap(fromEnvFile, EMAIL_ENV_KEYS);
+
+  const token =
+    options.token?.trim() || firstEnv(TOKEN_ENV_KEYS) || pickFromMap(fromEnvFile, TOKEN_ENV_KEYS);
+
+  const normalizedSite = site.replace(/^https?:\/\//, '').replace(/\/$/, '');
+
+  if (!email || !token) {
+    throw new Error(
+      'Missing Jira API credentials for fetch-historical-items.mjs.\n' +
+        'Provide credentials using one of:\n' +
+        '  • --env-file ~/.config/jira-fetch.env\n' +
+        '  • export JIRA_EMAIL and JIRA_API_TOKEN\n' +
+        'See jira-get-historical-items/CLI.md (First-time setup)'
+    );
+  }
+
+  return {
+    site: normalizedSite,
+    email,
+    token,
+    baseUrl: `https://${normalizedSite}`,
+  };
+}
+
+/**
+ * @param {{ email: string, token: string }} auth
+ */
+export function jiraAuthHeaders(auth) {
+  const encoded = Buffer.from(`${auth.email}:${auth.token}`).toString('base64');
+  return {
+    Authorization: `Basic ${encoded}`,
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/jira-fetch.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/jira-fetch.mjs
@@ -144,16 +144,26 @@ export async function fetchIssueWithChangelog(auth, issueKey, fields) {
 export async function mapPool(items, concurrency, fn) {
   const results = new Array(items.length);
   let nextIndex = 0;
+  let failed = false;
+  let firstError = null;
 
   async function worker() {
     while (nextIndex < items.length) {
+      if (failed) return;
       const index = nextIndex++;
-      results[index] = await fn(items[index], index);
+      try {
+        results[index] = await fn(items[index], index);
+      } catch (err) {
+        failed = true;
+        firstError = err;
+        return;
+      }
     }
   }
 
   const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
   await Promise.all(workers);
+  if (firstError) throw firstError;
   return results;
 }
 

--- a/.agents/skills/jira-get-historical-items/scripts/lib/jira-fetch.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/jira-fetch.mjs
@@ -1,0 +1,162 @@
+import { jiraAuthHeaders } from './jira-auth.mjs';
+
+const DEFAULT_FIELDS = ['summary', 'description', 'status', 'resolution', 'issuetype', 'created'];
+
+/**
+ * @param {Response} res
+ * @param {string} context
+ */
+async function readJsonOrThrow(res, context) {
+  const text = await res.text();
+  if (!res.ok) {
+    let detail = text;
+    try {
+      const parsed = JSON.parse(text);
+      detail = parsed.errorMessages?.join('; ') || parsed.message || text;
+    } catch {
+      // keep raw text
+    }
+    throw new Error(`${context}: HTTP ${res.status} — ${detail}`);
+  }
+  return text ? JSON.parse(text) : null;
+}
+
+/**
+ * @param {object} auth
+ * @param {string} jql
+ * @param {string[]} fields
+ * @param {number} [maxResults]
+ */
+export async function searchIssueKeys(auth, jql, fields, maxResults = 100) {
+  const keys = [];
+  const pageSize = Math.min(maxResults, 100);
+  let nextPageToken;
+
+  while (keys.length < maxResults) {
+    const remaining = maxResults - keys.length;
+    const limit = Math.min(pageSize, remaining);
+
+    const body = {
+      jql,
+      maxResults: limit,
+      fields,
+    };
+    if (nextPageToken) {
+      body.nextPageToken = nextPageToken;
+    }
+
+    const res = await fetch(`${auth.baseUrl}/rest/api/3/search/jql`, {
+      method: 'POST',
+      headers: jiraAuthHeaders(auth),
+      body: JSON.stringify(body),
+    });
+
+    const data = await readJsonOrThrow(res, 'JQL search');
+    const issues = data.issues ?? [];
+
+    for (const issue of issues) {
+      if (issue.key) keys.push(issue.key);
+    }
+
+    if (issues.length === 0 || keys.length >= maxResults) {
+      break;
+    }
+
+    nextPageToken = data.nextPageToken;
+    if (!nextPageToken) break;
+  }
+
+  return keys;
+}
+
+/**
+ * @param {object} auth
+ * @param {string} issueKey
+ */
+async function fetchChangelogPage(auth, issueKey, startAt, maxResults = 100) {
+  const url = new URL(`${auth.baseUrl}/rest/api/3/issue/${issueKey}/changelog`);
+  url.searchParams.set('startAt', String(startAt));
+  url.searchParams.set('maxResults', String(maxResults));
+
+  const res = await fetch(url, { headers: jiraAuthHeaders(auth) });
+  return readJsonOrThrow(res, `changelog for ${issueKey}`);
+}
+
+/**
+ * @param {object} auth
+ * @param {string} issueKey
+ */
+async function fetchFullChangelog(auth, issueKey) {
+  const first = await fetchChangelogPage(auth, issueKey, 0);
+  const histories = [...(first.values ?? [])];
+  const total = first.total ?? histories.length;
+
+  for (let startAt = histories.length; startAt < total; startAt += first.maxResults ?? 100) {
+    const page = await fetchChangelogPage(auth, issueKey, startAt);
+    histories.push(...(page.values ?? []));
+  }
+
+  return {
+    startAt: 0,
+    maxResults: histories.length,
+    total,
+    histories,
+  };
+}
+
+/**
+ * @param {object} auth
+ * @param {string} issueKey
+ * @param {string[]} fields
+ */
+export async function fetchIssueWithChangelog(auth, issueKey, fields) {
+  const url = new URL(`${auth.baseUrl}/rest/api/3/issue/${issueKey}`);
+  url.searchParams.set('expand', 'changelog');
+  url.searchParams.set('fields', fields.join(','));
+
+  const res = await fetch(url, { headers: jiraAuthHeaders(auth) });
+  const issue = await readJsonOrThrow(res, `issue ${issueKey}`);
+
+  const expanded = issue.changelog;
+  const needsMore =
+    expanded &&
+    typeof expanded.total === 'number' &&
+    Array.isArray(expanded.histories) &&
+    expanded.total > expanded.histories.length;
+
+  if (needsMore || !expanded?.histories?.length) {
+    issue.changelog = await fetchFullChangelog(auth, issueKey);
+  }
+
+  return {
+    key: issue.key,
+    fields: issue.fields,
+    changelog: issue.changelog,
+  };
+}
+
+/**
+ * @template T
+ * @param {T[]} items
+ * @param {number} concurrency
+ * @param {(item: T, index: number) => Promise<unknown>} fn
+ */
+export async function mapPool(items, concurrency, fn) {
+  const results = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker() {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await fn(items[index], index);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+export function buildFieldList(storyPointsField) {
+  return [...DEFAULT_FIELDS, storyPointsField];
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/load-issues.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/load-issues.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from 'fs';
+
+/**
+ * Normalize CLI, MCP, or REST issue JSON into an array of issue objects.
+ */
+export function loadIssuesFromJson(parsed) {
+  if (Array.isArray(parsed)) return parsed;
+  if (Array.isArray(parsed?.issues)) return parsed.issues;
+  if (parsed?.key && parsed?.fields) return [parsed];
+  throw new Error(
+    'Expected a JSON array of Jira issues, { issues: [...] }, or a single issue object'
+  );
+}
+
+export function readIssuesFromPath(path) {
+  return loadIssuesFromJson(JSON.parse(readFileSync(path, 'utf8')));
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/load-issues.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/load-issues.mjs
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { readJsonFile } from './read-json.mjs';
 
 /**
  * Normalize CLI, MCP, or REST issue JSON into an array of issue objects.
@@ -13,5 +13,5 @@ export function loadIssuesFromJson(parsed) {
 }
 
 export function readIssuesFromPath(path) {
-  return loadIssuesFromJson(JSON.parse(readFileSync(path, 'utf8')));
+  return loadIssuesFromJson(readJsonFile(path));
 }

--- a/.agents/skills/jira-get-historical-items/scripts/lib/metrics.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/metrics.mjs
@@ -1,0 +1,49 @@
+export function parseDate(iso) {
+  const d = new Date(iso);
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+export function formatDate(d) {
+  if (!d) return '';
+  return d.toISOString().slice(0, 10);
+}
+
+export function businessDaysBetween(start, end) {
+  if (!start || !end) return null;
+  let count = 0;
+  const cur = new Date(start);
+  const last = new Date(end);
+  while (cur <= last) {
+    const day = cur.getUTCDay();
+    if (day !== 0 && day !== 6) count++;
+    cur.setUTCDate(cur.getUTCDate() + 1);
+  }
+  return count;
+}
+
+/** PERCENTILE.INC-style linear interpolation */
+export function percentile(sorted, p) {
+  if (sorted.length === 0) return null;
+  if (sorted.length === 1) return sorted[0];
+  const index = (sorted.length - 1) * p;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) return sorted[lower];
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * (index - lower);
+}
+
+export function adfToText(node) {
+  if (node == null) return '';
+  if (typeof node === 'string') return node;
+  if (node.type === 'text') return node.text ?? '';
+  if (node.type === 'hardBreak' || node.type === 'rule') return ' ';
+  const parts = (node.content ?? []).map(adfToText);
+  const sep = node.type === 'paragraph' || String(node.type).includes('heading') ? ' ' : '';
+  return parts.join(sep);
+}
+
+export function plainDescription(field) {
+  if (!field) return '';
+  if (typeof field === 'string') return field.trim();
+  return adfToText(field).replace(/\s+/g, ' ').trim();
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/paths.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/paths.mjs
@@ -1,0 +1,21 @@
+import { existsSync } from 'fs';
+import { dirname, isAbsolute, resolve } from 'path';
+
+export function resolvePath(pathValue, baseDir = process.cwd()) {
+  if (!pathValue) {
+    throw new Error('Missing required path argument');
+  }
+  return isAbsolute(pathValue) ? pathValue : resolve(baseDir, pathValue);
+}
+
+export function resolveInputPath(pathValue, baseDir = process.cwd()) {
+  const resolved = resolvePath(pathValue, baseDir);
+  if (!existsSync(resolved)) {
+    throw new Error(`Input file not found: ${resolved}`);
+  }
+  return resolved;
+}
+
+export function defaultWorkspaceDir(inputPath) {
+  return dirname(resolvePath(inputPath));
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/process.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/process.mjs
@@ -1,0 +1,15 @@
+import { analyzeHistoricalItem } from './analyze.mjs';
+
+export function processHistoricalIssues(issues, storyPointsFieldId = 'customfield_10028') {
+  const rows = issues
+    .map((issue) => analyzeHistoricalItem(issue, storyPointsFieldId))
+    .filter(Boolean);
+
+  rows.sort((a, b) => {
+    const na = Number(a.key.split('-')[1]);
+    const nb = Number(b.key.split('-')[1]);
+    return na - nb;
+  });
+
+  return rows;
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/process.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/process.mjs
@@ -6,9 +6,10 @@ export function processHistoricalIssues(issues, storyPointsFieldId = 'customfiel
     .filter(Boolean);
 
   rows.sort((a, b) => {
-    const na = Number(a.key.split('-')[1]);
-    const nb = Number(b.key.split('-')[1]);
-    return na - nb;
+    const na = Number(a.key.split('-').pop());
+    const nb = Number(b.key.split('-').pop());
+    if (Number.isFinite(na) && Number.isFinite(nb) && na !== nb) return na - nb;
+    return a.key.localeCompare(b.key);
   });
 
   return rows;

--- a/.agents/skills/jira-get-historical-items/scripts/lib/read-json.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/read-json.mjs
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs';
+
+/**
+ * @param {string | number | import('fs').PathLike} path
+ * @param {{ label?: string }} [options]
+ */
+export function readJsonFile(path, { label = String(path) } = {}) {
+  let raw;
+  try {
+    raw = readFileSync(path, 'utf8');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Failed to read input file: ${label} — ${message}`);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`Invalid JSON in input file: ${label} — ${message}`);
+  }
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/report.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/report.mjs
@@ -1,0 +1,37 @@
+import { buildCycleTimeData } from './summarize.mjs';
+
+export const REPORT_VERSION = 1;
+export const JIRA_SITE = 'redhat.atlassian.net';
+
+/**
+ * @param {object} options
+ * @param {string} options.jql
+ * @param {object[]} options.issues Raw fetch issues (for counts)
+ * @param {object[]} options.rows Processed historical item rows
+ * @param {string} [options.storyPointsField]
+ * @param {string} [options.runAt] ISO 8601 timestamp
+ */
+export function buildHistoricalReport({
+  jql = '',
+  issues,
+  rows,
+  storyPointsField = 'customfield_10028',
+  runAt = new Date().toISOString(),
+}) {
+  return {
+    version: REPORT_VERSION,
+    runAt,
+    jql,
+    meta: {
+      site: JIRA_SITE,
+      storyPointsField,
+      counts: {
+        fetched: issues.length,
+        included: rows.length,
+        skipped: issues.length - rows.length,
+      },
+    },
+    items: rows,
+    cycleTime: buildCycleTimeData(rows),
+  };
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/report.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/report.mjs
@@ -16,19 +16,24 @@ export function buildHistoricalReport({
   issues,
   rows,
   storyPointsField = 'customfield_10028',
+  site = JIRA_SITE,
+  maxResults = 100,
   runAt = new Date().toISOString(),
 }) {
+  const fetched = issues.length;
   return {
     version: REPORT_VERSION,
     runAt,
     jql,
     meta: {
-      site: JIRA_SITE,
+      site,
       storyPointsField,
       counts: {
-        fetched: issues.length,
+        fetched,
         included: rows.length,
-        skipped: issues.length - rows.length,
+        skipped: fetched - rows.length,
+        maxResults,
+        fetchCapHit: fetched >= maxResults,
       },
     },
     items: rows,

--- a/.agents/skills/jira-get-historical-items/scripts/lib/run-report.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/run-report.mjs
@@ -1,0 +1,63 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { processHistoricalIssues } from './process.mjs';
+import { buildHistoricalReport } from './report.mjs';
+import { buildSummaryReport } from './summarize.mjs';
+import { defaultWorkspaceDir, resolvePath } from './paths.mjs';
+import { validateFetchIssues } from './validate-fetch.mjs';
+
+/**
+ * @param {object} options
+ * @param {string} options.inputPath Resolved absolute path to fetch JSON
+ * @param {string} [options.workspace] Workspace directory for report output
+ * @param {string} [options.jql]
+ * @param {string} [options.storyPointsField]
+ * @param {string} [options.reportOutput]
+ * @param {boolean} [options.stdout]
+ * @param {object[]} [options.issues] Pre-validated issues (skips read/parse when set)
+ * @returns {{ reportPath: string, report: object, issues: object[], rows: object[] }}
+ */
+export function runHistoricalReport({
+  inputPath,
+  workspace,
+  jql = '',
+  storyPointsField = 'customfield_10028',
+  reportOutput,
+  stdout = false,
+  issues: issuesOverride,
+}) {
+  const workspaceDir = workspace ? resolvePath(workspace) : defaultWorkspaceDir(inputPath);
+
+  const reportPath = reportOutput
+    ? resolvePath(reportOutput, workspaceDir)
+    : join(workspaceDir, '.jira-historical-report.json');
+
+  const issues = issuesOverride ?? validateFetchIssues(JSON.parse(readFileSync(inputPath, 'utf8')));
+  const rows = processHistoricalIssues(issues, storyPointsField);
+  const report = buildHistoricalReport({
+    jql,
+    issues,
+    rows,
+    storyPointsField,
+  });
+
+  const reportJson = JSON.stringify(report, null, 2);
+  writeFileSync(reportPath, reportJson);
+
+  console.error(
+    `Processed ${issues.length} issue(s); ${rows.length} with resolution Done (skipped ${issues.length - rows.length}).`
+  );
+  console.error(`Wrote ${reportPath}`);
+
+  if (stdout) {
+    console.log(reportJson);
+    console.log('---CYCLE_TIME_SUMMARY---');
+    if (report.cycleTime) {
+      console.log(buildSummaryReport(rows));
+    } else {
+      console.log('No items with measurable cycle time — summary not produced.');
+    }
+  }
+
+  return { reportPath, report, issues, rows };
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/run-report.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/run-report.mjs
@@ -1,10 +1,20 @@
-import { readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join, resolve, sep, dirname } from 'path';
 import { processHistoricalIssues } from './process.mjs';
 import { buildHistoricalReport } from './report.mjs';
 import { buildSummaryReport } from './summarize.mjs';
 import { defaultWorkspaceDir, resolvePath } from './paths.mjs';
+import { readJsonFile } from './read-json.mjs';
 import { validateFetchIssues } from './validate-fetch.mjs';
+
+function assertPathWithinWorkspace(resolvedPath, workspaceDir) {
+  const workspaceRoot = resolve(workspaceDir);
+  const target = resolve(resolvedPath);
+  const prefix = workspaceRoot.endsWith(sep) ? workspaceRoot : `${workspaceRoot}${sep}`;
+  if (target !== workspaceRoot && !target.startsWith(prefix)) {
+    throw new Error(`Report output must stay within workspace: ${workspaceRoot}`);
+  }
+}
 
 /**
  * @param {object} options
@@ -14,6 +24,8 @@ import { validateFetchIssues } from './validate-fetch.mjs';
  * @param {string} [options.storyPointsField]
  * @param {string} [options.reportOutput]
  * @param {boolean} [options.stdout]
+ * @param {string} [options.site]
+ * @param {number} [options.maxResults]
  * @param {object[]} [options.issues] Pre-validated issues (skips read/parse when set)
  * @returns {{ reportPath: string, report: object, issues: object[], rows: object[] }}
  */
@@ -22,6 +34,8 @@ export function runHistoricalReport({
   workspace,
   jql = '',
   storyPointsField = 'customfield_10028',
+  site,
+  maxResults = 100,
   reportOutput,
   stdout = false,
   issues: issuesOverride,
@@ -32,16 +46,21 @@ export function runHistoricalReport({
     ? resolvePath(reportOutput, workspaceDir)
     : join(workspaceDir, '.jira-historical-report.json');
 
-  const issues = issuesOverride ?? validateFetchIssues(JSON.parse(readFileSync(inputPath, 'utf8')));
+  assertPathWithinWorkspace(reportPath, workspaceDir);
+
+  const issues = issuesOverride ?? validateFetchIssues(readJsonFile(inputPath));
   const rows = processHistoricalIssues(issues, storyPointsField);
   const report = buildHistoricalReport({
     jql,
     issues,
     rows,
     storyPointsField,
+    site,
+    maxResults,
   });
 
   const reportJson = JSON.stringify(report, null, 2);
+  mkdirSync(dirname(reportPath), { recursive: true });
   writeFileSync(reportPath, reportJson);
 
   console.error(

--- a/.agents/skills/jira-get-historical-items/scripts/lib/stats.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/stats.mjs
@@ -1,0 +1,512 @@
+import { percentile } from './metrics.mjs';
+import {
+  buildCycleTimeData,
+  buildP75ByStoryPoints,
+  hasCycleTime,
+  itemsWithCycleTime,
+  normalizeIssueType,
+  pointSizes,
+  roundDays,
+} from './summarize.mjs';
+
+const JIRA_SITE = 'redhat.atlassian.net';
+const FETCH_CAP = 100;
+
+const CYCLE_TIME_BUCKETS = [
+  { label: '0–3 days', min: 0, max: 3 },
+  { label: '4–7 days', min: 4, max: 7 },
+  { label: '8–14 days', min: 8, max: 14 },
+  { label: '15+ days', min: 15, max: Infinity },
+];
+
+function dateRangeFrom(values) {
+  const dates = values.filter(Boolean).sort();
+  if (dates.length === 0) return null;
+  return { earliest: dates[0], latest: dates[dates.length - 1] };
+}
+
+function formatDateOnly(iso) {
+  if (!iso) return '';
+  return String(iso).slice(0, 10);
+}
+
+function isPointed(item) {
+  const points = item.storyPoints;
+  return points !== '' && points != null && !Number.isNaN(Number(points));
+}
+
+function cycleTimeValues(items) {
+  return itemsWithCycleTime(items)
+    .map((item) => item.cycleTime)
+    .sort((a, b) => a - b);
+}
+
+function distributionStats(items) {
+  const values = cycleTimeValues(items);
+  if (values.length === 0) return null;
+  return {
+    count: values.length,
+    min: roundDays(values[0]),
+    p50: roundDays(percentile(values, 0.5)),
+    p75: roundDays(percentile(values, 0.75)),
+    p90: roundDays(percentile(values, 0.9)),
+    max: roundDays(values[values.length - 1]),
+  };
+}
+
+function bucketCounts(items) {
+  const withCycle = itemsWithCycleTime(items);
+  return CYCLE_TIME_BUCKETS.map(({ label, min, max }) => ({
+    label,
+    count: withCycle.filter((item) => item.cycleTime >= min && item.cycleTime <= max).length,
+  })).filter((bucket) => bucket.count > 0);
+}
+
+function countByType(items) {
+  const counts = {};
+  for (const item of items) {
+    const type = item.issueType || 'Unknown';
+    counts[type] = (counts[type] ?? 0) + 1;
+  }
+  return counts;
+}
+
+function countMatrix(items) {
+  const rows = new Map();
+  for (const item of items) {
+    const type = item.issueType || 'Unknown';
+    const points = isPointed(item) ? Number(item.storyPoints) : 'unpointed';
+    const key = `${type}\0${points}`;
+    rows.set(key, (rows.get(key) ?? 0) + 1);
+  }
+
+  return [...rows.entries()]
+    .map(([key, count]) => {
+      const [issueType, pointsRaw] = key.split('\0');
+      return {
+        issueType,
+        storyPoints: pointsRaw === 'unpointed' ? null : Number(pointsRaw),
+        count,
+      };
+    })
+    .sort((a, b) => {
+      const typeCmp = a.issueType.localeCompare(b.issueType);
+      if (typeCmp !== 0) return typeCmp;
+      if (a.storyPoints == null) return 1;
+      if (b.storyPoints == null) return -1;
+      return a.storyPoints - b.storyPoints;
+    });
+}
+
+function pointDistribution(items) {
+  const pointed = items.filter(isPointed);
+  const total = pointed.length;
+  if (total === 0) return [];
+
+  const counts = new Map();
+  for (const item of pointed) {
+    const points = Number(item.storyPoints);
+    counts.set(points, (counts.get(points) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .sort(([a], [b]) => a - b)
+    .map(([storyPoints, count]) => ({
+      storyPoints,
+      count,
+      percent: Math.round((count / total) * 1000) / 10,
+    }));
+}
+
+function throughputByMonth(items) {
+  const months = new Map();
+  for (const item of items) {
+    const month = item.completionDate?.slice(0, 7);
+    if (!month) continue;
+    const entry = months.get(month) ?? { month, closedCount: 0, storyPoints: 0 };
+    entry.closedCount += 1;
+    if (isPointed(item)) entry.storyPoints += Number(item.storyPoints);
+    months.set(month, entry);
+  }
+  return [...months.values()].sort((a, b) => a.month.localeCompare(b.month));
+}
+
+function p75ForItem(item, reportCycleTime) {
+  const type = normalizeIssueType(item.issueType);
+  const points = isPointed(item) ? Number(item.storyPoints) : null;
+  const percentiles = reportCycleTime?.percentiles ?? [];
+
+  if (points != null) {
+    const exact = percentiles.find(
+      (entry) =>
+        entry.group === 'issueTypeAndStoryPoints' &&
+        entry.issueType === type &&
+        entry.storyPoints === points
+    );
+    if (exact?.p75Days != null) return exact.p75Days;
+
+    const byPoints = percentiles.find(
+      (entry) => entry.group === 'storyPoints' && entry.storyPoints === points
+    );
+    if (byPoints?.p75Days != null) return byPoints.p75Days;
+  }
+
+  const byType = percentiles.find(
+    (entry) => entry.group === 'issueType' && entry.issueType === type
+  );
+  if (byType?.p75Days != null) return byType.p75Days;
+
+  const all = percentiles.find((entry) => entry.group === 'all');
+  return all?.p75Days ?? null;
+}
+
+function findOutliers(items, reportCycleTime) {
+  const outliers = [];
+  for (const item of items) {
+    if (!hasCycleTime(item)) continue;
+    const p75 = p75ForItem(item, reportCycleTime);
+    if (p75 == null || p75 <= 0) continue;
+    if (item.cycleTime <= p75 * 1.5) continue;
+
+    outliers.push({
+      key: item.key,
+      summary: item.summary,
+      issueType: item.issueType,
+      storyPoints: isPointed(item) ? Number(item.storyPoints) : null,
+      cycleTime: item.cycleTime,
+      p75Days: p75,
+      ratio: Math.round((item.cycleTime / p75) * 10) / 10,
+    });
+  }
+
+  return outliers.sort((a, b) => b.ratio - a.ratio);
+}
+
+function buildCreatedDateMap(issues) {
+  const map = new Map();
+  if (!Array.isArray(issues)) return map;
+
+  for (const issue of issues) {
+    let created = formatDateOnly(issue.fields?.created);
+    if (!created && issue.changelog?.histories?.length) {
+      const sorted = [...issue.changelog.histories].sort(
+        (a, b) => new Date(a.created) - new Date(b.created)
+      );
+      created = formatDateOnly(sorted[0]?.created);
+    }
+    if (issue.key && created) map.set(issue.key, created);
+  }
+  return map;
+}
+
+function buildItemRows(items, report, createdByKey) {
+  const site = report.meta?.site ?? JIRA_SITE;
+  const outliers = new Set(findOutliers(items, report.cycleTime).map((row) => row.key));
+
+  return items.map((item) => ({
+    key: item.key,
+    summary: item.summary,
+    issueType: item.issueType,
+    created: createdByKey.get(item.key) ?? '',
+    startDate: item.startDate ?? '',
+    completionDate: item.completionDate ?? '',
+    cycleTime: hasCycleTime(item) ? item.cycleTime : null,
+    storyPoints: isPointed(item) ? Number(item.storyPoints) : null,
+    outlier: outliers.has(item.key),
+    jiraUrl: `https://${site}/browse/${item.key}`,
+  }));
+}
+
+/**
+ * @param {object} report Parsed `.jira-historical-report.json`
+ * @param {object[]|null} [rawIssues] Optional fetch JSON for Jira `created` dates
+ */
+export function buildReportStats(report, rawIssues = null) {
+  const items = report.items ?? [];
+  const createdByKey = buildCreatedDateMap(rawIssues);
+  const createdDates = items.map((item) => createdByKey.get(item.key)).filter(Boolean);
+  const startDates = items.map((item) => item.startDate).filter(Boolean);
+  const completionDates = items.map((item) => item.completionDate).filter(Boolean);
+  const fetched = report.meta?.counts?.fetched ?? items.length;
+
+  const cycleTimeFromReport = report.cycleTime ?? buildCycleTimeData(items);
+  const distributionByType = {};
+  for (const type of new Set(items.map((item) => item.issueType || 'Unknown'))) {
+    const group = items.filter((item) => (item.issueType || 'Unknown') === type);
+    const stats = distributionStats(group);
+    if (stats) distributionByType[type] = stats;
+  }
+
+  const distributionByPoints = {};
+  for (const points of pointSizes(items)) {
+    const group = items.filter((item) => Number(item.storyPoints) === points);
+    const stats = distributionStats(group);
+    if (stats) distributionByPoints[points] = stats;
+  }
+
+  return {
+    version: 1,
+    runAt: new Date().toISOString(),
+    scope: {
+      jql: report.jql ?? '',
+      reportRunAt: report.runAt ?? '',
+      site: report.meta?.site ?? JIRA_SITE,
+      storyPointsField: report.meta?.storyPointsField ?? 'customfield_10028',
+    },
+    counts: {
+      fetched,
+      included: report.meta?.counts?.included ?? items.length,
+      skipped: report.meta?.counts?.skipped ?? 0,
+      inReport: items.length,
+      fetchCapWarning: fetched >= FETCH_CAP,
+    },
+    dateRanges: {
+      created: dateRangeFrom(createdDates),
+      workStarted: dateRangeFrom(startDates),
+      closed: dateRangeFrom(completionDates),
+    },
+    issueCounts: {
+      total: items.length,
+      byType: countByType(items),
+      byTypeAndPoints: countMatrix(items),
+      unpointed: items.filter((item) => !isPointed(item)).length,
+      pointed: items.filter(isPointed).length,
+    },
+    cycleTime: {
+      closedDateRange: cycleTimeFromReport?.closedDateRange ?? null,
+      percentiles: cycleTimeFromReport?.percentiles ?? [],
+      p75ByStoryPoints: buildP75ByStoryPoints(items),
+      distribution: {
+        all: distributionStats(items),
+        byType: distributionByType,
+        byPoints: distributionByPoints,
+      },
+      buckets: bucketCounts(items),
+    },
+    throughput: {
+      byMonth: throughputByMonth(items),
+      totalStoryPoints: items
+        .filter(isPointed)
+        .reduce((sum, item) => sum + Number(item.storyPoints), 0),
+    },
+    dataQuality: {
+      missingStartDate: items.filter((item) => !item.startDate).length,
+      missingCompletionDate: items.filter((item) => !item.completionDate).length,
+      missingCycleTime: items.filter((item) => !hasCycleTime(item)).length,
+      unpointed: items.filter((item) => !isPointed(item)).length,
+      hasCreatedDates: createdDates.length > 0,
+    },
+    pointDistribution: pointDistribution(items),
+    outliers: findOutliers(items, cycleTimeFromReport),
+    items: buildItemRows(items, report, createdByKey),
+  };
+}
+
+function formatDistribution(label, stats) {
+  if (!stats) return null;
+  return `${label} (${stats.count}): min ${stats.min}, p50 ${stats.p50}, p75 ${stats.p75}, p90 ${stats.p90}, max ${stats.max} days`;
+}
+
+function formatRange(label, range) {
+  if (!range) return `${label}: —`;
+  return `${label}: ${range.earliest} – ${range.latest}`;
+}
+
+function formatMatrix(byTypeAndPoints) {
+  const types = [...new Set(byTypeAndPoints.map((row) => row.issueType))].sort();
+  const pointCols = [
+    ...new Set(
+      byTypeAndPoints.map((row) =>
+        row.storyPoints == null ? 'unpointed' : String(row.storyPoints)
+      )
+    ),
+  ].sort((a, b) => {
+    if (a === 'unpointed') return 1;
+    if (b === 'unpointed') return -1;
+    return Number(a) - Number(b);
+  });
+
+  const lookup = new Map(
+    byTypeAndPoints.map((row) => [
+      `${row.issueType}\0${row.storyPoints == null ? 'unpointed' : String(row.storyPoints)}`,
+      row.count,
+    ])
+  );
+
+  const header = ['Type', ...pointCols, 'Total'].join(' | ');
+  const divider = ['---', ...pointCols.map(() => '---'), '---'].join(' | ');
+  const lines = [header, divider];
+
+  for (const type of types) {
+    let total = 0;
+    const cells = pointCols.map((col) => {
+      const count = lookup.get(`${type}\0${col}`) ?? 0;
+      total += count;
+      return String(count);
+    });
+    lines.push([type, ...cells, String(total)].join(' | '));
+  }
+
+  return lines.join('\n');
+}
+
+export function formatStatsReport(stats) {
+  const lines = [];
+
+  lines.push('# Jira historical stats');
+  lines.push('');
+  lines.push(`Report generated: ${stats.runAt}`);
+  if (stats.scope.reportRunAt) lines.push(`Source report: ${stats.scope.reportRunAt}`);
+  lines.push('');
+
+  lines.push('## Scope');
+  lines.push('');
+  lines.push('```text');
+  lines.push(stats.scope.jql || '(no JQL recorded)');
+  lines.push('```');
+  lines.push('');
+  lines.push(
+    `Fetched **${stats.counts.fetched}**; included **${stats.counts.included}** (resolution Done); skipped **${stats.counts.skipped}**.`
+  );
+  if (stats.counts.fetchCapWarning) {
+    lines.push('');
+    lines.push(
+      '**Warning:** Fetch hit the 100-issue cap — results may be incomplete. Narrow JQL or raise `--max-results`.'
+    );
+  }
+
+  lines.push('');
+  lines.push('## Date ranges');
+  lines.push('');
+  lines.push(formatRange('Created (Jira)', stats.dateRanges.created));
+  lines.push(formatRange('Work started (left To Do)', stats.dateRanges.workStarted));
+  lines.push(formatRange('Closed', stats.dateRanges.closed));
+
+  lines.push('');
+  lines.push('## Issue counts');
+  lines.push('');
+  lines.push(
+    `Total in report: **${stats.issueCounts.total}** (${stats.issueCounts.pointed} pointed, ${stats.issueCounts.unpointed} unpointed)`
+  );
+  lines.push('');
+  for (const [type, count] of Object.entries(stats.issueCounts.byType).sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    lines.push(`- ${type}: ${count}`);
+  }
+
+  lines.push('');
+  lines.push('### By type and story points');
+  lines.push('');
+  lines.push(formatMatrix(stats.issueCounts.byTypeAndPoints));
+
+  lines.push('');
+  lines.push('## Cycle time');
+  lines.push('');
+  const allDist = formatDistribution('All items', stats.cycleTime.distribution.all);
+  if (allDist) lines.push(allDist);
+
+  for (const [type, dist] of Object.entries(stats.cycleTime.distribution.byType).sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    const line = formatDistribution(type, dist);
+    if (line) lines.push(line);
+  }
+
+  if (stats.cycleTime.buckets.length > 0) {
+    lines.push('');
+    lines.push('### Distribution buckets');
+    for (const bucket of stats.cycleTime.buckets) {
+      lines.push(`- ${bucket.label}: ${bucket.count}`);
+    }
+  }
+
+  if (stats.cycleTime.percentiles.length > 0 || stats.cycleTime.p75ByStoryPoints?.length > 0) {
+    lines.push('');
+    lines.push('### 75th percentile groups');
+    lines.push('');
+
+    for (const entry of stats.cycleTime.percentiles) {
+      if (entry.group !== 'all' && entry.group !== 'issueType') continue;
+      lines.push(`- ${entry.label} (${entry.count}): ${entry.p75Days} days`);
+    }
+
+    if (stats.cycleTime.p75ByStoryPoints?.length > 0) {
+      lines.push('');
+      for (const group of stats.cycleTime.p75ByStoryPoints) {
+        lines.push(group.label);
+        for (const key of ['all', 'stories', 'tasks', 'bugs']) {
+          const entry = group.breakdown[key];
+          if (!entry) continue;
+          lines.push(`  - ${entry.label}: ${entry.p75Days} days`);
+        }
+        lines.push('');
+      }
+    }
+  }
+
+  if (stats.throughput.byMonth.length > 0) {
+    lines.push('');
+    lines.push('## Throughput by month');
+    lines.push('');
+    for (const row of stats.throughput.byMonth) {
+      lines.push(`- ${row.month}: ${row.closedCount} closed, ${row.storyPoints} story points`);
+    }
+    lines.push(`- **Total story points delivered:** ${stats.throughput.totalStoryPoints}`);
+  }
+
+  if (stats.pointDistribution.length > 0) {
+    lines.push('');
+    lines.push('## Point distribution');
+    lines.push('');
+    for (const row of stats.pointDistribution) {
+      lines.push(`- ${row.storyPoints} points: ${row.count} (${row.percent}%)`);
+    }
+  }
+
+  lines.push('');
+  lines.push('## Data quality');
+  lines.push('');
+  lines.push(`- Missing work-start date: ${stats.dataQuality.missingStartDate}`);
+  lines.push(`- Missing completion date: ${stats.dataQuality.missingCompletionDate}`);
+  lines.push(`- Missing cycle time: ${stats.dataQuality.missingCycleTime}`);
+  lines.push(`- Unpointed: ${stats.dataQuality.unpointed}`);
+  if (!stats.dataQuality.hasCreatedDates) {
+    lines.push('- Created dates: not available (pass `--issues-input` for Jira created range)');
+  }
+
+  if (stats.outliers.length > 0) {
+    lines.push('');
+    lines.push('## Outliers (>1.5× group p75)');
+    lines.push('');
+    for (const row of stats.outliers.slice(0, 10)) {
+      const points = row.storyPoints == null ? 'unpointed' : `${row.storyPoints}pt`;
+      lines.push(
+        `- ${row.key} (${points}): ${row.cycleTime} days vs p75 ${row.p75Days} (${row.ratio}×)`
+      );
+    }
+    if (stats.outliers.length > 10) {
+      lines.push(`- … and ${stats.outliers.length - 10} more (see JSON items table)`);
+    }
+  }
+
+  lines.push('');
+  lines.push(`## Items (${stats.items.length})`);
+  lines.push('');
+  lines.push('| Key | Type | Pts | Created | Started | Closed | Cycle | Outlier | Summary |');
+  lines.push('| --- | --- | ---: | --- | --- | --- | ---: | --- | --- |');
+  for (const item of stats.items) {
+    const pts = item.storyPoints == null ? '—' : String(item.storyPoints);
+    const cycle = item.cycleTime == null ? '—' : String(item.cycleTime);
+    const outlier = item.outlier ? 'yes' : '';
+    const summary = String(item.summary ?? '')
+      .replace(/\|/g, '\\|')
+      .replace(/\n/g, ' ')
+      .slice(0, 80);
+    lines.push(
+      `| [${item.key}](${item.jiraUrl}) | ${item.issueType} | ${pts} | ${item.created || '—'} | ${item.startDate || '—'} | ${item.completionDate || '—'} | ${cycle} | ${outlier} | ${summary} |`
+    );
+  }
+
+  return lines.join('\n');
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/stats.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/stats.mjs
@@ -258,7 +258,9 @@ export function buildReportStats(report, rawIssues = null) {
       included: report.meta?.counts?.included ?? items.length,
       skipped: report.meta?.counts?.skipped ?? 0,
       inReport: items.length,
-      fetchCapWarning: fetched >= FETCH_CAP,
+      fetchCapWarning:
+        report.meta?.counts?.fetchCapHit ??
+        fetched >= (report.meta?.counts?.maxResults ?? FETCH_CAP),
     },
     dateRanges: {
       created: dateRangeFrom(createdDates),
@@ -371,7 +373,7 @@ export function formatStatsReport(stats) {
   if (stats.counts.fetchCapWarning) {
     lines.push('');
     lines.push(
-      '**Warning:** Fetch hit the 100-issue cap — results may be incomplete. Narrow JQL or raise `--max-results`.'
+      '**Warning:** Fetch hit the issue cap — results may be incomplete. Narrow JQL or raise `--max-results`.'
     );
   }
 

--- a/.agents/skills/jira-get-historical-items/scripts/lib/summarize.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/summarize.mjs
@@ -1,0 +1,224 @@
+import { percentile } from './metrics.mjs';
+
+const CYCLE_TIME_PERCENTILE = 0.75;
+
+const ISSUE_TYPE_SECTIONS = [
+  { label: 'STORIES', match: (t) => t === 'story' },
+  { label: 'TASKS', match: (t) => t === 'task' },
+];
+
+const ALL_TYPE_LINES = [
+  { label: 'All items', match: () => true },
+  { label: 'All stories', match: (t) => t === 'story' },
+  { label: 'All bugs', match: (t) => t === 'bug' },
+  { label: 'All tasks', match: (t) => t === 'task' },
+];
+
+export function hasCycleTime(item) {
+  return typeof item.cycleTime === 'number' && !Number.isNaN(item.cycleTime);
+}
+
+export function itemsWithCycleTime(items) {
+  return items.filter(hasCycleTime);
+}
+
+export function percentileCycleTime(items, p = CYCLE_TIME_PERCENTILE) {
+  const values = itemsWithCycleTime(items)
+    .map((item) => item.cycleTime)
+    .sort((a, b) => a - b);
+  if (values.length === 0) return null;
+  return percentile(values, p);
+}
+
+export function closedDateRange(items) {
+  const dates = items
+    .map((item) => item.completionDate)
+    .filter(Boolean)
+    .sort();
+  if (dates.length === 0) return null;
+  return { earliest: dates[0], latest: dates[dates.length - 1] };
+}
+
+export function normalizeIssueType(issueType) {
+  return String(issueType ?? '')
+    .trim()
+    .toLowerCase();
+}
+
+export function pointSizes(items) {
+  const sizes = new Set();
+  for (const item of items) {
+    if (item.storyPoints === '' || item.storyPoints == null) continue;
+    const points = Number(item.storyPoints);
+    if (!Number.isNaN(points)) sizes.add(points);
+  }
+  return [...sizes].sort((a, b) => b - a);
+}
+
+export function roundDays(value) {
+  if (value == null) return null;
+  return Math.round(value * 10) / 10;
+}
+
+export function formatDays(value) {
+  if (value == null) return '—';
+  const rounded = roundDays(value);
+  return Number.isInteger(rounded) ? `${rounded} days` : `${rounded.toFixed(1)} days`;
+}
+
+function cycleTimeEntry(items, base) {
+  const withCycle = itemsWithCycleTime(items);
+  const p75 = percentileCycleTime(withCycle);
+  if (withCycle.length === 0) return null;
+  return { ...base, count: withCycle.length, p75Days: roundDays(p75) };
+}
+
+function formatLine(label, items) {
+  const withCycle = itemsWithCycleTime(items);
+  const p75 = percentileCycleTime(withCycle);
+  if (withCycle.length === 0) return null;
+  return `${label} (${withCycle.length}): ${formatDays(p75)}`;
+}
+
+export function buildSummaryReport(items) {
+  const lines = [];
+  const range = closedDateRange(items);
+
+  if (range) {
+    lines.push(`Closed date range: ${range.earliest} - ${range.latest}`);
+  } else {
+    lines.push('Closed date range: —');
+  }
+  lines.push('Cycle time: 75th percentile (business days)');
+  lines.push('');
+
+  for (const { label, match } of ALL_TYPE_LINES) {
+    const group = items.filter((item) => match(normalizeIssueType(item.issueType)));
+    const line = formatLine(label, group);
+    if (line) lines.push(line);
+  }
+
+  const sizes = pointSizes(items);
+  if (sizes.length > 0) {
+    lines.push('');
+    const pointGroups = buildP75ByStoryPoints(items);
+    if (pointGroups.length > 0) {
+      lines.push(formatP75ByStoryPoints(pointGroups));
+    }
+  }
+
+  return lines.join('\n');
+}
+
+const ISSUE_TYPE_BY_LABEL = {
+  'All stories': 'story',
+  'All bugs': 'bug',
+  'All tasks': 'task',
+};
+
+const SECTION_ISSUE_TYPE = {
+  STORIES: 'story',
+  TASKS: 'task',
+};
+
+export function buildCycleTimeData(items) {
+  if (itemsWithCycleTime(items).length === 0) return null;
+
+  const range = closedDateRange(items);
+  const percentiles = [];
+
+  for (const { label, match } of ALL_TYPE_LINES) {
+    const group = items.filter((item) => match(normalizeIssueType(item.issueType)));
+    if (label === 'All items') {
+      const entry = cycleTimeEntry(group, { group: 'all', label });
+      if (entry) percentiles.push(entry);
+      continue;
+    }
+    const issueType = ISSUE_TYPE_BY_LABEL[label];
+    const entry = cycleTimeEntry(group, { group: 'issueType', issueType, label });
+    if (entry) percentiles.push(entry);
+  }
+
+  const sizes = pointSizes(items);
+  for (const points of sizes) {
+    const group = items.filter((item) => Number(item.storyPoints) === points);
+    const entry = cycleTimeEntry(group, {
+      group: 'storyPoints',
+      storyPoints: points,
+      label: `All ${points} point items`,
+    });
+    if (entry) percentiles.push(entry);
+  }
+
+  for (const { label, match } of ISSUE_TYPE_SECTIONS) {
+    const issueType = SECTION_ISSUE_TYPE[label];
+    const typeItems = items.filter((item) => match(normalizeIssueType(item.issueType)));
+    for (const points of pointSizes(typeItems)) {
+      const group = typeItems.filter((item) => Number(item.storyPoints) === points);
+      const pointLabel = points === 1 ? '1 point item' : `${points} point items`;
+      const entry = cycleTimeEntry(group, {
+        group: 'issueTypeAndStoryPoints',
+        issueType,
+        storyPoints: points,
+        label: pointLabel,
+      });
+      if (entry) percentiles.push(entry);
+    }
+  }
+
+  return {
+    closedDateRange: range ? { earliest: range.earliest, latest: range.latest } : null,
+    percentiles,
+  };
+}
+
+const P75_TYPE_BREAKDOWNS = [
+  { key: 'all', label: 'all', match: () => true },
+  { key: 'stories', label: 'stories', match: (t) => t === 'story' },
+  { key: 'tasks', label: 'tasks', match: (t) => t === 'task' },
+  { key: 'bugs', label: 'bugs', match: (t) => t === 'bug' },
+];
+
+/**
+ * p75 cycle time grouped by story points, with all/stories/tasks/bugs breakdown per size.
+ */
+export function buildP75ByStoryPoints(items) {
+  const groups = [];
+
+  for (const points of pointSizes(items)) {
+    const pointItems = items.filter((item) => Number(item.storyPoints) === points);
+    const breakdown = {};
+
+    for (const { key, label, match } of P75_TYPE_BREAKDOWNS) {
+      const group = pointItems.filter((item) => match(normalizeIssueType(item.issueType)));
+      const withCycle = itemsWithCycleTime(group);
+      const p75 = percentileCycleTime(withCycle);
+      if (withCycle.length === 0) continue;
+      breakdown[key] = { label, count: withCycle.length, p75Days: roundDays(p75) };
+    }
+
+    if (Object.keys(breakdown).length === 0) continue;
+
+    groups.push({
+      storyPoints: points,
+      label: points === 1 ? '1 point item' : `${points} point items`,
+      breakdown,
+    });
+  }
+
+  return groups;
+}
+
+function formatP75ByStoryPoints(groups) {
+  const lines = [];
+  for (const group of groups) {
+    lines.push(group.label);
+    for (const key of ['all', 'stories', 'tasks', 'bugs']) {
+      const entry = group.breakdown[key];
+      if (!entry) continue;
+      lines.push(`  - ${entry.label}: ${entry.p75Days} days`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd();
+}

--- a/.agents/skills/jira-get-historical-items/scripts/lib/summarize.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/summarize.mjs
@@ -5,6 +5,7 @@ const CYCLE_TIME_PERCENTILE = 0.75;
 const ISSUE_TYPE_SECTIONS = [
   { label: 'STORIES', match: (t) => t === 'story' },
   { label: 'TASKS', match: (t) => t === 'task' },
+  { label: 'BUGS', match: (t) => t === 'bug' },
 ];
 
 const ALL_TYPE_LINES = [
@@ -34,7 +35,7 @@ export function closedDateRange(items) {
   const dates = items
     .map((item) => item.completionDate)
     .filter(Boolean)
-    .sort();
+    .sort((a, b) => new Date(a) - new Date(b));
   if (dates.length === 0) return null;
   return { earliest: dates[0], latest: dates[dates.length - 1] };
 }
@@ -119,6 +120,7 @@ const ISSUE_TYPE_BY_LABEL = {
 const SECTION_ISSUE_TYPE = {
   STORIES: 'story',
   TASKS: 'task',
+  BUGS: 'bug',
 };
 
 export function buildCycleTimeData(items) {

--- a/.agents/skills/jira-get-historical-items/scripts/lib/validate-fetch.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/lib/validate-fetch.mjs
@@ -1,0 +1,39 @@
+import { loadIssuesFromJson } from './load-issues.mjs';
+
+/**
+ * @param {unknown} parsed
+ * @returns {object[]}
+ */
+export function validateFetchIssues(parsed) {
+  let issues;
+  try {
+    issues = loadIssuesFromJson(parsed);
+  } catch (err) {
+    throw new Error(
+      `Expected a JSON array of Jira issues with changelog (or { issues: [...] }). ${err.message}`
+    );
+  }
+
+  const errors = [];
+  for (const issue of issues) {
+    const key = issue?.key ?? '(unknown)';
+    if (!issue?.key) {
+      errors.push('One issue is missing key');
+      continue;
+    }
+    if (!issue.fields) {
+      errors.push(`${key}: missing fields`);
+    }
+    if (!issue.changelog?.histories?.length) {
+      errors.push(
+        `${key}: missing changelog histories — fetch with expand=changelog (CLI script or MCP getJiraIssue)`
+      );
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid fetch JSON:\n- ${errors.join('\n- ')}`);
+  }
+
+  return issues;
+}

--- a/.agents/skills/jira-get-historical-items/scripts/process-historical-items.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/process-historical-items.mjs
@@ -10,11 +10,18 @@
  *        { "issues": [...] } from searchJiraIssuesUsingJql merged with changelogs.
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { writeFileSync } from 'fs';
 import { loadIssuesFromJson } from './lib/load-issues.mjs';
+import { readJsonFile } from './lib/read-json.mjs';
 import { resolveInputPath, resolvePath } from './lib/paths.mjs';
 import { processHistoricalIssues } from './lib/process.mjs';
 import { validateFetchIssues } from './lib/validate-fetch.mjs';
+
+function requireOptionValue(flag, next) {
+  if (!next || next.startsWith('-')) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+}
 
 function parseArgs(argv) {
   const opts = {
@@ -26,10 +33,19 @@ function parseArgs(argv) {
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     const next = argv[i + 1];
-    if (a === '--input' || a === '-i') ((opts.input = next), i++);
-    else if (a === '--output' || a === '-o') ((opts.output = next), i++);
-    else if (a === '--story-points-field') ((opts.storyPointsField = next), i++);
-    else if (a === '--help' || a === '-h') {
+    if (a === '--input' || a === '-i') {
+      requireOptionValue(a, next);
+      opts.input = next;
+      i++;
+    } else if (a === '--output' || a === '-o') {
+      requireOptionValue(a, next);
+      opts.output = next;
+      i++;
+    } else if (a === '--story-points-field') {
+      requireOptionValue(a, next);
+      opts.storyPointsField = next;
+      i++;
+    } else if (a === '--help' || a === '-h') {
       console.log(
         'Usage: node process-historical-items.mjs [--input issues.json] [--output rows.json]'
       );
@@ -41,10 +57,10 @@ function parseArgs(argv) {
 }
 
 function readIssues(opts) {
-  const raw = opts.input
-    ? readFileSync(resolveInputPath(opts.input), 'utf8')
-    : readFileSync(0, 'utf8');
-  return validateFetchIssues(JSON.parse(raw));
+  const inputPath = opts.input ? resolveInputPath(opts.input) : 0;
+  const label = opts.input ? inputPath : '<stdin>';
+  const parsed = readJsonFile(inputPath, { label });
+  return validateFetchIssues(loadIssuesFromJson(parsed));
 }
 
 function main() {

--- a/.agents/skills/jira-get-historical-items/scripts/process-historical-items.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/process-historical-items.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Process fetched Jira issue JSON into historical item rows (no auth).
+ *
+ * Usage:
+ *   node process-historical-items.mjs --input /abs/path/.jira-historical-issues.json
+ *   cat issues.json | node process-historical-items.mjs
+ *
+ * Input: array of Jira issues with changelog (CLI or MCP fetch), or
+ *        { "issues": [...] } from searchJiraIssuesUsingJql merged with changelogs.
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { loadIssuesFromJson } from './lib/load-issues.mjs';
+import { resolveInputPath, resolvePath } from './lib/paths.mjs';
+import { processHistoricalIssues } from './lib/process.mjs';
+import { validateFetchIssues } from './lib/validate-fetch.mjs';
+
+function parseArgs(argv) {
+  const opts = {
+    input: '',
+    output: '',
+    storyPointsField: 'customfield_10028',
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === '--input' || a === '-i') ((opts.input = next), i++);
+    else if (a === '--output' || a === '-o') ((opts.output = next), i++);
+    else if (a === '--story-points-field') ((opts.storyPointsField = next), i++);
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage: node process-historical-items.mjs [--input issues.json] [--output rows.json]'
+      );
+      process.exit(0);
+    }
+  }
+
+  return opts;
+}
+
+function readIssues(opts) {
+  const raw = opts.input
+    ? readFileSync(resolveInputPath(opts.input), 'utf8')
+    : readFileSync(0, 'utf8');
+  return validateFetchIssues(JSON.parse(raw));
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  const issues = readIssues(opts);
+  const rows = processHistoricalIssues(issues, opts.storyPointsField);
+
+  console.error(
+    `Processed ${issues.length} issue(s); ${rows.length} with resolution Done (skipped ${issues.length - rows.length}).`
+  );
+
+  const json = JSON.stringify(rows, null, 2);
+  if (opts.output) {
+    const outputPath = resolvePath(opts.output);
+    writeFileSync(outputPath, json);
+    console.error(`Wrote ${outputPath}`);
+  }
+
+  console.log(json);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/.agents/skills/jira-get-historical-items/scripts/run-historical-report.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/run-historical-report.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+/**
+ * Validate fetch JSON, process historical rows, and write a single report JSON.
+ *
+ * Usage:
+ *   node run-historical-report.mjs \
+ *     --input /abs/path/.jira-historical-issues.json \
+ *     --workspace /abs/path/to/workspace \
+ *     --jql 'parent = FCN-41 AND created >= -20d'
+ *
+ * Writes:
+ *   {workspace}/.jira-historical-report.json
+ *
+ * With --stdout, also prints the full report JSON.
+ */
+
+import { runHistoricalReport } from './lib/run-report.mjs';
+import { defaultWorkspaceDir, resolveInputPath, resolvePath } from './lib/paths.mjs';
+
+function parseArgs(argv) {
+  const opts = {
+    input: '',
+    workspace: '',
+    jql: '',
+    reportOutput: '',
+    storyPointsField: 'customfield_10028',
+    stdout: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--input' || arg === '-i') ((opts.input = next), i++);
+    else if (arg === '--workspace' || arg === '-w') ((opts.workspace = next), i++);
+    else if (arg === '--jql') ((opts.jql = next), i++);
+    else if (arg === '--report-output') ((opts.reportOutput = next), i++);
+    else if (arg === '--story-points-field') ((opts.storyPointsField = next), i++);
+    else if (arg === '--stdout') opts.stdout = true;
+    else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node run-historical-report.mjs --input ISSUES.json [--workspace DIR] [--jql JQL] [--stdout]
+
+Options:
+  --input, -i              Fetch JSON (array of issues with changelog)
+  --workspace, -w          Directory for output artifacts (default: input file directory)
+  --jql                    JQL used for the search (stored in report)
+  --report-output          Override report JSON path
+  --stdout                 Print full report JSON to stdout
+  --story-points-field     Story points custom field id (default: customfield_10028)`);
+      process.exit(0);
+    }
+  }
+
+  if (!opts.input) {
+    throw new Error('Missing required --input path');
+  }
+
+  return opts;
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  const inputPath = resolveInputPath(opts.input);
+  const workspace = opts.workspace ? resolvePath(opts.workspace) : defaultWorkspaceDir(inputPath);
+
+  runHistoricalReport({
+    inputPath,
+    workspace,
+    jql: opts.jql,
+    storyPointsField: opts.storyPointsField,
+    reportOutput: opts.reportOutput,
+    stdout: opts.stdout,
+  });
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/.agents/skills/jira-get-historical-items/scripts/summarize-cycle-times.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/summarize-cycle-times.mjs
@@ -6,9 +6,9 @@
  *   node summarize-cycle-times.mjs --input /abs/path/.jira-historical-report.json
  */
 
-import { readFileSync } from 'fs';
 import { buildSummaryReport } from './lib/summarize.mjs';
 import { resolveInputPath } from './lib/paths.mjs';
+import { readJsonFile } from './lib/read-json.mjs';
 
 function parseArgs(argv) {
   const opts = { input: '' };
@@ -31,8 +31,8 @@ function parseArgs(argv) {
 }
 
 function readItems(opts) {
-  const raw = readFileSync(resolveInputPath(opts.input), 'utf8');
-  const parsed = JSON.parse(raw);
+  const inputPath = resolveInputPath(opts.input);
+  const parsed = readJsonFile(inputPath);
   if (Array.isArray(parsed)) return parsed;
   if (parsed && Array.isArray(parsed.items)) return parsed.items;
   throw new Error(

--- a/.agents/skills/jira-get-historical-items/scripts/summarize-cycle-times.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/summarize-cycle-times.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Summarize 75th-percentile cycle times from historical items or a full report JSON.
+ *
+ * Usage:
+ *   node summarize-cycle-times.mjs --input /abs/path/.jira-historical-report.json
+ */
+
+import { readFileSync } from 'fs';
+import { buildSummaryReport } from './lib/summarize.mjs';
+import { resolveInputPath } from './lib/paths.mjs';
+
+function parseArgs(argv) {
+  const opts = { input: '' };
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    const next = argv[i + 1];
+    if (a === '--input' || a === '-i') ((opts.input = next), i++);
+    else if (a === '--help' || a === '-h') {
+      console.log('Usage: node summarize-cycle-times.mjs --input report-or-items.json');
+      process.exit(0);
+    }
+  }
+
+  if (!opts.input) {
+    throw new Error('Missing required --input path');
+  }
+
+  return opts;
+}
+
+function readItems(opts) {
+  const raw = readFileSync(resolveInputPath(opts.input), 'utf8');
+  const parsed = JSON.parse(raw);
+  if (Array.isArray(parsed)) return parsed;
+  if (parsed && Array.isArray(parsed.items)) return parsed.items;
+  throw new Error(
+    'Expected a JSON array of historical items or a report object with an items array'
+  );
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  const items = readItems(opts);
+  const hasCycleTime = items.some(
+    (item) => typeof item.cycleTime === 'number' && !Number.isNaN(item.cycleTime)
+  );
+
+  if (!hasCycleTime) {
+    console.log('No items with measurable cycle time — summary not produced.');
+    return;
+  }
+
+  console.log(buildSummaryReport(items));
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/.agents/skills/jira-get-historical-items/scripts/summarize-report-stats.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/summarize-report-stats.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Build a human-readable stats summary from `.jira-historical-report.json`.
+ *
+ * Usage:
+ *   node summarize-report-stats.mjs --input /abs/path/.jira-historical-report.json
+ *   node summarize-report-stats.mjs --input report.json --issues-input issues.json --output stats.json
+ *   node summarize-report-stats.mjs --input report.json --stdout
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { buildReportStats, formatStatsReport } from './lib/stats.mjs';
+import { defaultWorkspaceDir, resolveInputPath, resolvePath } from './lib/paths.mjs';
+
+function parseArgs(argv) {
+  const opts = {
+    input: '',
+    issuesInput: '',
+    output: '',
+    stdout: false,
+  };
+
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if (arg === '--input' || arg === '-i') ((opts.input = next), i++);
+    else if (arg === '--issues-input') ((opts.issuesInput = next), i++);
+    else if (arg === '--output' || arg === '-o') ((opts.output = next), i++);
+    else if (arg === '--stdout') opts.stdout = true;
+    else if (arg === '--help' || arg === '-h') {
+      console.log(`Usage: node summarize-report-stats.mjs --input REPORT.json [options]
+
+Options:
+  --input, -i           Path to .jira-historical-report.json (required)
+  --issues-input        Path to .jira-historical-issues.json for Jira created dates
+  --output, -o          Write stats JSON to this path (default: {workspace}/.jira-historical-stats.json)
+  --stdout              Print markdown summary to stdout (JSON still written unless --output /dev/null)
+  --help, -h            Show this help`);
+      process.exit(0);
+    }
+  }
+
+  if (!opts.input) {
+    throw new Error('Missing required --input path');
+  }
+
+  return opts;
+}
+
+function readJson(pathValue) {
+  return JSON.parse(readFileSync(resolveInputPath(pathValue), 'utf8'));
+}
+
+function main() {
+  const opts = parseArgs(process.argv);
+  const inputPath = resolveInputPath(opts.input);
+  const workspace = defaultWorkspaceDir(inputPath);
+  const report = readJson(inputPath);
+
+  let rawIssues = null;
+  if (opts.issuesInput) {
+    rawIssues = readJson(opts.issuesInput);
+  } else {
+    const siblingIssues = join(workspace, '.jira-historical-issues.json');
+    try {
+      rawIssues = readJson(siblingIssues);
+    } catch {
+      // Optional — created date range omitted when fetch file is absent
+    }
+  }
+
+  const stats = buildReportStats(report, rawIssues);
+  const outputPath = opts.output
+    ? resolvePath(opts.output, workspace)
+    : join(workspace, '.jira-historical-stats.json');
+
+  writeFileSync(outputPath, `${JSON.stringify(stats, null, 2)}\n`);
+  console.error(`Wrote ${outputPath}`);
+
+  if (opts.stdout) {
+    console.log(formatStatsReport(stats));
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/.agents/skills/jira-get-historical-items/scripts/summarize-report-stats.mjs
+++ b/.agents/skills/jira-get-historical-items/scripts/summarize-report-stats.mjs
@@ -8,10 +8,11 @@
  *   node summarize-report-stats.mjs --input report.json --stdout
  */
 
-import { readFileSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { writeFileSync } from 'fs';
+import { join } from 'path';
 import { buildReportStats, formatStatsReport } from './lib/stats.mjs';
 import { defaultWorkspaceDir, resolveInputPath, resolvePath } from './lib/paths.mjs';
+import { readJsonFile } from './lib/read-json.mjs';
 
 function parseArgs(argv) {
   const opts = {
@@ -49,7 +50,8 @@ Options:
 }
 
 function readJson(pathValue) {
-  return JSON.parse(readFileSync(resolveInputPath(pathValue), 'utf8'));
+  const resolved = resolveInputPath(pathValue);
+  return readJsonFile(resolved);
 }
 
 function main() {

--- a/.agents/skills/jira-get-stats/OUTPUT.md
+++ b/.agents/skills/jira-get-stats/OUTPUT.md
@@ -1,0 +1,82 @@
+# Stats output format
+
+Supplement to [SKILL.md](SKILL.md). Post results **in chat** unless the user asks for a file only.
+
+---
+
+## Order
+
+Post **in this order**:
+
+### 1. Source
+
+One line: absolute path to the report file used.
+
+### 2. Scope
+
+Fenced block with exact JQL from the report.
+
+One short line: fetched / included / skipped counts. Include the fetch-cap warning when present.
+
+### 3. Date ranges
+
+```text
+Created (Jira):          YYYY-MM-DD – YYYY-MM-DD   (or "not available")
+Work started (To Do→):   YYYY-MM-DD – YYYY-MM-DD
+Closed:                  YYYY-MM-DD – YYYY-MM-DD
+```
+
+### 4. Issue counts
+
+- Total, pointed, unpointed
+- By type (bullets)
+- Type × story points matrix (from script output)
+
+### 5. Cycle time
+
+- All-items distribution: min, p50, p75, p90, max (business days)
+- By-type distributions when present
+- Bucket counts (0–3, 4–7, 8–14, 15+ days)
+- All-items and by-type p75 (all, stories, tasks)
+- Per story point: all + stories + tasks (+ bugs when present)
+
+### 6. Throughput (when data exists)
+
+- Closed count and story points per month
+- Total story points delivered
+
+### 7. Data quality
+
+Bullets: missing start date, missing cycle time, unpointed count.
+
+### 8. Outliers (when present)
+
+Top items >1.5× their group p75 — key, points, actual vs p75, ratio.
+
+### 9. Items table
+
+| Row count | Delivery |
+|-----------|----------|
+| ≤ 15 | Full markdown table from `--stdout` |
+| > 15 | **Canvas** sortable table + one-line count in chat |
+
+Columns: Key (linked), Type, Points, Created, Started, Closed, Cycle time, Outlier flag, Summary (truncated).
+
+### 10. Saved files
+
+```markdown
+## Saved files
+
+- [.jira-historical-stats.json](/absolute/path/to/.jira-historical-stats.json)
+- [.jira-historical-report.json](/absolute/path/to/.jira-historical-report.json)
+```
+
+Paths only — do not re-paste JSON contents.
+
+---
+
+## Do not include unless asked
+
+- Full `.jira-historical-stats.json` dump
+- Full `.jira-historical-report.json` dump
+- Per-item descriptions

--- a/.agents/skills/jira-get-stats/README.md
+++ b/.agents/skills/jira-get-stats/README.md
@@ -220,4 +220,4 @@ Site default: **redhat.atlassian.net**. Story points field default (FCN): `custo
 
 ---
 
-*Originally created by Kim Doberstein.*
+*Created by Kim Doberstein.*

--- a/.agents/skills/jira-get-stats/README.md
+++ b/.agents/skills/jira-get-stats/README.md
@@ -1,0 +1,223 @@
+# jira-get-stats
+
+A [Cursor Agent Skill](https://cursor.com/docs/agent/skills) that summarizes `.jira-historical-report.json` into readable stats — date ranges, issue counts, cycle time distribution, throughput, outliers, and an items table. **Read-only** — no Jira fetch.
+
+Use when you want to understand a historical baseline — volume, timing, and data quality — without re-fetching Jira or sizing new tickets.
+
+---
+
+## Where it fits
+
+```
+jira-get-historical-items  →  fetch + process  →  .jira-historical-report.json
+jira-get-stats             →  read report      →  stats summary + items table
+jira-get-estimates         →  read report      →  forward-looking sizing
+```
+
+| Skill | Question it answers |
+|-------|---------------------|
+| **jira-get-historical-items** | “Build me a baseline from closed Jira work.” |
+| **jira-get-stats** | “What does that baseline look like?” |
+| **jira-get-estimates** | “Size these open tickets from that baseline.” |
+
+---
+
+## Prerequisites
+
+This skill **does not fetch historical data on its own**. It reads an existing `.jira-historical-report.json`.
+
+| Requirement | Details |
+|-------------|---------|
+| **Historical report** | `.jira-historical-report.json` — lookup order: active workspace, then `~/.cursor/skills/` (see [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md)); or a path you provide |
+| **Optional fetch file** | `.jira-historical-issues.json` in the same directory — adds Jira **created** date range (auto-detected when present) |
+| **No report yet?** | The agent **stops** and asks you to provide a file **or** run [jira-get-historical-items](../jira-get-historical-items/SKILL.md) |
+
+**Tip:** A narrow, recent report (one project, last 3–6 months, resolution Done) gives stats that reflect how the team ships today. See [jira-get-historical-items/README.md](../jira-get-historical-items/README.md).
+
+---
+
+## What it does
+
+**Report → stats script → summary in chat (+ optional canvas for large tables).**
+
+1. **Resolve report** — load `.jira-historical-report.json` ([SKILL.md](SKILL.md) step 1). Stops and asks if missing.
+2. **Run stats script** — `summarize-report-stats.mjs` with absolute paths.
+3. **Post summary** — formatted markdown in chat ([OUTPUT.md](OUTPUT.md)).
+4. **Large item tables** — when **>15 rows**, opens a sortable **canvas** instead of dumping a huge markdown table.
+
+Also writes `{report-dir}/.jira-historical-stats.json` for reuse or tooling.
+
+---
+
+## What you get
+
+| Section | Contents |
+|---------|----------|
+| **Scope** | JQL used, fetched / included / skipped counts, fetch-cap warning |
+| **Date ranges** | Jira created, work started (left To Do), closed |
+| **Issue counts** | Total, pointed vs unpointed, by type, type × story points matrix |
+| **Cycle time** | min / p50 / p75 / p90 / max, distribution buckets, p75 groups |
+| **Throughput** | Closed items and story points per month |
+| **Point distribution** | How many 1s, 2s, 3s, etc. |
+| **Data quality** | Missing dates, unpointed items |
+| **Outliers** | Items >1.5× their group p75 |
+| **Items table** | Key (linked), type, points, dates, cycle time, outlier flag, summary |
+
+### p75 groups (by story points)
+
+For each point size, p75 cycle time is shown for **all**, **stories**, and **tasks**:
+
+```text
+### 75th percentile groups
+
+- All items (78): 6 days
+- All stories (39): 7 days
+- All tasks (39): 2 days
+
+8 point items
+  - all: 5.5 days
+  - stories: 6.3 days
+  - tasks: 1 days
+
+3 point items
+  - all: 7.3 days
+  - stories: 8 days
+  - tasks: 3 days
+```
+
+Type lines (`stories`, `tasks`, `bugs`) only appear when there is data for that point size.
+
+---
+
+## Output (chat)
+
+After each run, chat includes scope, counts, cycle time, throughput, and either a compact items table or a canvas link ([OUTPUT.md](OUTPUT.md)).
+
+**Saved files** (absolute paths as clickable links):
+
+| File | Contents |
+|------|----------|
+| `.jira-historical-stats.json` | Full structured stats (counts, distributions, items, outliers) |
+| `.jira-historical-report.json` | Source report (linked, not re-pasted) |
+
+---
+
+## How to use it
+
+### Install the skill
+
+| Location | Scope |
+|----------|-------|
+| `~/.cursor/skills/jira-get-stats/` | Personal — all projects |
+| `.cursor/skills/jira-get-stats/` | Project — shared with the repo |
+
+### Trigger in Cursor
+
+Ask the agent — for example:
+
+- “Show stats from the FCN historical report”
+- “Run jira-get-stats on `~/.cursor/skills/.jira-historical-report.json`”
+- “Summarize closed work — counts, cycle time, and throughput”
+
+**Not this skill:** fetching Jira or building `.jira-historical-report.json` → use [jira-get-historical-items](../jira-get-historical-items/SKILL.md) first.
+- “Give me a table of closed items with cycle times from the last 90-day report”
+- “How many story points did we deliver in May?”
+
+The skill is **user-invocable** (`SKILL.md` frontmatter).
+
+### What to have ready
+
+| Input | When |
+|-------|------|
+| **Historical report** path or prior jira-get-historical-items run | Always — agent stops if missing |
+| **Report path override** | When the report is not in the workspace or skills dir |
+
+### No report yet?
+
+The agent posts:
+
+> I couldn't find `.jira-historical-report.json`.
+>
+> How would you like to proceed?
+> 1. **Provide a file** — paste the report JSON or give me a path.
+> 2. **Generate a report** — run **jira-get-historical-items**, then come back here.
+
+It will not run stats until you choose.
+
+### After delivery
+
+1. Review counts, cycle time, and throughput in chat.
+2. Open `.jira-historical-stats.json` for the full structured data.
+3. For large sets, use the **canvas** items table to sort and scan.
+4. To refresh stats, re-run [jira-get-historical-items](../jira-get-historical-items/SKILL.md) with an updated window, then run stats again.
+
+---
+
+## Script (direct)
+
+You can run the stats script without the agent:
+
+```bash
+node ../jira-get-historical-items/scripts/summarize-report-stats.mjs \
+  --input /path/to/.jira-historical-report.json \
+  --issues-input /path/to/.jira-historical-issues.json \
+  --stdout
+```
+
+| Flag | Purpose |
+|------|---------|
+| `--input` | Path to `.jira-historical-report.json` (required) |
+| `--issues-input` | Optional fetch file for Jira **created** dates |
+| `--output` | Override stats JSON path (default: `{report-dir}/.jira-historical-stats.json`) |
+| `--stdout` | Print markdown summary to stdout |
+
+Requires **Node.js 18+**.
+
+---
+
+## Directory layout
+
+```
+jira-get-stats/
+├── README.md       # This file
+├── SKILL.md        # Orchestrator — workflow, report resolution gate
+└── OUTPUT.md       # Chat output format
+
+# Shared:
+jira-get-historical-items/RESOLVE_REPORT.md   # Step 1 — find report file
+jira-get-historical-items/scripts/summarize-report-stats.mjs
+jira-acceptance-criteria-check/CONVENTIONS.md
+```
+
+---
+
+## Related skills
+
+| Skill | Relationship |
+|-------|--------------|
+| [jira-get-historical-items](../jira-get-historical-items/SKILL.md) | **Upstream** — fetch + process → `.jira-historical-report.json` |
+| [jira-get-estimates](../jira-get-estimates/SKILL.md) | **Sibling** — forward-looking story point and cycle-time sizing from the same report |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, skill index |
+| [jira-epic-breakdown](../jira-epic-breakdown/SKILL.md) | Optional — break down epics; run stats or estimates on child scope |
+| [jira-acceptance-criteria-check](../jira-acceptance-criteria-check/SKILL.md) | Separate — ticket quality review; does not use this report |
+
+---
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|----------------|
+| No `.jira-historical-report.json` found | Agent stops at step 1c — provide a file or generate via jira-get-historical-items |
+| Agent asks before running stats | Expected when no report is resolved — same gate as jira-get-estimates |
+| Invalid report JSON | File must parse as JSON with `version` and `items` — regenerate or fix path |
+| Created date range shows `—` | Pass `--issues-input` when fetch JSON is not beside the report |
+| Fetch cap warning in output | Report JQL matched ≥100 issues — narrow JQL or raise fetch cap upstream |
+| Stats feel stale or off | Re-run jira-get-historical-items with a recent 3–6 month window |
+| Huge items table in chat | Expected for ≤15 items; >15 uses canvas — see [SKILL.md](SKILL.md) step 4 |
+| `Input file not found` | Use **absolute paths** for `--input` and `--issues-input` |
+
+Site default: **redhat.atlassian.net**. Story points field default (FCN): `customfield_10028` (or `meta.storyPointsField` from the report).
+
+---
+
+*Originally created by Kim Doberstein.*

--- a/.agents/skills/jira-get-stats/SKILL.md
+++ b/.agents/skills/jira-get-stats/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: jira-get-stats
+description: >-
+  Summarize `.jira-historical-report.json` into readable stats: date ranges, issue
+  counts by type and story points, cycle time distribution, throughput, outliers,
+  and an items table. Resolves the report from user path, active workspace, or
+  ~/.cursor/skills fallback. Read-only — no Jira fetch. Use when the user asks for Jira
+  historical stats, report summary, cycle time breakdown, throughput metrics, or
+  a table of closed items from an existing historical report.
+user-invocable: true
+---
+
+# Get Jira stats
+
+Read-only summary of `.jira-historical-report.json` — no Jira fetch.
+
+**Reference files:**
+
+| File | Contents |
+|------|----------|
+| [OUTPUT.md](OUTPUT.md) | Chat output format |
+| [jira-get-historical-items/RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) | Step 1 — resolve report file |
+| [jira-get-historical-items/REPORT.md](../jira-get-historical-items/REPORT.md) | Report JSON schema |
+| [jira-get-historical-items/SKILL.md](../jira-get-historical-items/SKILL.md) | Generate report (user consent only) |
+| [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) | Shared paths, MCP rules, glossary |
+
+---
+
+## Hard rules
+
+| Do | Do not |
+|----|--------|
+| Resolve `.jira-historical-report.json` first — **stop** if missing → [RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) | Guess a report path or continue without a report |
+| **Stop** when no report file is found | Silently invoke `jira-get-historical-items` without user consent |
+| **Hand off** to `jira-get-historical-items` with its §0 discovery gate | Assume report scope or CLI/MCP from this thread |
+| Run `summarize-report-stats.mjs` with **absolute paths** | Reimplement stats logic in chat |
+| Post summary **in chat** by default per [OUTPUT.md](OUTPUT.md) | Write a markdown file unless the user asks for one |
+| Write stats JSON to `{report-dir}/.jira-historical-stats.json` (script default) | Save JSON to skill dir or a different folder |
+| Write optional markdown to `{report-dir}/.jira-historical-stats.md` when asked — **absolute path** | Save markdown to cwd or an unstated path |
+| **Post absolute artifact paths** under `## Saved files` after success (step 3) | Omit where JSON (or optional markdown) was saved |
+| Use **canvas** for the items table when **>15 rows** | Paste a 50+ row markdown table in chat |
+| Auto-detect sibling `.jira-historical-issues.json` for created dates | Re-fetch Jira for created dates |
+
+---
+
+## Constants
+
+| | Value |
+|--|--------|
+| **`{workspace}`**, **`{report-dir}`**, report lookup | [jira-acceptance-criteria-check/CONVENTIONS.md](../jira-acceptance-criteria-check/CONVENTIONS.md) |
+| Report filename | `.jira-historical-report.json` |
+| Default output | **Chat only** — script still writes stats JSON |
+| Stats script | `jira-get-historical-items/scripts/summarize-report-stats.mjs` (use absolute path to script) |
+| Stats JSON artifact | `{report-dir}/.jira-historical-stats.json` |
+| Optional markdown artifact | `{report-dir}/.jira-historical-stats.md` — only when the user asks for a markdown file |
+
+---
+
+## Workflow
+
+```
+Progress:
+- [ ] Step 1 — Resolve historical report file → [RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md)
+- [ ] Step 2 — Run stats script
+- [ ] Step 3 — Post summary in chat
+- [ ] Step 4 — Canvas for large item table (when applicable)
+```
+
+### Step 1 — Resolve historical report file
+
+Follow [jira-get-historical-items/RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) (steps 1a–1d).
+
+### Step 2 — Run stats script
+
+```bash
+node {absolute-path-to}/jira-get-historical-items/scripts/summarize-report-stats.mjs \
+  --input {absolute-report-path} \
+  --stdout
+```
+
+When `{report-dir}/.jira-historical-issues.json` exists, pass it explicitly:
+
+```bash
+node {absolute-path-to}/jira-get-historical-items/scripts/summarize-report-stats.mjs \
+  --input {absolute-report-path} \
+  --issues-input {report-dir}/.jira-historical-issues.json \
+  --stdout
+```
+
+The script writes `{report-dir}/.jira-historical-stats.json` automatically.
+
+If the script exits **1**, read stderr.
+
+### Step 3 — Post summary in chat
+
+Follow [OUTPUT.md](OUTPUT.md). Use the markdown from `--stdout` as the base — do not re-paste the full stats JSON unless the user asks.
+
+When the user asked for a **markdown file**, write the same summary to `{report-dir}/.jira-historical-stats.md` using an **absolute path**.
+
+Always post **`## Saved files`** (OUTPUT.md §10) after a successful run: clickable **absolute** links to `.jira-historical-stats.json` and the report file used; add `.jira-historical-stats.md` when written. Paths only — do not re-paste file contents.
+
+### Step 4 — Canvas for large item table
+
+When `items.length > 15`, read [canvas/SKILL.md](../../skills-cursor/canvas/SKILL.md) and create a sortable items table canvas. Embed data from `.jira-historical-stats.json` `items` array. Skip the full markdown items table in chat — link to the canvas instead.
+
+When `items.length ≤ 15`, include the items table from `--stdout` in chat.
+
+---
+
+## Pitfalls
+
+| Problem | Fix |
+|---------|-----|
+| No report file | [RESOLVE_REPORT.md](../jira-get-historical-items/RESOLVE_REPORT.md) step 1c — stop; workspace then `~/.cursor/skills/` |
+| Report in workspace but agent checked skills dir only | RESOLVE_REPORT step 1b — workspace first |
+| Agent omitted artifact paths | Step 3 — always post `## Saved files` with absolute links after success |
+| User asked for markdown file | Step 3 — write `{report-dir}/.jira-historical-stats.md`; link in `## Saved files` |
+| User chose generate | Follow jira-get-historical-items §0 — ask scope + CLI/MCP; return to step 1 when done |
+| Invalid or unparsable report JSON | RESOLVE_REPORT step 1d — tell user; treat as not found unless they fix the file |
+| Created date range shows `—` | Pass `--issues-input` when fetch JSON lives elsewhere |
+| Fetch cap warning in output | Report JQL matched ≥100 issues — mention incomplete data |
+| Huge chat table | Step 4 — use canvas when >15 items |

--- a/.agents/skills/jira-get-stats/SKILL.md
+++ b/.agents/skills/jira-get-stats/SKILL.md
@@ -101,7 +101,7 @@ Always post **`## Saved files`** (OUTPUT.md §10) after a successful run: clicka
 
 ### Step 4 — Canvas for large item table
 
-When `items.length > 15`, read [canvas/SKILL.md](../../skills-cursor/canvas/SKILL.md) and create a sortable items table canvas. Embed data from `.jira-historical-stats.json` `items` array. Skip the full markdown items table in chat — link to the canvas instead.
+When `items.length > 15`, create a sortable items table canvas (`.canvas.tsx` in the workspace `canvases/` directory). Embed data from `.jira-historical-stats.json` `items` array; columns per [OUTPUT.md](OUTPUT.md) §9. Skip the full markdown items table in chat — post a one-line item count and link to the canvas.
 
 When `items.length ≤ 15`, include the items table from `--stdout` in chat.
 


### PR DESCRIPTION
## Description

Adds a **Jira planning and estimation skill suite** under `.agents/skills/` — six skills that share conventions, type rubrics, and artifact paths so each can run independently or as steps in one workflow. Each skill is intended to be easily updated and expanded on.

- **`jira-epic-create`** — drafts discovery-first, paste-ready epic bodies (description, acceptance criteria, scope, test plan, and related sections) for PMs and project owners.
- **`jira-epic-breakdown`** — decomposes an epic into child stories, tasks, and spikes with recommended types, dependencies, and paste-ready ticket bodies; reuses **`jira-acceptance-criteria-check`** type rubrics and runs a quality review on drafts before delivery.
- **`jira-acceptance-criteria-check`** — classifies work by type, scores description and type-specific content 1–5, drafts improvements for low scores, and reports Ready / Needs review / Needs Refinement; optional Jira comment posting after user approval.
- **`jira-get-historical-items`** — fetches closed Jira issues with changelog (CLI or MCP), runs the report pipeline, and writes `.jira-historical-issues.json` and `.jira-historical-report.json` for cycle-time analysis. Includes Node scripts under `scripts/` for fetch, process, and report generation.
- **`jira-get-estimates`** — reads the historical report, maps target issues to story-point buckets from team history, and recommends points plus p75 cycle-time comments; optional Jira updates after user approval.
- **`jira-get-stats`** — read-only companion to summarize an existing historical report (counts, throughput, cycle-time distribution) without a new Jira fetch.

### End-to-end workflow (optional)

Each skill works independently. Together they support a full planning loop:

1. **Create epic** — `jira-epic-create` turns a feature description (plus discovery) into a structured epic ready for Jira.
2. **Break down epic** — `jira-epic-breakdown` splits that epic into typed child tickets with bodies aligned to shared templates.
3. **Validate acceptance criteria** — `jira-acceptance-criteria-check` scores epic and child drafts (or live Jira issues) and flags gaps before creation or sprint planning.
4. **Gather historical data** — `jira-get-historical-items` builds the closed-item dataset and cycle-time report for the team or project.
5. **Estimate story points and time** — `jira-get-estimates` uses that report to recommend story points and expected completion time for unpointed stories and tasks.

**Jira issue #**

**Backport of** #


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] UI/UX improvement
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests
- [ ] Configuration change
- [x] Infrastructure/build change
- [ ] Other (please specify):


## Testing

### Manual Testing

**Test Steps:**
1. Invoke each new skill from Cursor (e.g. ask to draft an epic, break down an epic, or check acceptance criteria on a Jira key) and confirm the agent follows the skill workflow and companion files.
2. Run `jira-get-historical-items` against a narrow JQL window and confirm `.jira-historical-issues.json` and `.jira-historical-report.json` are produced.
3. Run `jira-get-estimates` and `jira-get-stats` against the generated report and confirm readable chat output.

**Test Environment:**
- [x] Tested locally
- [ ] Tested in Storybook

### Automated Testing

**E2E Run:**

- [ ] Playwright Tests: E2E tests completed successfully (npm run test:e2e)

**Unit Tests:**
- [ ] Unit tests added/updated
- [ ] All unit tests pass (npm run test)
- [ ] Ran new/updated files in Stryker

**Integration Tests:**
- [ ] Integration tests added/updated
- [ ] All integration tests pass


## Screenshots/Recordings

Demos from the same skill suite in another repo (behavior is equivalent):

**Epic breakdown and estimation**

https://github.com/user-attachments/assets/34dde2d8-8ef1-43b2-902d-ca8ea550bf1b
NOTE: This is NOT a real epic - just a demo.


**Acceptance criteria check on existing Jira items (stories, tasks, bugs, and spikes)**


https://github.com/user-attachments/assets/56afcf07-c185-4d7a-b2ee-37c150aa7734




## Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have removed any console logs and debugging code
- [x] My changes generate no new warnings or errors
- [ ] I have checked for and fixed any linting errors (npm run lint)
- [ ] Code formatting is correct (npm run prettier:fix)

### Documentation
- [x] I have updated the documentation accordingly
- [x] I have updated the README if necessary
- [ ] I have added/updated Storybook stories for new/modified components
- [ ] I have updated TypeScript types/interfaces

### Accessibility
- [ ] My changes follow accessibility best practices
- [ ] Interactive elements are keyboard accessible
- [ ] Proper ARIA labels and roles are used where needed
- [ ] Color contrast meets WCAG standards

### Dependencies
- [x] Any dependent changes have been merged and published
- [ ] I have updated package dependencies if needed


## Breaking Changes

**Does this PR introduce breaking changes?**
- [ ] Yes
- [x] No


## Additional Notes

### Skills added

| Skill | Path |
|-------|------|
| `jira-epic-create` | `.agents/skills/jira-epic-create/SKILL.md` |
| `jira-epic-breakdown` | `.agents/skills/jira-epic-breakdown/SKILL.md` |
| `jira-acceptance-criteria-check` | `.agents/skills/jira-acceptance-criteria-check/SKILL.md` |
| `jira-get-historical-items` | `.agents/skills/jira-get-historical-items/SKILL.md` |
| `jira-get-estimates` | `.agents/skills/jira-get-estimates/SKILL.md` |
| `jira-get-stats` | `.agents/skills/jira-get-stats/SKILL.md` |

### Skill checklist

- [x] YAML frontmatter present and valid (`name`, `description`) on each `SKILL.md`
- [x] No hardcoded usernames, API keys, or org-specific values in skill content
- [x] Historical report scripts colocated under `.agents/skills/jira-get-historical-items/scripts/`
- [ ] Jira MCP credentials configured locally for live fetch/update flows

No component library, Storybook, or package API changes — agent skills and supporting scripts only (~76 files).


## Reviewer Guidelines

### Focus Areas

- `.agents/skills/jira-*/SKILL.md` — workflow steps, discovery gates, and Jira write boundaries (MCP only; user approval before writes)
- `.agents/skills/jira-acceptance-criteria-check/JIRA_TYPE/` — shared type rubrics reused by epic breakdown
- `.agents/skills/jira-get-historical-items/scripts/` — fetch/report pipeline and artifact paths (`.jira-historical-issues.json`, `.jira-historical-report.json`)
- Cross-skill conventions in `CONVENTIONS.md`, `WRITING.md`, and per-skill `README.md` files

### Questions for Reviewers

-

---
<!-- Thank you for contributing to nxtcm-components! -->
